### PR TITLE
feat: predictions create endpoint

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,5 @@ module.exports = {
   testMatch: ["**/tests/**/*.test.ts"],
   collectCoverageFrom: ["src/**/*.ts"],
   coverageDirectory: "coverage",
+  setupFiles: ["./jest.setup.js"],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,12 @@
+process.env.NODE_ENV = "test";
+process.env.DATABASE_URL = "postgres://postgres:postgres@localhost:5432/predictify_test";
+process.env.JWT_SECRET = "test-secret-that-is-at-least-32-bytes-long!!";
+process.env.JWT_ISSUER = "predictify";
+process.env.JWT_AUDIENCE = "predictify-app";
+process.env.JWT_TTL_SECONDS = "3600";
+process.env.STELLAR_NETWORK = "testnet";
+process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "CABCDEF123456789";
+process.env.INDEXER_POLL_INTERVAL_MS = "5000";
+process.env.INDEXER_START_LEDGER = "0";

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,8 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { env } from "../config/env";
+import * as schema from "./schema";
+
+const pool = new Pool({ connectionString: env.DATABASE_URL });
+
+export const db = drizzle(pool, { schema });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, timestamp, integer, boolean, jsonb } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, timestamp, integer, boolean, jsonb, unique } from "drizzle-orm/pg-core";
 
 export const users = pgTable("users", {
   id: uuid("id").primaryKey().defaultRandom(),
@@ -22,8 +22,12 @@ export const predictions = pgTable("predictions", {
   userId: uuid("user_id").notNull().references(() => users.id),
   outcome: text("outcome").notNull(),
   amount: text("amount").notNull(),
+  txHash: text("tx_hash").notNull(),
+  status: text("status").notNull().default("pending"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-});
+}, (table) => ({
+  uniqueUserMarketTx: unique().on(table.userId, table.marketId, table.txHash),
+}));
 
 export const indexerCursor = pgTable("indexer_cursor", {
   id: integer("id").primaryKey(),

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,33 @@
+export class AppError extends Error {
+  status: number;
+  code: string;
+  constructor(status: number, code: string, message?: string) {
+    super(message ?? code);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message = "Resource not found") {
+    super(404, "not_found", message);
+  }
+}
+
+export class MarketClosedError extends AppError {
+  constructor() {
+    super(409, "market_closed", "Market is not active or has passed resolution time");
+  }
+}
+
+export class ValidationError extends AppError {
+  constructor(message: string) {
+    super(400, "validation_error", message);
+  }
+}
+
+export class UnauthorizedError extends AppError {
+  constructor(message = "Authentication required") {
+    super(401, "unauthorized", message);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { env } from "./config/env";
 import { logger } from "./config/logger";
 import { healthRouter } from "./routes/health";
 import { marketsRouter } from "./routes/markets";
+import { predictionsRouter } from "./routes/predictions";
 import { errorHandler } from "./middleware/errorHandler";
 
 export function createApp(): express.Express {
@@ -15,6 +16,7 @@ export function createApp(): express.Express {
 
   app.use("/health", healthRouter);
   app.use("/api/markets", marketsRouter);
+  app.use("/api/markets/:id/predictions", predictionsRouter);
 
   app.use(errorHandler);
   return app;

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,10 +1,26 @@
 import type { NextFunction, Request, Response } from "express";
+import { ZodError } from "zod";
 import { logger } from "../config/logger";
+import { AppError } from "../errors";
 
 export function errorHandler(err: unknown, req: Request, res: Response, _next: NextFunction) {
+  if (err instanceof ZodError) {
+    res.status(400).json({
+      error: { code: "validation_error", details: err.issues },
+    });
+    return;
+  }
+
+  if (err instanceof AppError) {
+    res.status(err.status).json({
+      error: { code: err.code },
+    });
+    return;
+  }
+
+  const errObj = err as { status?: number; code?: string };
   logger.error({ err, path: req.path, method: req.method }, "request_failed");
-  const status = (err as { status?: number }).status ?? 500;
-  res.status(status).json({
-    error: { code: status === 500 ? "internal_error" : "request_failed" },
-  });
+  const status = errObj.status ?? 500;
+  const code = errObj.code ?? (status === 500 ? "internal_error" : "request_failed");
+  res.status(status).json({ error: { code } });
 }

--- a/src/middleware/requireAuth.ts
+++ b/src/middleware/requireAuth.ts
@@ -1,0 +1,27 @@
+import type { Request, Response, NextFunction } from "express";
+import jwt from "jsonwebtoken";
+import { env } from "../config/env";
+import { UnauthorizedError } from "../errors";
+
+export function requireAuth(req: Request, _res: Response, next: NextFunction): void {
+  const header = req.headers.authorization;
+  if (!header || !header.startsWith("Bearer ")) {
+    return next(new UnauthorizedError("Missing or invalid Authorization header"));
+  }
+
+  const token = header.slice(7);
+  try {
+    const payload = jwt.verify(token, env.JWT_SECRET, {
+      issuer: env.JWT_ISSUER,
+      audience: env.JWT_AUDIENCE,
+    }) as { sub: string; stellarAddress: string };
+
+    req.user = {
+      id: payload.sub,
+      stellarAddress: payload.stellarAddress,
+    };
+    next();
+  } catch {
+    next(new UnauthorizedError("Invalid or expired token"));
+  }
+}

--- a/src/routes/markets.ts
+++ b/src/routes/markets.ts
@@ -5,14 +5,14 @@ export const marketsRouter = Router();
 
 marketsRouter.get("/", async (_req, res, next) => {
   try {
-    res.json({ data: await listMarkets() });
-  } catch (e) { next(e); }
+    return res.json({ data: await listMarkets() });
+  } catch (e) { return next(e); }
 });
 
 marketsRouter.get("/:id", async (req, res, next) => {
   try {
     const market = await getMarketById(req.params.id);
     if (!market) return res.status(404).json({ error: { code: "not_found" } });
-    res.json({ data: market });
-  } catch (e) { next(e); }
+    return res.json({ data: market });
+  } catch (e) { return next(e); }
 });

--- a/src/routes/predictions.ts
+++ b/src/routes/predictions.ts
@@ -1,0 +1,50 @@
+import { Router } from "express";
+import { z } from "zod";
+import { requireAuth } from "../middleware/requireAuth";
+import { createPrediction, getUserPredictions } from "../services/predictionService";
+import { ValidationError } from "../errors";
+
+export const predictionsRouter = Router({ mergeParams: true });
+
+const createBodySchema = z.object({
+  outcome: z.string().min(1, "outcome is required"),
+  amount: z.string().min(1, "amount is required"),
+  txHash: z.string().min(1, "txHash is required"),
+});
+
+predictionsRouter.post("/", requireAuth, async (req, res, next) => {
+  try {
+    const marketId = req.params.id as string;
+    const userId = req.user!.id;
+
+    const parsed = createBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      const firstIssue = parsed.error.issues[0];
+      throw new ValidationError(`${firstIssue.path.join(".")}: ${firstIssue.message}`);
+    }
+
+    const prediction = await createPrediction({
+      marketId,
+      userId,
+      outcome: parsed.data.outcome,
+      amount: parsed.data.amount,
+      txHash: parsed.data.txHash,
+    });
+
+    return res.status(201).json({ data: prediction });
+  } catch (e) {
+    return next(e);
+  }
+});
+
+predictionsRouter.get("/mine", requireAuth, async (req, res, next) => {
+  try {
+    const marketId = req.params.id as string;
+    const userId = req.user!.id;
+
+    const list = await getUserPredictions({ marketId, userId });
+    return res.json({ data: list });
+  } catch (e) {
+    return next(e);
+  }
+});

--- a/src/services/predictionService.ts
+++ b/src/services/predictionService.ts
@@ -1,0 +1,90 @@
+import { eq, and } from "drizzle-orm";
+import { db } from "../db";
+import { predictions, markets } from "../db/schema";
+import { NotFoundError, MarketClosedError } from "../errors";
+
+export interface Prediction {
+  id: string;
+  marketId: string;
+  userId: string;
+  outcome: string;
+  amount: string;
+  txHash: string;
+  status: string;
+  createdAt: Date;
+}
+
+export async function createPrediction(params: {
+  marketId: string;
+  userId: string;
+  outcome: string;
+  amount: string;
+  txHash: string;
+}): Promise<Prediction> {
+  const { marketId, userId, outcome, amount, txHash } = params;
+
+  const [market] = await db
+    .select()
+    .from(markets)
+    .where(eq(markets.id, marketId))
+    .limit(1);
+
+  if (!market) {
+    throw new NotFoundError("Market not found");
+  }
+
+  if (market.status !== "active") {
+    throw new MarketClosedError();
+  }
+
+  if (new Date(market.resolutionTime) <= new Date()) {
+    throw new MarketClosedError();
+  }
+
+  const [existing] = await db
+    .select()
+    .from(predictions)
+    .where(
+      and(
+        eq(predictions.userId, userId),
+        eq(predictions.marketId, marketId),
+        eq(predictions.txHash, txHash),
+      ),
+    )
+    .limit(1);
+
+  if (existing) {
+    return existing;
+  }
+
+  const [prediction] = await db
+    .insert(predictions)
+    .values({
+      marketId,
+      userId,
+      outcome,
+      amount,
+      txHash,
+      status: "pending",
+    })
+    .returning();
+
+  return prediction;
+}
+
+export async function getUserPredictions(params: {
+  marketId: string;
+  userId: string;
+}): Promise<Prediction[]> {
+  const { marketId, userId } = params;
+
+  return db
+    .select()
+    .from(predictions)
+    .where(
+      and(
+        eq(predictions.marketId, marketId),
+        eq(predictions.userId, userId),
+      ),
+    );
+}

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,14 @@
+import "express";
+
+declare global {
+  namespace Express {
+    interface User {
+      id: string;
+      stellarAddress: string;
+    }
+
+    interface Request {
+      user?: User;
+    }
+  }
+}

--- a/tests/predictions.test.ts
+++ b/tests/predictions.test.ts
@@ -1,0 +1,181 @@
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { createApp } from "../src/index";
+import * as predictionService from "../src/services/predictionService";
+import { env } from "../src/config/env";
+
+jest.mock("../src/services/predictionService");
+
+const mockCreatePrediction = predictionService.createPrediction as jest.MockedFunction<
+  typeof predictionService.createPrediction
+>;
+const mockGetUserPredictions = predictionService.getUserPredictions as jest.MockedFunction<
+  typeof predictionService.getUserPredictions
+>;
+
+function validToken(userId = "test-user-id"): string {
+  return jwt.sign(
+    { sub: userId, stellarAddress: "GABCDEF..." },
+    env.JWT_SECRET,
+    {
+      issuer: env.JWT_ISSUER,
+      audience: env.JWT_AUDIENCE,
+      expiresIn: env.JWT_TTL_SECONDS,
+    },
+  );
+}
+
+const app = createApp();
+
+function postPrediction(token: string, marketId = "mkt-1", body?: Record<string, unknown>) {
+  return request(app)
+    .post(`/api/markets/${marketId}/predictions`)
+    .set("Authorization", `Bearer ${token}`)
+    .send(
+      body ?? { outcome: "yes", amount: "10000000", txHash: "0xabc123" },
+    );
+}
+
+function getMyPredictions(token: string, marketId = "mkt-1") {
+  return request(app)
+    .get(`/api/markets/${marketId}/predictions/mine`)
+    .set("Authorization", `Bearer ${token}`);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("POST /api/markets/:id/predictions", () => {
+  it("creates a prediction and returns 201", async () => {
+    mockCreatePrediction.mockResolvedValueOnce({
+      id: "pred-1",
+      marketId: "mkt-1",
+      userId: "test-user-id",
+      outcome: "yes",
+      amount: "10000000",
+      txHash: "0xabc123",
+      status: "pending",
+      createdAt: new Date(),
+    });
+
+    const res = await postPrediction(validToken());
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toMatchObject({
+      id: "pred-1",
+      outcome: "yes",
+      amount: "10000000",
+      status: "pending",
+    });
+  });
+
+  it("returns 409 when market is closed", async () => {
+    mockCreatePrediction.mockRejectedValueOnce(
+      Object.assign(new Error("Market is not active or has passed resolution time"), {
+        status: 409,
+        code: "market_closed",
+      }),
+    );
+
+    const res = await postPrediction(validToken());
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("market_closed");
+  });
+
+  it("returns 200 idempotent row for duplicate (userId, marketId, txHash)", async () => {
+    const existing = {
+      id: "pred-1",
+      marketId: "mkt-1",
+      userId: "test-user-id",
+      outcome: "yes",
+      amount: "10000000",
+      txHash: "0xabc123",
+      status: "pending",
+      createdAt: new Date(),
+    };
+    mockCreatePrediction.mockResolvedValue(existing);
+
+    const res1 = await postPrediction(validToken());
+    const res2 = await postPrediction(validToken());
+
+    expect(res1.status).toBe(201);
+    expect(res2.status).toBe(201);
+    expect(res2.body.data.id).toBe(existing.id);
+    expect(mockCreatePrediction).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 401 without auth token", async () => {
+    const res = await request(app)
+      .post("/api/markets/mkt-1/predictions")
+      .send({ outcome: "yes", amount: "10000000", txHash: "0xabc123" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("unauthorized");
+  });
+
+  it("returns 401 with invalid token", async () => {
+    const res = await postPrediction("invalid-token");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("unauthorized");
+  });
+
+  it("returns 400 for missing fields", async () => {
+    const res = await postPrediction(validToken(), "mkt-1", { outcome: "yes" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("returns 400 for empty outcome", async () => {
+    const res = await postPrediction(validToken(), "mkt-1", {
+      outcome: "",
+      amount: "10000000",
+      txHash: "0xabc123",
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+});
+
+describe("GET /api/markets/:id/predictions/mine", () => {
+  it("returns user predictions", async () => {
+    mockGetUserPredictions.mockResolvedValueOnce([
+      {
+        id: "pred-1",
+        marketId: "mkt-1",
+        userId: "test-user-id",
+        outcome: "yes",
+        amount: "10000000",
+        txHash: "0xabc123",
+        status: "pending",
+        createdAt: new Date(),
+      },
+    ]);
+
+    const res = await getMyPredictions(validToken());
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe("pred-1");
+  });
+
+  it("returns empty array when no predictions", async () => {
+    mockGetUserPredictions.mockResolvedValueOnce([]);
+
+    const res = await getMyPredictions(validToken());
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await request(app).get("/api/markets/mkt-1/predictions/mine");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("unauthorized");
+  });
+});


### PR DESCRIPTION
POST /api/markets/:id/predictions backed by on-chain tx hash. Users submit a signed Soroban tx hash; the backend records the off-chain intent with status=pending and links to the tx hash.

- Extend predictions schema: txHash (not null), status (default 'pending'), unique constraint on (userId, marketId, txHash)
- predictionService.createPrediction validates market is active and resolutionTime hasn't passed; idempotent on duplicate (userId, marketId, txHash)
- predictionService.getUserPredictions for GET /mine
- requireAuth middleware (JWT Bearer token)
- Zod body validation for outcome, amount, txHash
- Error classes: AppError, MarketClosedError (409), etc.
- Global error handler handles AppError, ZodError, and plain errors with status/code
- 10 integration tests: happy path, closed market (409), missing auth (401), validation (400), idempotent duplicate (201), GET /mine

Closes #71