### PR TITLE
feat: durable Soroban indexer worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,52 @@ npm run db:migrate
 npm run dev
 ```
 
+## Indexer worker
+
+A long-running worker ingests Soroban contract events and maintains a durable
+cursor so ingestion resumes exactly where it left off across restarts.
+
+```bash
+npm run build && npm run indexer   # compiled (production)
+npm run indexer:dev                # ts-node, auto-reload (local)
+```
+
+How it works:
+
+- Polls `SOROBAN_RPC_URL` every `INDEXER_POLL_INTERVAL_MS` (default 5000ms) via
+  `@stellar/stellar-sdk`, reading `getEvents` for `PREDICTIFY_CONTRACT_ID`
+  starting just after the last ingested ledger.
+- On the very first run (no cursor row yet) it starts from
+  `INDEXER_START_LEDGER`.
+- Each tick persists the fetched events **and** advances the
+  `indexer_cursor` row in a **single database transaction**. If persistence
+  fails, the transaction rolls back and the cursor is left untouched, so the
+  same ledger range is safely retried on the next tick — the cursor never
+  advances past events that were not stored. Event ids are unique, so a retried
+  overlapping range is idempotent (`ON CONFLICT DO NOTHING`).
+- Events beyond the per-tick page cap are deferred to the next tick rather than
+  buffered unbounded.
+
+### Graceful shutdown
+
+On `SIGTERM`/`SIGINT` the worker stops scheduling new ticks, lets the in-flight
+tick finish (so no partial range is dropped), closes the connection pool, and
+exits `0`.
+
+The core is exported as `pollOnce()` (`src/services/indexerService.ts`) with the
+RPC source and transactional store injected, which makes it unit-testable
+without a live RPC or database (`tests/indexerService.test.ts`).
+
 ## Layout
 
 ```
 src/
   config/      env + logger
   routes/      health, markets (more to come)
-  services/    domain services
+  services/    domain services (incl. indexerService.pollOnce)
   middleware/  errorHandler, auth (planned)
-  db/          drizzle schema
+  workers/     long-running processes (Soroban indexer)
+  db/          drizzle schema, client, repositories
 tests/         jest tests
 docs/          architecture docs
 scripts/       dev helpers

--- a/drizzle/0000_contract_events.sql
+++ b/drizzle/0000_contract_events.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "contract_events" (
+	"id" text PRIMARY KEY NOT NULL,
+	"ledger" integer NOT NULL,
+	"contract_id" text,
+	"type" text NOT NULL,
+	"tx_hash" text NOT NULL,
+	"ledger_closed_at" timestamp with time zone NOT NULL,
+	"topic" jsonb NOT NULL,
+	"value" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "contract_events_ledger_idx" ON "contract_events" ("ledger");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1782385935780,
+      "tag": "0000_contract_events",
+      "breakpoints": true
+    }
+  ]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   testMatch: ["**/tests/**/*.test.ts"],
+  setupFiles: ["<rootDir>/tests/setup.ts"],
   collectCoverageFrom: ["src/**/*.ts"],
   coverageDirectory: "coverage",
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "dev": "ts-node-dev --respawn src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
+    "indexer": "node dist/workers/indexer.js",
+    "indexer:dev": "ts-node-dev --respawn --transpile-only src/workers/indexer.ts",
     "lint": "eslint \"src/**/*.ts\"",
     "test": "jest",
     "test:coverage": "jest --coverage",

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,0 +1,12 @@
+import { Pool } from "pg";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { env } from "../config/env";
+import * as schema from "./schema";
+
+// A single shared connection pool for the process. The indexer worker keeps the
+// pool small since it performs one transaction per poll tick.
+export const pool = new Pool({ connectionString: env.DATABASE_URL });
+
+export const db = drizzle(pool, { schema });
+
+export type Database = typeof db;

--- a/src/db/indexerRepository.ts
+++ b/src/db/indexerRepository.ts
@@ -1,0 +1,56 @@
+import { eq, sql } from "drizzle-orm";
+import type { Database } from "./client";
+import { contractEvents, indexerCursor } from "./schema";
+import type { CursorStore, IndexedEvent } from "../services/indexerService";
+
+// The cursor table holds a single row identified by this id.
+const CURSOR_ID = 1;
+
+/**
+ * Drizzle-backed {@link CursorStore}. `commit` runs the event inserts and the
+ * cursor advance inside one database transaction, so a failure on either rolls
+ * back both and the cursor is never left ahead of the persisted events.
+ */
+export function createDbCursorStore(db: Database): CursorStore {
+  return {
+    async loadLedger(): Promise<number | null> {
+      const rows = await db
+        .select({ lastLedger: indexerCursor.lastLedger })
+        .from(indexerCursor)
+        .where(eq(indexerCursor.id, CURSOR_ID))
+        .limit(1);
+      return rows.length ? rows[0].lastLedger : null;
+    },
+
+    async commit(events: IndexedEvent[], newLedger: number): Promise<void> {
+      await db.transaction(async (tx) => {
+        if (events.length > 0) {
+          await tx
+            .insert(contractEvents)
+            .values(
+              events.map((e) => ({
+                id: e.id,
+                ledger: e.ledger,
+                contractId: e.contractId,
+                type: e.type,
+                txHash: e.txHash,
+                ledgerClosedAt: e.ledgerClosedAt,
+                topic: e.topic,
+                value: e.value,
+              })),
+            )
+            // Re-fetching an overlapping range must not error on duplicates.
+            .onConflictDoNothing({ target: contractEvents.id });
+        }
+
+        await tx
+          .insert(indexerCursor)
+          .values({ id: CURSOR_ID, lastLedger: newLedger })
+          .onConflictDoUpdate({
+            target: indexerCursor.id,
+            set: { lastLedger: newLedger, updatedAt: sql`now()` },
+          });
+      });
+    },
+  };
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, timestamp, integer, boolean, jsonb } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, timestamp, integer, boolean, jsonb, index } from "drizzle-orm/pg-core";
 
 export const users = pgTable("users", {
   id: uuid("id").primaryKey().defaultRandom(),
@@ -30,3 +30,20 @@ export const indexerCursor = pgTable("indexer_cursor", {
   lastLedger: integer("last_ledger").notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });
+
+// Raw Soroban contract events ingested by the indexer worker. The event `id`
+// returned by the RPC is globally unique and used as the primary key so that
+// re-fetching an overlapping ledger range is naturally idempotent.
+export const contractEvents = pgTable("contract_events", {
+  id: text("id").primaryKey(),
+  ledger: integer("ledger").notNull(),
+  contractId: text("contract_id"),
+  type: text("type").notNull(),
+  txHash: text("tx_hash").notNull(),
+  ledgerClosedAt: timestamp("ledger_closed_at", { withTimezone: true }).notNull(),
+  topic: jsonb("topic").notNull(),
+  value: jsonb("value").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+}, (t) => ({
+  ledgerIdx: index("contract_events_ledger_idx").on(t.ledger),
+}));

--- a/src/routes/markets.ts
+++ b/src/routes/markets.ts
@@ -12,7 +12,10 @@ marketsRouter.get("/", async (_req, res, next) => {
 marketsRouter.get("/:id", async (req, res, next) => {
   try {
     const market = await getMarketById(req.params.id);
-    if (!market) return res.status(404).json({ error: { code: "not_found" } });
+    if (!market) {
+      res.status(404).json({ error: { code: "not_found" } });
+      return;
+    }
     res.json({ data: market });
   } catch (e) { next(e); }
 });

--- a/src/services/indexerService.ts
+++ b/src/services/indexerService.ts
@@ -1,0 +1,148 @@
+import type { rpc } from "@stellar/stellar-sdk";
+
+/**
+ * A normalized contract event ready to be persisted. Decoupled from the raw
+ * `@stellar/stellar-sdk` shape so the persistence layer and tests do not depend
+ * on XDR types.
+ */
+export interface IndexedEvent {
+  id: string;
+  ledger: number;
+  contractId: string | null;
+  type: string;
+  txHash: string;
+  ledgerClosedAt: Date;
+  topic: string[];
+  value: string;
+}
+
+/**
+ * Transactional persistence boundary for the indexer. Implementations MUST
+ * insert the events and advance the cursor to `newLedger` atomically — either
+ * both are committed or neither is. This is what guarantees the cursor never
+ * advances past events that were not persisted.
+ */
+export interface CursorStore {
+  /** Returns the last fully-ingested ledger, or null if the indexer has never run. */
+  loadLedger(): Promise<number | null>;
+  /**
+   * Persist `events` and set the cursor to `newLedger` in a single transaction.
+   * Inserting an event whose id already exists is a no-op (idempotent).
+   */
+  commit(events: IndexedEvent[], newLedger: number): Promise<void>;
+}
+
+/** The slice of `rpc.Server` the indexer actually uses, so it is trivial to mock. */
+export type EventSource = Pick<rpc.Server, "getEvents">;
+
+export interface PollDeps {
+  rpc: EventSource;
+  store: CursorStore;
+  contractId: string;
+  /** Ledger to begin from on the very first run, when no cursor exists yet. */
+  startLedger: number;
+  /** Upper bound on RPC pages fetched per tick, to bound work and memory. */
+  maxPagesPerTick?: number;
+  /** Page size passed to getEvents. */
+  pageSize?: number;
+  logger?: { info: (obj: object, msg?: string) => void; warn: (obj: object, msg?: string) => void };
+}
+
+export interface PollResult {
+  /** Ledger the cursor pointed at before this tick. */
+  fromLedger: number;
+  /** Ledger the cursor was advanced to (unchanged if nothing to do). */
+  toLedger: number;
+  /** Number of events persisted this tick. */
+  eventCount: number;
+  /** True when the per-tick page cap was hit and more events likely remain. */
+  truncated: boolean;
+}
+
+const DEFAULT_MAX_PAGES = 10;
+const DEFAULT_PAGE_SIZE = 100;
+
+function toIndexedEvent(raw: rpc.Api.EventResponse): IndexedEvent {
+  return {
+    id: raw.id,
+    ledger: raw.ledger,
+    // `contractId` is a Contract instance; normalize to its string form.
+    contractId: raw.contractId ? raw.contractId.toString() : null,
+    type: raw.type,
+    txHash: raw.txHash,
+    ledgerClosedAt: new Date(raw.ledgerClosedAt),
+    topic: raw.topic.map((t) => t.toXDR("base64")),
+    value: raw.value.toXDR("base64"),
+  };
+}
+
+/**
+ * Perform exactly one indexing tick: read the cursor, drain matching events from
+ * the Soroban RPC up to the per-tick page cap, then persist the events and
+ * advance the cursor transactionally.
+ *
+ * Failures (RPC or persistence) propagate to the caller and leave the cursor
+ * untouched, so the next tick safely retries the same range.
+ */
+export async function pollOnce(deps: PollDeps): Promise<PollResult> {
+  const maxPages = deps.maxPagesPerTick ?? DEFAULT_MAX_PAGES;
+  const pageSize = deps.pageSize ?? DEFAULT_PAGE_SIZE;
+
+  const last = await deps.store.loadLedger();
+  // First run starts at startLedger; subsequent runs resume just after the
+  // last fully-ingested ledger.
+  const fromLedger = last === null ? deps.startLedger : last + 1;
+
+  const filters = [{ type: "contract" as const, contractIds: [deps.contractId] }];
+
+  const events: IndexedEvent[] = [];
+  let cursorToken: string | undefined;
+  let latestLedger = last ?? deps.startLedger;
+  let pages = 0;
+  let truncated = false;
+
+  // Page through getEvents. The first request anchors on `startLedger`; later
+  // pages continue from the previous page's last pagingToken.
+  for (;;) {
+    const request = cursorToken
+      ? { filters, cursor: cursorToken, limit: pageSize }
+      : { startLedger: fromLedger, filters, limit: pageSize };
+
+    const res = await deps.rpc.getEvents(request);
+    latestLedger = res.latestLedger;
+
+    for (const raw of res.events) {
+      events.push(toIndexedEvent(raw));
+    }
+
+    pages += 1;
+
+    // A short page means we have drained everything available for this range.
+    if (res.events.length < pageSize) {
+      break;
+    }
+    if (pages >= maxPages) {
+      truncated = true;
+      break;
+    }
+    cursorToken = res.events[res.events.length - 1].pagingToken;
+  }
+
+  // When truncated, resume *at* the last persisted event's ledger (not past it):
+  // that ledger may hold further events beyond the page cap, so we re-scan it
+  // next tick — the unique event id makes the overlapping re-fetch idempotent.
+  // Otherwise we have drained everything up to latestLedger. `fromLedger - 1`
+  // is the previous cursor, so the value can never move backwards.
+  const newLedger = truncated
+    ? Math.max(fromLedger - 1, events[events.length - 1].ledger - 1)
+    : Math.max(latestLedger, fromLedger - 1);
+
+  await deps.store.commit(events, newLedger);
+
+  deps.logger?.info(
+    { fromLedger, toLedger: newLedger, eventCount: events.length, truncated },
+    "indexer tick complete",
+  );
+
+  return { fromLedger, toLedger: newLedger, eventCount: events.length, truncated };
+}

--- a/src/workers/indexer.ts
+++ b/src/workers/indexer.ts
@@ -1,0 +1,83 @@
+import { rpc } from "@stellar/stellar-sdk";
+import { env } from "../config/env";
+import { logger } from "../config/logger";
+import { db, pool } from "../db/client";
+import { createDbCursorStore } from "../db/indexerRepository";
+import { pollOnce, type PollDeps } from "../services/indexerService";
+
+/**
+ * Long-running Soroban indexer worker.
+ *
+ * Polls `SOROBAN_RPC_URL` every `INDEXER_POLL_INTERVAL_MS`, ingesting contract
+ * events and advancing the durable cursor. On SIGTERM/SIGINT it stops scheduling
+ * new ticks, lets the in-flight tick finish, then exits cleanly.
+ */
+async function main(): Promise<void> {
+  const server = new rpc.Server(env.SOROBAN_RPC_URL, {
+    allowHttp: env.SOROBAN_RPC_URL.startsWith("http://"),
+  });
+
+  const deps: PollDeps = {
+    rpc: server,
+    store: createDbCursorStore(db),
+    contractId: env.PREDICTIFY_CONTRACT_ID,
+    startLedger: env.INDEXER_START_LEDGER,
+    logger,
+  };
+
+  let shuttingDown = false;
+  let activeTick: Promise<unknown> = Promise.resolve();
+
+  const requestShutdown = (signal: NodeJS.Signals): void => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    logger.info({ signal }, "indexer shutdown requested; draining current tick");
+  };
+
+  process.on("SIGTERM", requestShutdown);
+  process.on("SIGINT", requestShutdown);
+
+  logger.info(
+    { rpc: env.SOROBAN_RPC_URL, interval: env.INDEXER_POLL_INTERVAL_MS },
+    "indexer worker started",
+  );
+
+  // Sleep that wakes early if shutdown is requested, so SIGTERM is responsive
+  // even between ticks.
+  const sleep = (ms: number): Promise<void> =>
+    new Promise((resolve) => {
+      const timer = setTimeout(resolve, ms);
+      const onSignal = (): void => {
+        clearTimeout(timer);
+        resolve();
+      };
+      process.once("SIGTERM", onSignal);
+      process.once("SIGINT", onSignal);
+    });
+
+  while (!shuttingDown) {
+    try {
+      activeTick = pollOnce(deps);
+      await activeTick;
+    } catch (err) {
+      // Cursor is untouched on failure; log and retry on the next tick.
+      logger.error({ err }, "indexer tick failed");
+    }
+    if (shuttingDown) break;
+    await sleep(env.INDEXER_POLL_INTERVAL_MS);
+  }
+
+  // Ensure the in-flight tick is fully settled before tearing down resources.
+  await activeTick.catch(() => undefined);
+  await pool.end();
+  logger.info({}, "indexer worker stopped");
+}
+
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      logger.error({ err }, "indexer worker crashed");
+      process.exit(1);
+    });
+}

--- a/tests/indexerRepository.test.ts
+++ b/tests/indexerRepository.test.ts
@@ -1,0 +1,103 @@
+import { createDbCursorStore } from "../src/db/indexerRepository";
+import { contractEvents, indexerCursor } from "../src/db/schema";
+import type { Database } from "../src/db/client";
+import type { IndexedEvent } from "../src/services/indexerService";
+
+const sampleEvent: IndexedEvent = {
+  id: "evt-1",
+  ledger: 105,
+  contractId: "C...",
+  type: "contract",
+  txHash: "tx-1",
+  ledgerClosedAt: new Date("2024-01-01T00:00:00Z"),
+  topic: ["xdr:t"],
+  value: "xdr:v",
+};
+
+/**
+ * Records the order of insert targets and whether the cursor write happened
+ * inside the same transaction callback. `failEventsInsert` makes the event
+ * insert reject so we can assert the transaction aborts before the cursor write.
+ */
+function makeFakeDb(opts: { failEventsInsert?: boolean } = {}) {
+  const ops: string[] = [];
+  let cursorWritten = false;
+
+  const insert = (table: unknown) => {
+    const isEvents = table === contractEvents;
+    const isCursor = table === indexerCursor;
+    const builder = {
+      values() {
+        return builder;
+      },
+      onConflictDoNothing() {
+        ops.push("insert:events");
+        if (isEvents && opts.failEventsInsert) {
+          return Promise.reject(new Error("insert failed"));
+        }
+        return Promise.resolve();
+      },
+      onConflictDoUpdate() {
+        if (isCursor) {
+          ops.push("upsert:cursor");
+          cursorWritten = true;
+        }
+        return Promise.resolve();
+      },
+    };
+    return builder;
+  };
+
+  const db = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => [{ lastLedger: 42 }],
+        }),
+      }),
+    }),
+    async transaction(cb: (tx: unknown) => Promise<void>) {
+      // Mirrors pg/drizzle: an error thrown in the callback aborts the tx.
+      await cb({ insert });
+    },
+  };
+
+  return { db: db as unknown as Database, ops, get cursorWritten() {
+    return cursorWritten;
+  } };
+}
+
+describe("createDbCursorStore", () => {
+  it("loads the current ledger from the cursor row", async () => {
+    const { db } = makeFakeDb();
+    const store = createDbCursorStore(db);
+    expect(await store.loadLedger()).toBe(42);
+  });
+
+  it("inserts events then advances the cursor within one transaction", async () => {
+    const { db, ops } = makeFakeDb();
+    const store = createDbCursorStore(db);
+
+    await store.commit([sampleEvent], 110);
+
+    expect(ops).toEqual(["insert:events", "upsert:cursor"]);
+  });
+
+  it("aborts the cursor advance when the event insert fails", async () => {
+    const fake = makeFakeDb({ failEventsInsert: true });
+    const store = createDbCursorStore(fake.db);
+
+    await expect(store.commit([sampleEvent], 110)).rejects.toThrow("insert failed");
+    // The cursor upsert never ran because the transaction aborted first.
+    expect(fake.cursorWritten).toBe(false);
+  });
+
+  it("skips the event insert entirely when there are no events", async () => {
+    const { db, ops } = makeFakeDb();
+    const store = createDbCursorStore(db);
+
+    await store.commit([], 110);
+
+    expect(ops).toEqual(["upsert:cursor"]);
+  });
+});

--- a/tests/indexerService.test.ts
+++ b/tests/indexerService.test.ts
@@ -1,0 +1,194 @@
+import { pollOnce, type CursorStore, type EventSource, type IndexedEvent } from "../src/services/indexerService";
+import type { rpc } from "@stellar/stellar-sdk";
+
+const CONTRACT_ID = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+
+/** Build a minimal object that satisfies the bits of EventResponse the service reads. */
+function fakeEvent(id: string, ledger: number): rpc.Api.EventResponse {
+  const scVal = (v: string) => ({ toXDR: (_fmt: "base64") => `xdr:${v}` });
+  return {
+    id,
+    type: "contract",
+    ledger,
+    ledgerClosedAt: "2024-01-01T00:00:00Z",
+    pagingToken: id,
+    inSuccessfulContractCall: true,
+    txHash: `tx-${id}`,
+    contractId: { toString: () => CONTRACT_ID },
+    topic: [scVal(`topic-${id}`)],
+    value: scVal(`value-${id}`),
+  } as unknown as rpc.Api.EventResponse;
+}
+
+/**
+ * In-memory transactional store. `commit` mutates state atomically and can be
+ * configured to throw, simulating a failed transaction that must NOT advance
+ * the cursor.
+ */
+function makeStore(initialLedger: number | null): CursorStore & {
+  ledger: number | null;
+  events: IndexedEvent[];
+  failNextCommit: boolean;
+} {
+  return {
+    ledger: initialLedger,
+    events: [],
+    failNextCommit: false,
+    async loadLedger() {
+      return this.ledger;
+    },
+    async commit(events: IndexedEvent[], newLedger: number) {
+      if (this.failNextCommit) {
+        // Atomic failure: neither events nor cursor change.
+        throw new Error("commit failed");
+      }
+      this.events.push(...events);
+      this.ledger = newLedger;
+    },
+  };
+}
+
+/** RPC stub returning the given pages in order. */
+function makeRpc(pages: rpc.Api.GetEventsResponse[]): EventSource & { calls: unknown[] } {
+  let i = 0;
+  return {
+    calls: [],
+    async getEvents(request) {
+      this.calls.push(request);
+      const page = pages[Math.min(i, pages.length - 1)];
+      i += 1;
+      return page;
+    },
+  };
+}
+
+const page = (events: rpc.Api.EventResponse[], latestLedger: number): rpc.Api.GetEventsResponse => ({
+  events,
+  latestLedger,
+});
+
+describe("pollOnce", () => {
+  it("starts from startLedger on the first run and advances the cursor", async () => {
+    const store = makeStore(null);
+    const rpcStub = makeRpc([page([fakeEvent("a", 105)], 110)]);
+
+    const result = await pollOnce({
+      rpc: rpcStub,
+      store,
+      contractId: CONTRACT_ID,
+      startLedger: 100,
+    });
+
+    expect((rpcStub.calls[0] as { startLedger: number }).startLedger).toBe(100);
+    expect(result.fromLedger).toBe(100);
+    expect(result.toLedger).toBe(110);
+    expect(result.eventCount).toBe(1);
+    expect(store.ledger).toBe(110);
+    expect(store.events.map((e) => e.id)).toEqual(["a"]);
+  });
+
+  it("resumes from lastLedger + 1 on subsequent runs", async () => {
+    const store = makeStore(200);
+    const rpcStub = makeRpc([page([], 205)]);
+
+    const result = await pollOnce({ rpc: rpcStub, store, contractId: CONTRACT_ID, startLedger: 0 });
+
+    expect((rpcStub.calls[0] as { startLedger: number }).startLedger).toBe(201);
+    expect(result.fromLedger).toBe(201);
+    // No events: advance to the latest observed ledger so empty ranges are skipped.
+    expect(store.ledger).toBe(205);
+  });
+
+  it("normalizes event fields for persistence", async () => {
+    const store = makeStore(null);
+    const rpcStub = makeRpc([page([fakeEvent("a", 105)], 110)]);
+
+    await pollOnce({ rpc: rpcStub, store, contractId: CONTRACT_ID, startLedger: 100 });
+
+    expect(store.events[0]).toEqual({
+      id: "a",
+      ledger: 105,
+      contractId: CONTRACT_ID,
+      type: "contract",
+      txHash: "tx-a",
+      ledgerClosedAt: new Date("2024-01-01T00:00:00Z"),
+      topic: ["xdr:topic-a"],
+      value: "xdr:value-a",
+    });
+  });
+
+  it("does NOT advance the cursor when the RPC call fails", async () => {
+    const store = makeStore(300);
+    const rpcStub: EventSource = {
+      async getEvents() {
+        throw new Error("rpc down");
+      },
+    };
+
+    await expect(
+      pollOnce({ rpc: rpcStub, store, contractId: CONTRACT_ID, startLedger: 0 }),
+    ).rejects.toThrow("rpc down");
+    expect(store.ledger).toBe(300);
+    expect(store.events).toHaveLength(0);
+  });
+
+  it("does NOT advance the cursor past events that fail to persist", async () => {
+    const store = makeStore(300);
+    store.failNextCommit = true;
+    const rpcStub = makeRpc([page([fakeEvent("a", 305)], 310)]);
+
+    await expect(
+      pollOnce({ rpc: rpcStub, store, contractId: CONTRACT_ID, startLedger: 0 }),
+    ).rejects.toThrow("commit failed");
+    // Cursor unchanged and no events committed — the failed range is retried next tick.
+    expect(store.ledger).toBe(300);
+    expect(store.events).toHaveLength(0);
+  });
+
+  it("pages through multiple full pages until drained", async () => {
+    const store = makeStore(null);
+    const full = Array.from({ length: 2 }, (_, i) => fakeEvent(`p1-${i}`, 100 + i));
+    const rpcStub = makeRpc([
+      page(full, 150), // full page (== pageSize) -> fetch another
+      page([fakeEvent("p2-0", 120)], 150), // short page -> stop
+    ]);
+
+    const result = await pollOnce({
+      rpc: rpcStub,
+      store,
+      contractId: CONTRACT_ID,
+      startLedger: 100,
+      pageSize: 2,
+    });
+
+    expect(rpcStub.calls).toHaveLength(2);
+    // Second call paginates via the previous page's last pagingToken.
+    expect((rpcStub.calls[1] as { cursor?: string }).cursor).toBe("p1-1");
+    expect(result.eventCount).toBe(3);
+    expect(store.ledger).toBe(150);
+    expect(result.truncated).toBe(false);
+  });
+
+  it("stops at maxPagesPerTick and advances only to the last persisted event", async () => {
+    const store = makeStore(null);
+    const rpcStub = makeRpc([
+      page([fakeEvent("a", 101)], 999),
+      page([fakeEvent("b", 102)], 999),
+    ]);
+
+    const result = await pollOnce({
+      rpc: rpcStub,
+      store,
+      contractId: CONTRACT_ID,
+      startLedger: 100,
+      pageSize: 1,
+      maxPagesPerTick: 2,
+    });
+
+    expect(result.truncated).toBe(true);
+    expect(result.eventCount).toBe(2);
+    // Does not jump to latestLedger (999). Resumes AT the last event's ledger
+    // (102) next tick, so the cursor is left at 102 - 1 = 101.
+    expect(store.ledger).toBe(101);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,16 @@
+// Provide the environment variables required by src/config/env.ts so the app
+// and worker modules can be imported under test without a real .env file.
+const TEST_ENV: Record<string, string> = {
+  NODE_ENV: "test",
+  DATABASE_URL: "postgres://postgres:postgres@localhost:5432/predictify_test",
+  JWT_SECRET: "test-secret-test-secret-test-secret-0123456789",
+  SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org",
+  HORIZON_URL: "https://horizon-testnet.stellar.org",
+  PREDICTIFY_CONTRACT_ID: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+};
+
+for (const [key, value] of Object.entries(TEST_ENV)) {
+  if (process.env[key] === undefined) {
+    process.env[key] = value;
+  }
+}


### PR DESCRIPTION
Closes #68

## Summary

Adds a long-running Soroban indexer worker that polls `SOROBAN_RPC_URL` for `PREDICTIFY_CONTRACT_ID` events and advances the `indexer_cursor` durably and transactionally.

- **`src/workers/indexer.ts`** — worker entrypoint runnable via `npm run indexer` (and `npm run indexer:dev`). Poll loop honoring `INDEXER_POLL_INTERVAL_MS` and `INDEXER_START_LEDGER`, with `SIGTERM`/`SIGINT` graceful shutdown that drains the in-flight tick, closes the pool, and exits `0`.
- **`src/services/indexerService.ts`** — `pollOnce()` with the RPC source and a transactional store **injected**, so it is unit-testable without a live RPC or DB. Pages through `getEvents` and bounds work per tick (page cap).
- **`src/db/indexerRepository.ts`** — Drizzle-backed store that inserts the events **and** advances the cursor in a **single transaction**. On failure the transaction rolls back and the cursor is left untouched, so the same range is safely retried. Inserts are idempotent on the unique event id (`ON CONFLICT DO NOTHING`), making overlapping re-fetches safe.
- **`src/db/client.ts`, `src/db/schema.ts`, `drizzle/`** — pg/Drizzle client, new `contract_events` table (+ ledger index) and its migration.

## Acceptance criteria

- [x] Cursor never advances past unpersisted events — events + cursor commit in one transaction; verified by `tests/indexerService.test.ts` (persist failure leaves cursor unchanged) and `tests/indexerRepository.test.ts` (cursor upsert never runs when the event insert aborts the transaction).
- [x] SIGTERM completes the in-flight tick before exit — verified manually (boots → failing tick keeps cursor → SIGTERM drains → exit 0).
- [x] Worker exported as `pollOnce()` for unit tests.

## Tests

`npm test` → **3 suites, 12 tests passing**. Coverage: first-run start ledger, resume from `last + 1`, event normalization, RPC failure (no advance), persist failure (no advance), multi-page pagination, per-tick truncation, and transaction-abort ordering.

## Notes for reviewers

Two small pre-existing fixes were required so the new worker compiles and the suite boots (both unrelated to the indexer but blocking it):
- `tests/setup.ts` + `setupFiles` in `jest.config.js` — supplies test env so `src/config/env.ts` parses (the suite could not boot before this).
- `src/routes/markets.ts` — fixed an inconsistent return that broke `tsc` under `noImplicitReturns` (and thus `npm run build`).

`@stellar/stellar-sdk` is mocked in tests as the issue suggests; no live RPC/DB needed to run the suite.
