### PR TITLE
bug: replace markets stub with real query

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ npm run db:migrate
 npm run dev
 ```
 
+`DATABASE_URL` is required in development and production. The markets API reads from
+Postgres with Drizzle and returns active, non-archived rows from the `markets` table.
+
+## Markets API
+
+```http
+GET /api/markets?limit=50&offset=0
+```
+
+`limit` is optional and capped at 100; `offset` defaults to 0. Responses contain
+ISO-8601 `resolutionTime` values.
+
 ## Layout
 
 ```

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   testMatch: ["**/tests/**/*.test.ts"],
+  setupFiles: ["<rootDir>/tests/setupEnv.ts"],
   collectCoverageFrom: ["src/**/*.ts"],
   coverageDirectory: "coverage",
 };

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,21 +1,31 @@
 import { z } from "zod";
 
-const schema = z.object({
-  NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
-  PORT: z.coerce.number().int().positive().default(3001),
-  LOG_LEVEL: z.enum(["fatal", "error", "warn", "info", "debug", "trace"]).default("info"),
-  DATABASE_URL: z.string().url(),
-  JWT_SECRET: z.string().min(32),
-  JWT_ISSUER: z.string().default("predictify"),
-  JWT_AUDIENCE: z.string().default("predictify-app"),
-  JWT_TTL_SECONDS: z.coerce.number().int().positive().default(3600),
-  STELLAR_NETWORK: z.enum(["testnet", "mainnet"]).default("testnet"),
-  SOROBAN_RPC_URL: z.string().url(),
-  HORIZON_URL: z.string().url(),
-  PREDICTIFY_CONTRACT_ID: z.string().min(1),
-  INDEXER_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(5000),
-  INDEXER_START_LEDGER: z.coerce.number().int().nonnegative().default(0),
-});
+const schema = z
+  .object({
+    NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+    PORT: z.coerce.number().int().positive().default(3001),
+    LOG_LEVEL: z.enum(["fatal", "error", "warn", "info", "debug", "trace"]).default("info"),
+    DATABASE_URL: z.string().url().optional(),
+    JWT_SECRET: z.string().min(32),
+    JWT_ISSUER: z.string().default("predictify"),
+    JWT_AUDIENCE: z.string().default("predictify-app"),
+    JWT_TTL_SECONDS: z.coerce.number().int().positive().default(3600),
+    STELLAR_NETWORK: z.enum(["testnet", "mainnet"]).default("testnet"),
+    SOROBAN_RPC_URL: z.string().url(),
+    HORIZON_URL: z.string().url(),
+    PREDICTIFY_CONTRACT_ID: z.string().min(1),
+    INDEXER_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(5000),
+    INDEXER_START_LEDGER: z.coerce.number().int().nonnegative().default(0),
+  })
+  .superRefine((value, ctx) => {
+    if (value.NODE_ENV !== "test" && !value.DATABASE_URL) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["DATABASE_URL"],
+        message: "DATABASE_URL is required outside test",
+      });
+    }
+  });
 
 export const env = schema.parse(process.env);
 export type Env = z.infer<typeof schema>;

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,0 +1,43 @@
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { env } from "../config/env";
+import * as schema from "./schema";
+
+export type Database = NodePgDatabase<typeof schema>;
+
+let pool: Pool | null = null;
+let db: Database | null = null;
+
+export function getDb(): Database {
+  if (db) return db;
+
+  if (!env.DATABASE_URL) {
+    throw new Error(
+      env.NODE_ENV === "test"
+        ? "Test database client has not been configured"
+        : "DATABASE_URL is required to query markets",
+    );
+  }
+
+  pool = new Pool({ connectionString: env.DATABASE_URL });
+  db = drizzle(pool, { schema });
+  return db;
+}
+
+export function getPool(): Pool {
+  if (!pool) getDb();
+  if (!pool) {
+    throw new Error("Database pool is not available");
+  }
+
+  return pool;
+}
+
+export function setDbForTests(testDb: Database | null): void {
+  if (env.NODE_ENV !== "test") {
+    throw new Error("setDbForTests can only be used in test");
+  }
+
+  db = testDb;
+  pool = null;
+}

--- a/src/routes/markets.ts
+++ b/src/routes/markets.ts
@@ -1,18 +1,38 @@
 import { Router } from "express";
+import { z } from "zod";
 import { listMarkets, getMarketById } from "../services/marketService";
 
 export const marketsRouter = Router();
 
-marketsRouter.get("/", async (_req, res, next) => {
+const paginationQuerySchema = z.object({
+  limit: z.coerce.number().int().positive().max(100).optional(),
+  offset: z.coerce.number().int().nonnegative().optional(),
+});
+
+marketsRouter.get("/", async (req, res, next) => {
   try {
-    res.json({ data: await listMarkets() });
-  } catch (e) { next(e); }
+    const parsed = paginationQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      res.status(400).json({ error: { code: "invalid_query" } });
+      return;
+    }
+
+    res.json({ data: await listMarkets(parsed.data) });
+  } catch (e) {
+    next(e);
+  }
 });
 
 marketsRouter.get("/:id", async (req, res, next) => {
   try {
     const market = await getMarketById(req.params.id);
-    if (!market) return res.status(404).json({ error: { code: "not_found" } });
+    if (!market) {
+      res.status(404).json({ error: { code: "not_found" } });
+      return;
+    }
+
     res.json({ data: market });
-  } catch (e) { next(e); }
+  } catch (e) {
+    next(e);
+  }
 });

--- a/src/services/marketService.ts
+++ b/src/services/marketService.ts
@@ -1,3 +1,7 @@
+import { and, asc, eq } from "drizzle-orm";
+import { getDb } from "../db/client";
+import { markets } from "../db/schema";
+
 export interface Market {
   id: string;
   question: string;
@@ -5,10 +9,72 @@ export interface Market {
   resolutionTime: string;
 }
 
-export async function listMarkets(): Promise<Market[]> {
-  return [];
+export interface ListMarketsOptions {
+  limit?: number;
+  offset?: number;
 }
 
-export async function getMarketById(_id: string): Promise<Market | null> {
-  return null;
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+const marketStatus = new Set<Market["status"]>(["active", "resolved", "disputed"]);
+
+export async function listMarkets(options: ListMarketsOptions = {}): Promise<Market[]> {
+  const limit = normalizeLimit(options.limit);
+  const offset = normalizeOffset(options.offset);
+  const rows = await getDb()
+    .select({
+      id: markets.id,
+      question: markets.question,
+      status: markets.status,
+      resolutionTime: markets.resolutionTime,
+    })
+    .from(markets)
+    .where(eq(markets.archived, false))
+    .orderBy(asc(markets.resolutionTime), asc(markets.id))
+    .limit(limit)
+    .offset(offset);
+
+  return rows.map(toMarket);
+}
+
+export async function getMarketById(id: string): Promise<Market | null> {
+  const [row] = await getDb()
+    .select({
+      id: markets.id,
+      question: markets.question,
+      status: markets.status,
+      resolutionTime: markets.resolutionTime,
+    })
+    .from(markets)
+    .where(and(eq(markets.id, id), eq(markets.archived, false)))
+    .limit(1);
+
+  return row ? toMarket(row) : null;
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  if (limit === undefined) return DEFAULT_LIMIT;
+  return Math.min(limit, MAX_LIMIT);
+}
+
+function normalizeOffset(offset: number | undefined): number {
+  return offset ?? 0;
+}
+
+function toMarket(row: {
+  id: string;
+  question: string;
+  status: string;
+  resolutionTime: Date;
+}): Market {
+  if (!marketStatus.has(row.status as Market["status"])) {
+    throw new Error(`Unexpected market status: ${row.status}`);
+  }
+
+  return {
+    id: row.id,
+    question: row.question,
+    status: row.status as Market["status"],
+    resolutionTime: row.resolutionTime.toISOString(),
+  };
 }

--- a/tests/markets.test.ts
+++ b/tests/markets.test.ts
@@ -1,0 +1,66 @@
+import request from "supertest";
+import type { Database } from "../src/db/client";
+import { setDbForTests } from "../src/db/client";
+import { createApp } from "../src/index";
+
+type MarketRow = {
+  id: string;
+  question: string;
+  status: string;
+  resolutionTime: Date;
+};
+
+describe("GET /api/markets", () => {
+  afterEach(() => {
+    setDbForTests(null);
+  });
+
+  it("returns seeded markets from the database query", async () => {
+    setDbForTests(createMarketDb([
+      {
+        id: "market-1",
+        question: "Will Predictify ship real market reads?",
+        status: "active",
+        resolutionTime: new Date("2026-07-01T00:00:00.000Z"),
+      },
+    ]));
+
+    const res = await request(createApp()).get("/api/markets");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      data: [
+        {
+          id: "market-1",
+          question: "Will Predictify ship real market reads?",
+          status: "active",
+          resolutionTime: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("rejects invalid pagination input", async () => {
+    const res = await request(createApp()).get("/api/markets?limit=1000");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: { code: "invalid_query" } });
+  });
+});
+
+function createMarketDb(rows: MarketRow[]): Database {
+  return {
+    select: jest.fn(() => ({
+      from: jest.fn(() => ({
+        where: jest.fn(() => ({
+          orderBy: jest.fn(() => ({
+            limit: jest.fn(() => ({
+              offset: jest.fn(async () => rows),
+            })),
+          })),
+          limit: jest.fn(async (limit: number) => rows.slice(0, limit)),
+        })),
+      })),
+    })),
+  } as unknown as Database;
+}

--- a/tests/setupEnv.ts
+++ b/tests/setupEnv.ts
@@ -1,0 +1,5 @@
+process.env.NODE_ENV = "test";
+process.env.JWT_SECRET = "test-secret-with-at-least-32-characters";
+process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "test-contract";


### PR DESCRIPTION
## Summary

- Replaces the empty markets stub with Drizzle-backed Postgres queries.
- Adds pagination validation for `GET /api/markets`.
- Adds `GET /api/markets/:id` database lookup behavior for non-archived markets.
- Introduces a shared database client with test injection support.
- Documents the Markets API and required `DATABASE_URL` behavior.
- Adds Jest coverage for successful market reads and invalid pagination.

## Testing

- `npm.cmd test`
- `npm.cmd run build`

## Closes #96 