### PR TITLE
feat: requireAuth middleware with typed req.user

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { env } from "./config/env";
 import { logger } from "./config/logger";
 import { healthRouter } from "./routes/health";
 import { marketsRouter } from "./routes/markets";
+import { predictionsRouter } from "./routes/predictions";
 import { errorHandler } from "./middleware/errorHandler";
 
 export function createApp(): express.Express {
@@ -15,6 +16,7 @@ export function createApp(): express.Express {
 
   app.use("/health", healthRouter);
   app.use("/api/markets", marketsRouter);
+  app.use("/api/predictions", predictionsRouter);
 
   app.use(errorHandler);
   return app;

--- a/src/middleware/requireAuth.ts
+++ b/src/middleware/requireAuth.ts
@@ -1,0 +1,219 @@
+/**
+ * requireAuth / optionalAuth
+ * --------------------------
+ * Single source of truth for "this request is authenticated as Stellar address X".
+ *
+ * Usage
+ * -----
+ *   import { requireAuth, optionalAuth } from "../middleware/requireAuth";
+ *
+ *   // Protected route — returns 401 when token is absent or invalid
+ *   router.post("/predictions", requireAuth, handler);
+ *
+ *   // Personalised but public route — req.user may be undefined
+ *   router.get("/markets", optionalAuth, handler);
+ *
+ * JWT contract
+ * ------------
+ *   Tokens must be signed with HS256 (HMAC-SHA256) using `env.JWT_SECRET`.
+ *   Required claims:
+ *     - iss  === env.JWT_ISSUER    (e.g. "predictify")
+ *     - aud  === env.JWT_AUDIENCE  (e.g. "predictify-app")
+ *     - sub  === users.stellar_address
+ *   Optional but expected:
+ *     - exp  (verified automatically by jsonwebtoken)
+ *
+ * Hot-path notes
+ * --------------
+ *   Only a single indexed DB look-up is performed (users.stellar_address has
+ *   a UNIQUE index). No external I/O otherwise.
+ */
+
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+import jwt, { type JwtPayload } from "jsonwebtoken";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { eq } from "drizzle-orm";
+import { env } from "../config/env";
+import { logger } from "../config/logger";
+import { users } from "../db/schema";
+
+// ---------------------------------------------------------------------------
+// Shared DB pool (module-level singleton — one pool for the whole process).
+// In tests this module is imported fresh per-suite so the pool stays small.
+// ---------------------------------------------------------------------------
+const pool = new Pool({ connectionString: env.DATABASE_URL });
+const db = drizzle(pool);
+
+// ---------------------------------------------------------------------------
+// Internal helper — resolves with req.user value or throws an AppError.
+// Extracted so that both requireAuth and optionalAuth share the same logic.
+// ---------------------------------------------------------------------------
+interface AuthPayload extends JwtPayload {
+  sub: string; // Stellar address
+}
+
+/** A lightweight typed error used only inside this module. */
+class AuthError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string = "unauthenticated",
+    public readonly status: number = 401,
+  ) {
+    super(message);
+    this.name = "AuthError";
+  }
+}
+
+/**
+ * Extracts the Bearer token from the Authorization header.
+ * Returns the raw JWT string or throws an AuthError.
+ */
+function extractBearerToken(req: Request): string {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    throw new AuthError("Missing or malformed Authorization header");
+  }
+  const token = authHeader.slice(7).trim();
+  if (!token) {
+    throw new AuthError("Empty Bearer token");
+  }
+  return token;
+}
+
+/**
+ * Verifies the JWT and returns the decoded payload.
+ * Throws an AuthError for expired, forged, or wrong-audience tokens.
+ */
+function verifyToken(token: string): AuthPayload {
+  let payload: JwtPayload | string;
+  try {
+    payload = jwt.verify(token, env.JWT_SECRET, {
+      algorithms: ["HS256"],
+      issuer: env.JWT_ISSUER,
+      audience: env.JWT_AUDIENCE,
+    });
+  } catch (err) {
+    // Map jsonwebtoken error names to a single stable code so callers don't
+    // need to inspect the message string.
+    const name = (err as Error).name;
+    if (name === "TokenExpiredError") {
+      throw new AuthError("Token has expired", "unauthenticated");
+    }
+    // JsonWebTokenError covers bad signature, wrong issuer, wrong audience, etc.
+    throw new AuthError("Invalid token", "unauthenticated");
+  }
+
+  // jwt.verify returns a string only when `complete: false` AND the header
+  // algorithm is "none". Our options pin HS256 so this branch is unreachable,
+  // but narrowing keeps TypeScript happy.
+  if (typeof payload === "string" || !payload.sub) {
+    throw new AuthError("Token payload is missing subject", "unauthenticated");
+  }
+
+  return payload as AuthPayload;
+}
+
+/**
+ * Loads the user row from the database by Stellar address.
+ * The look-up uses the unique index on `stellar_address` — O(log n) I/O.
+ * Throws an AuthError when no matching user exists (token is valid but the
+ * account has been deleted, for example).
+ */
+async function loadUser(stellarAddress: string): Promise<Request["user"]> {
+  const rows = await db
+    .select({ id: users.id, stellarAddress: users.stellarAddress })
+    .from(users)
+    .where(eq(users.stellarAddress, stellarAddress))
+    .limit(1);
+
+  if (rows.length === 0) {
+    throw new AuthError("User not found", "unauthenticated");
+  }
+
+  return rows[0];
+}
+
+/**
+ * Core authentication flow shared by both middleware variants.
+ *
+ * @returns The hydrated user object, or throws an AuthError.
+ */
+async function authenticate(req: Request): Promise<NonNullable<Request["user"]>> {
+  const token = extractBearerToken(req);
+  const payload = verifyToken(token);
+  const user = await loadUser(payload.sub);
+  return user!;
+}
+
+// ---------------------------------------------------------------------------
+// Public middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * `requireAuth` — protects a route; rejects unauthenticated requests.
+ *
+ * On success  → calls `next()` with `req.user` populated.
+ * On failure  → responds 401 `{ error: { code: "unauthenticated" } }` and
+ *               does NOT call `next()`.
+ */
+export const requireAuth: RequestHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    req.user = await authenticate(req);
+    next();
+  } catch (err) {
+    if (err instanceof AuthError) {
+      logger.warn(
+        { path: req.path, method: req.method, reason: err.message },
+        "auth_rejected",
+      );
+      res.status(err.status).json({ error: { code: err.code } });
+      return;
+    }
+    // Unexpected errors (e.g. DB unavailable) bubble to the global error handler.
+    next(err);
+  }
+};
+
+/**
+ * `optionalAuth` — personalises a route without requiring authentication.
+ *
+ * On valid token   → `req.user` is populated, `next()` is called.
+ * On missing token → `req.user` stays `undefined`, `next()` is called.
+ * On invalid token → responds 401 so clients know their token is broken and
+ *                    can re-authenticate rather than silently receiving a
+ *                    de-personalised response.
+ */
+export const optionalAuth: RequestHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  const authHeader = req.headers.authorization;
+
+  // No header at all → treat as anonymous, continue.
+  if (!authHeader) {
+    next();
+    return;
+  }
+
+  // Header present → validate fully; a broken token is still an error.
+  try {
+    req.user = await authenticate(req);
+    next();
+  } catch (err) {
+    if (err instanceof AuthError) {
+      logger.warn(
+        { path: req.path, method: req.method, reason: err.message },
+        "auth_rejected",
+      );
+      res.status(err.status).json({ error: { code: err.code } });
+      return;
+    }
+    next(err);
+  }
+};

--- a/src/routes/markets.ts
+++ b/src/routes/markets.ts
@@ -1,11 +1,19 @@
 import { Router } from "express";
+import { optionalAuth } from "../middleware/requireAuth";
 import { listMarkets, getMarketById } from "../services/marketService";
 
 export const marketsRouter = Router();
 
-marketsRouter.get("/", async (_req, res, next) => {
+/**
+ * GET /api/markets
+ * Public listing — personalised when a valid JWT is supplied.
+ * optionalAuth populates req.user when a token is present; 401s on a bad token
+ * so the client knows to re-authenticate rather than silently losing context.
+ */
+marketsRouter.get("/", optionalAuth, async (req, res, next) => {
   try {
-    res.json({ data: await listMarkets() });
+    // req.user is defined only when the caller sent a valid JWT.
+    res.json({ data: await listMarkets(), authenticatedAs: req.user ?? null });
   } catch (e) { next(e); }
 });
 

--- a/src/routes/predictions.ts
+++ b/src/routes/predictions.ts
@@ -1,0 +1,25 @@
+/**
+ * /api/predictions — sample protected resource.
+ *
+ * Demonstrates how to import and apply `requireAuth`.  Because the middleware
+ * runs before every handler on this router, TypeScript knows `req.user` is
+ * defined (non-optional) inside the callbacks.
+ */
+
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+
+export const predictionsRouter = Router();
+
+// Apply requireAuth to every route on this router.
+predictionsRouter.use(requireAuth);
+
+/**
+ * GET /api/predictions
+ * Returns predictions belonging to the authenticated user.
+ */
+predictionsRouter.get("/", (req, res) => {
+  // req.user is guaranteed to be defined here because requireAuth
+  // would have returned 401 before reaching this handler.
+  res.json({ data: [], user: req.user });
+});

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,28 @@
+/**
+ * Augments the Express `Request` type so that TypeScript knows about
+ * `req.user` on every route handler — no more `any` casts.
+ *
+ * This file is a pure ambient declaration; it has no runtime footprint.
+ */
+
+import "express";
+
+declare module "express" {
+  interface Request {
+    /**
+     * Populated by `requireAuth` (or `optionalAuth`) after a valid JWT is
+     * verified and the corresponding user row is loaded from the database.
+     *
+     * - `requireAuth`  → always defined on the handler (middleware returns 401
+     *                    before the handler runs if the token is absent/invalid)
+     * - `optionalAuth` → defined only when a valid token was supplied; `undefined`
+     *                    otherwise (handler must check before use)
+     */
+    user?: {
+      /** Database UUID primary key */
+      id: string;
+      /** Stellar G-address that owns this account */
+      stellarAddress: string;
+    };
+  }
+}

--- a/tests/requireAuth.test.ts
+++ b/tests/requireAuth.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Tests for requireAuth and optionalAuth middleware.
+ *
+ * Strategy
+ * --------
+ * The middleware depends on:
+ *   1. `jsonwebtoken`  — for JWT verification (real library, no mock needed)
+ *   2. `drizzle-orm`   — for the DB query
+ *   3. `pg`            — for the underlying connection pool
+ *
+ * We mock the `pg` Pool and the drizzle select chain so the tests run
+ * without a real database while exercising the full middleware logic.
+ *
+ * Environment
+ * -----------
+ * JWT_SECRET, JWT_ISSUER, and JWT_AUDIENCE are set in beforeAll so that
+ * `env.ts` (which validates at import time) gets valid values.
+ */
+
+// ---------------------------------------------------------------------------
+// 1. Provide env vars BEFORE any project module is imported.
+// ---------------------------------------------------------------------------
+const TEST_SECRET = "a-very-long-test-secret-at-least-32-bytes!!";
+const TEST_ISSUER = "predictify";
+const TEST_AUDIENCE = "predictify-app";
+const TEST_USER_ID = "11111111-1111-1111-1111-111111111111";
+const TEST_STELLAR = "GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12";
+
+process.env.NODE_ENV = "test";
+process.env.PORT = "3001";
+process.env.LOG_LEVEL = "silent";
+process.env.DATABASE_URL = "postgres://localhost/test";
+process.env.JWT_SECRET = TEST_SECRET;
+process.env.JWT_ISSUER = TEST_ISSUER;
+process.env.JWT_AUDIENCE = TEST_AUDIENCE;
+process.env.JWT_TTL_SECONDS = "3600";
+process.env.STELLAR_NETWORK = "testnet";
+process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "CABCDEF";
+
+// ---------------------------------------------------------------------------
+// 2. Mock `pg` so no real DB connection is attempted.
+// ---------------------------------------------------------------------------
+jest.mock("pg", () => {
+  const Pool = jest.fn().mockImplementation(() => ({
+    connect: jest.fn(),
+    query: jest.fn(),
+    end: jest.fn(),
+  }));
+  return { Pool };
+});
+
+// ---------------------------------------------------------------------------
+// 3. Mock drizzle-orm/node-postgres so we control DB results.
+// ---------------------------------------------------------------------------
+const mockLimit = jest.fn();
+const mockWhere = jest.fn(() => ({ limit: mockLimit }));
+const mockFrom = jest.fn(() => ({ where: mockWhere }));
+const mockSelect = jest.fn(() => ({ from: mockFrom }));
+
+jest.mock("drizzle-orm/node-postgres", () => ({
+  drizzle: jest.fn(() => ({ select: mockSelect })),
+}));
+
+// ---------------------------------------------------------------------------
+// 4. Now import everything (env parsing runs here with the vars set above).
+// ---------------------------------------------------------------------------
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { createApp } from "../src/index";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Sign a JWT with configurable overrides for negative-path tests. */
+function signToken(
+  sub: string = TEST_STELLAR,
+  options: jwt.SignOptions = {},
+): string {
+  return jwt.sign({ sub }, TEST_SECRET, {
+    algorithm: "HS256",
+    issuer: TEST_ISSUER,
+    audience: TEST_AUDIENCE,
+    expiresIn: 3600,
+    ...options,
+  });
+}
+
+/** Configure the drizzle mock to return a user row. */
+function mockDbReturnsUser(): void {
+  mockLimit.mockResolvedValueOnce([
+    { id: TEST_USER_ID, stellarAddress: TEST_STELLAR },
+  ]);
+}
+
+/** Configure the drizzle mock to return an empty result set. */
+function mockDbReturnsNoUser(): void {
+  mockLimit.mockResolvedValueOnce([]);
+}
+
+// ---------------------------------------------------------------------------
+// Test suites
+// ---------------------------------------------------------------------------
+
+describe("requireAuth middleware", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeAll(() => {
+    app = createApp();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── Happy path ────────────────────────────────────────────────────────────
+
+  it("populates req.user and calls next for a valid JWT", async () => {
+    mockDbReturnsUser();
+
+    const token = signToken();
+    const res = await request(app)
+      .get("/api/predictions")
+      .set("Authorization", `Bearer ${token}`);
+
+    // The predictions route echoes req.user back in the response.
+    expect(res.status).toBe(200);
+    expect(res.body.user).toEqual({
+      id: TEST_USER_ID,
+      stellarAddress: TEST_STELLAR,
+    });
+  });
+
+  // ── Missing token ─────────────────────────────────────────────────────────
+
+  it("returns 401 with code=unauthenticated when Authorization header is absent", async () => {
+    const res = await request(app).get("/api/predictions");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("unauthenticated");
+  });
+
+  it("returns 401 when Authorization header lacks 'Bearer' prefix", async () => {
+    const res = await request(app)
+      .get("/api/predictions")
+      .set("Authorization", "Token some-random-value");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("unauthenticated");
+  });
+
+  // ── Expired token ─────────────────────────────────────────────────────────
+
+  it("returns 401 with code=unauthenticated for an expired token", async () => {
+    // expiresIn: -1 creates a token that expired one second ago.
+    const token = signToken(TEST_STELLAR, { expiresIn: -1 });
+
+    const res = await request(app)
+      .get("/api/predictions")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("unauthenticated");
+  });
+
+  // ── Forged / tampered token ───────────────────────────────────────────────
+
+  it("returns 401 for a token signed with the wrong secret", async () => {
+    const token = jwt.sign({ sub: TEST_STELLAR }, "wrong-secret-that-is-long-enough-32bytes!!", {
+      algorithm: "HS256",
+      issuer: TEST_ISSUER,
+      audience: TEST_AUDIENCE,
+      expiresIn: 3600,
+    });
+
+    const res = await request(app)
+      .get("/api/predictions")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("unauthenticated");
+  });
+
+  it("returns 401 for a token with a completely invalid format", async () => {
+    const res = await request(app)
+      .get("/api/predictions")
+      .set("Authorization", "Bearer not.a.jwt");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("unauthenticated");
+  });
+
+  // ── Wrong audience ────────────────────────────────────────────────────────
+
+  it("returns 401 when the token audience does not match", async () => {
+    const token = signToken(TEST_STELLAR, { audience: "wrong-audience" });
+
+    const res = await request(app)
+      .get("/api/predictions")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("unauthenticated");
+  });
+
+  // ── Wrong issuer ──────────────────────────────────────────────────────────
+
+  it("returns 401 when the token issuer does not match", async () => {
+    const token = signToken(TEST_STELLAR, { issuer: "evil-issuer" });
+
+    const res = await request(app)
+      .get("/api/predictions")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("unauthenticated");
+  });
+
+  // ── User not found in DB ──────────────────────────────────────────────────
+
+  it("returns 401 when the JWT is valid but no matching user exists", async () => {
+    mockDbReturnsNoUser();
+
+    const token = signToken();
+    const res = await request(app)
+      .get("/api/predictions")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("unauthenticated");
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("optionalAuth middleware", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeAll(() => {
+    app = createApp();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("continues anonymously (authenticatedAs: null) when no token is provided", async () => {
+    const res = await request(app).get("/api/markets");
+
+    // Markets route is public; 200 expected even without a token.
+    expect(res.status).toBe(200);
+    expect(res.body.authenticatedAs).toBeNull();
+  });
+
+  it("populates req.user when a valid token is provided", async () => {
+    mockDbReturnsUser();
+
+    const token = signToken();
+    const res = await request(app)
+      .get("/api/markets")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.authenticatedAs).toEqual({
+      id: TEST_USER_ID,
+      stellarAddress: TEST_STELLAR,
+    });
+  });
+
+  it("returns 401 when an Authorization header is present but the token is invalid", async () => {
+    const res = await request(app)
+      .get("/api/markets")
+      .set("Authorization", "Bearer this-is-garbage");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("unauthenticated");
+  });
+
+  it("returns 401 for an expired token even on an optional route", async () => {
+    const token = signToken(TEST_STELLAR, { expiresIn: -1 });
+
+    const res = await request(app)
+      .get("/api/markets")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("unauthenticated");
+  });
+});


### PR DESCRIPTION
Summary


Implements a single source of truth for authenticated requests. Any route that needs to know \"this request is Stellar address X\" now imports `requireAuth` or `optionalAuth` instead of re-verifying tokens inline.

---

## Changes

### New files
- **`src/middleware/requireAuth.ts`** — core middleware with two exports:
  - `requireAuth` — hard gate; returns `401` before the handler runs if the token is missing, expired, forged, wrong audience, or the user row doesn't exist
  - `optionalAuth` — soft gate; populates `req.user` when a valid token is present, passes through anonymously when no `Authorization` header is sent, still 401s on a present-but-invalid token
- **`src/types/express.d.ts`** — ambient module augmentation that adds `req.user?: { id: string; stellarAddress: string }` to Express `Request`; TypeScript sees the type everywhere with zero `any` casts
- **`src/routes/predictions.ts`** — sample protected resource demonstrating `requireAuth` applied at router level
- **`tests/requireAuth.test.ts`** — full test suite (see below)

### Modified files
- **`src/routes/markets.ts`** — `GET /api/markets` now uses `optionalAuth` to demonstrate personalised-but-public pattern
- **`src/index.ts`** — registers the new `/api/predictions` router

---

## JWT contract

| Claim | Expected value |
|-------|----------------|
| `alg` | `HS256` |
| `iss` | `env.JWT_ISSUER` |
| `aud` | `env.JWT_AUDIENCE` |
| `sub` | `users.stellar_address` |
| `exp` | verified automatically |

---

## Security & performance notes

- **No I/O in the hot path beyond one indexed DB lookup** — `stellar_address` has a `UNIQUE` index so the query is O(log n)
- Algorithm is pinned to `HS256`; `jsonwebtoken` rejects anything else
- All failure paths return the same stable `error.code = \"unauthenticated\"` — no information leakage about whether the token was expired vs forged vs user-not-found
- DB pool is a module-level singleton — one pool per process, not per request

---

## Test coverage

| Test | Expectation |
|------|-------------|
| Valid JWT | `200`, `req.user` populated |
| Missing `Authorization` header | `401 unauthenticated` |
| Malformed header (no Bearer prefix) | `401 unauthenticated` |
| Expired token | `401 unauthenticated` |
| Wrong secret (forged token) | `401 unauthenticated` |
| Completely invalid JWT format | `401 unauthenticated` |
| Wrong audience | `401 unauthenticated` |
| Wrong issuer | `401 unauthenticated` |
| Valid JWT but user deleted from DB | `401 unauthenticated` |
| `optionalAuth` — no token | `200`, `authenticatedAs: null` |
| `optionalAuth` — valid token | `200`, `req.user` populated |
| `optionalAuth` — invalid token present | `401 unauthenticated` |
| `optionalAuth` — expired token present | `401 unauthenticated` |

pg and drizzle-orm are mocked so the suite runs without a live database.

---

## How to use

\`\`\`ts
import { requireAuth, optionalAuth } from '../middleware/requireAuth';

// Hard-protected route
router.post('/predictions', requireAuth, handler);

// Personalised public route
router.get('/markets', optionalAuth, handler);
\`\`\`


Closes #65
