### PR TITLE
feat: reorg-safe Soroban indexer with rewind window and event dedup (#69)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,6 @@ PREDICTIFY_CONTRACT_ID=CABCDEF...
 # Indexer
 INDEXER_POLL_INTERVAL_MS=5000
 INDEXER_START_LEDGER=0
+
+# How many ledgers behind the cursor to re-fetch each tick for reorg detection  (default: 100)
+INDEXER_REWIND_LEDGERS=100

--- a/drizzle/0001_add_indexer_events.sql
+++ b/drizzle/0001_add_indexer_events.sql
@@ -1,0 +1,27 @@
+-- Migration: add indexer_events table
+--
+-- Stores every on-chain Soroban event seen for the Predictify contract.
+-- The unique index on (ledger, tx_hash, op_index) is the deduplication key:
+--   INSERT ... ON CONFLICT DO NOTHING silently drops re-ingested duplicates,
+--   and the same index makes orphan detection efficient during reorg handling.
+
+CREATE TABLE IF NOT EXISTS "indexer_events" (
+  "id"               uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- RPC paging cursor kept for debugging and re-play queries
+  "event_id"         text        NOT NULL,
+  "ledger"           integer     NOT NULL,
+  "tx_hash"          text        NOT NULL,
+  -- Zero-based position of the event within the transaction
+  "op_index"         integer     NOT NULL,
+  "contract_id"      text        NOT NULL,
+  -- XDR-encoded topic segments as a JSON array of base64 strings
+  "topic_xdr"        jsonb       NOT NULL,
+  -- XDR-encoded event value (base64)
+  "value_xdr"        text        NOT NULL,
+  "ledger_closed_at" timestamptz NOT NULL,
+  "created_at"       timestamptz NOT NULL DEFAULT now()
+);
+
+-- Deduplication + reorg-detection index
+CREATE UNIQUE INDEX IF NOT EXISTS "indexer_events_ledger_tx_op_idx"
+  ON "indexer_events" ("ledger", "tx_hash", "op_index");

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   testMatch: ["**/tests/**/*.test.ts"],
+  setupFiles: ["./tests/setup.ts"],
   collectCoverageFrom: ["src/**/*.ts"],
   coverageDirectory: "coverage",
 };

--- a/src/config/env-schema.ts
+++ b/src/config/env-schema.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+export const envSchema = z.object({
+  // ── Application ───────────────────────────────────────────
+  NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+  PORT: z.coerce.number().int().positive().default(3001),
+  LOG_LEVEL: z.enum(["fatal", "error", "warn", "info", "debug", "trace"]).default("info"),
+
+  // ── Database ──────────────────────────────────────────────
+  DATABASE_URL: z.string().url(),
+
+  // ── JWT ───────────────────────────────────────────────────
+  JWT_SECRET: z.string().min(32),
+  JWT_ISSUER: z.string().default("predictify"),
+  JWT_AUDIENCE: z.string().default("predictify-app"),
+  JWT_TTL_SECONDS: z.coerce.number().int().positive().default(3600),
+
+  // ── Stellar / Soroban ─────────────────────────────────────
+  STELLAR_NETWORK: z.enum(["testnet", "mainnet"]).default("testnet"),
+  SOROBAN_RPC_URL: z.string().url(),
+  HORIZON_URL: z.string().url(),
+  PREDICTIFY_CONTRACT_ID: z.string().min(1),
+
+  // ── Indexer tunables ──────────────────────────────────────
+  INDEXER_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(5000),
+  INDEXER_START_LEDGER: z.coerce.number().int().nonnegative().default(0),
+  // How many ledgers behind the cursor to re-fetch each tick (reorg protection)
+  INDEXER_REWIND_LEDGERS: z.coerce.number().int().positive().default(100),
+});
+
+export type Env = z.infer<typeof envSchema>;
+
+// Returns a bullet-list string of all validation failures, suitable for console output.
+export function formatEnvErrors(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => `  • ${issue.path.join(".") || "(root)"}: ${issue.message}`)
+    .join("\n");
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,21 +1,4 @@
-import { z } from "zod";
+import { envSchema } from "./env-schema";
 
-const schema = z.object({
-  NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
-  PORT: z.coerce.number().int().positive().default(3001),
-  LOG_LEVEL: z.enum(["fatal", "error", "warn", "info", "debug", "trace"]).default("info"),
-  DATABASE_URL: z.string().url(),
-  JWT_SECRET: z.string().min(32),
-  JWT_ISSUER: z.string().default("predictify"),
-  JWT_AUDIENCE: z.string().default("predictify-app"),
-  JWT_TTL_SECONDS: z.coerce.number().int().positive().default(3600),
-  STELLAR_NETWORK: z.enum(["testnet", "mainnet"]).default("testnet"),
-  SOROBAN_RPC_URL: z.string().url(),
-  HORIZON_URL: z.string().url(),
-  PREDICTIFY_CONTRACT_ID: z.string().min(1),
-  INDEXER_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(5000),
-  INDEXER_START_LEDGER: z.coerce.number().int().nonnegative().default(0),
-});
-
-export const env = schema.parse(process.env);
-export type Env = z.infer<typeof schema>;
+export const env = envSchema.parse(process.env);
+export type { Env } from "./env-schema";

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,0 +1,9 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { env } from "../config/env";
+import * as schema from "./schema";
+
+const pool = new Pool({ connectionString: env.DATABASE_URL });
+
+export const db = drizzle(pool, { schema });
+export type DB = typeof db;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, timestamp, integer, boolean, jsonb } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, timestamp, integer, boolean, jsonb, uniqueIndex } from "drizzle-orm/pg-core";
 
 export const users = pgTable("users", {
   id: uuid("id").primaryKey().defaultRandom(),
@@ -30,3 +30,33 @@ export const indexerCursor = pgTable("indexer_cursor", {
   lastLedger: integer("last_ledger").notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });
+
+// One row per on-chain Soroban event seen for the Predictify contract.
+// The unique index on (ledger, tx_hash, op_index) is the deduplication
+// key used for both normal re-ingestion and post-reorg re-ingest.
+export const indexerEvents = pgTable(
+  "indexer_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    // RPC paging cursor – kept for debugging / re-play queries
+    eventId: text("event_id").notNull(),
+    ledger: integer("ledger").notNull(),
+    txHash: text("tx_hash").notNull(),
+    // Position of the event within the transaction
+    opIndex: integer("op_index").notNull(),
+    contractId: text("contract_id").notNull(),
+    // XDR-encoded topic segments stored as a JSON array of base64 strings
+    topicXdr: jsonb("topic_xdr").notNull().$type<string[]>(),
+    // XDR-encoded event value (base64)
+    valueXdr: text("value_xdr").notNull(),
+    ledgerClosedAt: timestamp("ledger_closed_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    eventKey: uniqueIndex("indexer_events_ledger_tx_op_idx").on(
+      t.ledger,
+      t.txHash,
+      t.opIndex,
+    ),
+  }),
+);

--- a/src/routes/markets.ts
+++ b/src/routes/markets.ts
@@ -12,7 +12,7 @@ marketsRouter.get("/", async (_req, res, next) => {
 marketsRouter.get("/:id", async (req, res, next) => {
   try {
     const market = await getMarketById(req.params.id);
-    if (!market) return res.status(404).json({ error: { code: "not_found" } });
+    if (!market) { res.status(404).json({ error: { code: "not_found" } }); return; }
     res.json({ data: market });
   } catch (e) { next(e); }
 });

--- a/src/services/indexerService.ts
+++ b/src/services/indexerService.ts
@@ -1,0 +1,271 @@
+/**
+ * Reorg-safe Soroban event indexer.
+ *
+ * Each tick the service re-fetches the last INDEXER_REWIND_LEDGERS ledgers
+ * from Soroban RPC and compares them against persisted events.  Any event
+ * that was stored in a previous tick but is no longer returned by the RPC
+ * indicates a chain reorganisation: the indexer rolls back derived state to
+ * the earliest orphaned ledger, then re-ingests the canonical events.
+ *
+ * Duplicate events (same ledger + txHash + opIndex) are silently dropped via
+ * the unique index on indexer_events — inserts use ON CONFLICT DO NOTHING.
+ *
+ * Dependency injection via IndexerStore / EventFetcher makes the algorithm
+ * unit-testable without a live database or RPC node.
+ */
+
+import { eq, gte, inArray } from "drizzle-orm";
+import { rpc as SorobanRpc } from "@stellar/stellar-sdk";
+import { logger } from "../config/logger";
+import { indexerCursor, indexerEvents, markets, predictions } from "../db/schema";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import type * as schema from "../db/schema";
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+export interface RawEvent {
+  /** Soroban ledger sequence number */
+  ledger: number;
+  /** Full transaction hash */
+  txHash: string;
+  /** Event's zero-based position within the transaction */
+  opIndex: number;
+  /** RPC paging cursor (globally unique per event) */
+  id: string;
+  /** Contract Strkey (starts with 'C') */
+  contractId: string;
+  /** XDR-encoded topic segments (base64) */
+  topicXdr: string[];
+  /** XDR-encoded event value (base64) */
+  valueXdr: string;
+  ledgerClosedAt: Date;
+}
+
+/** Minimal projection used for reorg comparison */
+export interface StoredEventRef {
+  ledger: number;
+  txHash: string;
+  opIndex: number;
+  id: string;
+}
+
+// ── Store interface ───────────────────────────────────────────────────────────
+//
+// Implementations: DrizzleIndexerStore (production) and MemoryIndexerStore
+// (tests).  Keeping this boundary thin means the algorithm tests never touch
+// a real database.
+
+export interface IndexerStore {
+  getLastLedger(): Promise<number>;
+  setLastLedger(ledger: number): Promise<void>;
+  /** Returns all stored events with ledger >= fromLedger */
+  getEventsInWindow(fromLedger: number): Promise<StoredEventRef[]>;
+  /** Insert; silently skips if (ledger, txHash, opIndex) already exists */
+  insertEventIgnoreDuplicate(event: RawEvent): Promise<void>;
+  /**
+   * Rolls back all indexer_events and derived rows (markets, predictions)
+   * with ledger / indexedLedger >= fromLedger.  Must be atomic.
+   */
+  deleteFromLedger(fromLedger: number): Promise<void>;
+}
+
+// ── Service ───────────────────────────────────────────────────────────────────
+
+export interface IndexerConfig {
+  contractId: string;
+  startLedger: number;
+  rewindLedgers: number;
+}
+
+export type EventFetcher = (fromLedger: number) => Promise<RawEvent[]>;
+
+export class IndexerService {
+  constructor(
+    private readonly store: IndexerStore,
+    private readonly fetchEvents: EventFetcher,
+    private readonly config: IndexerConfig,
+  ) {}
+
+  async pollOnce(): Promise<void> {
+    const cursor = await this.store.getLastLedger();
+
+    // On the very first run, start from the configured ledger.
+    // On subsequent runs, rewind by rewindLedgers to catch reorgs.
+    const windowStart =
+      cursor > 0
+        ? Math.max(this.config.startLedger, cursor - this.config.rewindLedgers)
+        : this.config.startLedger;
+
+    if (windowStart <= 0) {
+      logger.warn({ event: "indexer_skipped" }, "no start ledger configured; set INDEXER_START_LEDGER");
+      return;
+    }
+
+    const freshEvents = await this.fetchEvents(windowStart);
+
+    if (freshEvents.length === 0) {
+      logger.debug({ event: "indexer_no_events", fromLedger: windowStart }, "no new events in window");
+      return;
+    }
+
+    await this.detectAndHandleReorg(windowStart, freshEvents);
+    await this.ingest(freshEvents);
+
+    const maxLedger = Math.max(...freshEvents.map((e) => e.ledger));
+    if (maxLedger > cursor) {
+      await this.store.setLastLedger(maxLedger);
+      logger.debug({ event: "indexer_cursor_advanced", ledger: maxLedger }, "cursor advanced");
+    }
+  }
+
+  private async detectAndHandleReorg(windowStart: number, freshEvents: RawEvent[]): Promise<void> {
+    const persisted = await this.store.getEventsInWindow(windowStart);
+    if (persisted.length === 0) return;
+
+    const freshKeys = new Set(freshEvents.map(eventKey));
+    const orphaned = persisted.filter((e) => !freshKeys.has(eventKey(e)));
+
+    if (orphaned.length === 0) return;
+
+    const minOrphanedLedger = Math.min(...orphaned.map((e) => e.ledger));
+    const maxFreshLedger = Math.max(...freshEvents.map((e) => e.ledger));
+
+    logger.warn(
+      {
+        event: "indexer_reorg_detected",
+        from: minOrphanedLedger,
+        to: maxFreshLedger,
+        orphanedCount: orphaned.length,
+      },
+      "reorg detected — rolling back derived state",
+    );
+
+    await this.store.deleteFromLedger(minOrphanedLedger);
+  }
+
+  private async ingest(events: RawEvent[]): Promise<void> {
+    for (const event of events) {
+      await this.store.insertEventIgnoreDuplicate(event);
+    }
+    logger.debug({ event: "indexer_ingested", count: events.length }, "events ingested");
+  }
+}
+
+// ── Key helpers ───────────────────────────────────────────────────────────────
+
+/** Composite key used to detect orphaned events during reorg comparison */
+export function eventKey(e: { ledger: number; txHash: string; opIndex: number }): string {
+  return `${e.ledger}:${e.txHash}:${e.opIndex}`;
+}
+
+/**
+ * Soroban event IDs are zero-padded cursor strings in the form
+ * "LLLLLLLLLLL-TTTTTTTTTTT-EEEEEEEEEEE" (ledger-tx-event).
+ * The last segment is the event's zero-based index within the transaction.
+ */
+export function parseOpIndex(eventId: string): number {
+  const parts = eventId.split("-");
+  const parsed = parseInt(parts[parts.length - 1], 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+// ── Production: Soroban RPC event fetcher ─────────────────────────────────────
+
+export function createSorobanFetcher(rpcUrl: string, contractId: string): EventFetcher {
+  const server = new SorobanRpc.Server(rpcUrl, { allowHttp: false });
+
+  return async (fromLedger: number): Promise<RawEvent[]> => {
+    // TODO: paginate when event count may exceed the RPC limit (~10 000).
+    const response = await server.getEvents({
+      startLedger: fromLedger,
+      filters: [{ type: "contract", contractIds: [contractId] }],
+      limit: 10_000,
+    });
+
+    return response.events.map((e) => ({
+      ledger: e.ledger,
+      txHash: e.txHash,
+      opIndex: parseOpIndex(e.id),
+      id: e.id,
+      contractId: e.contractId?.toString() ?? contractId,
+      topicXdr: e.topic.map((t) => t.toXDR("base64")),
+      valueXdr: e.value.toXDR("base64"),
+      ledgerClosedAt: new Date(e.ledgerClosedAt),
+    }));
+  };
+}
+
+// ── Production: Drizzle-backed IndexerStore ───────────────────────────────────
+
+type DB = NodePgDatabase<typeof schema>;
+
+export function createDrizzleStore(db: DB): IndexerStore {
+  return {
+    async getLastLedger(): Promise<number> {
+      const rows = await db
+        .select({ lastLedger: indexerCursor.lastLedger })
+        .from(indexerCursor)
+        .where(eq(indexerCursor.id, 1))
+        .limit(1);
+      return rows[0]?.lastLedger ?? 0;
+    },
+
+    async setLastLedger(ledger: number): Promise<void> {
+      await db
+        .insert(indexerCursor)
+        .values({ id: 1, lastLedger: ledger })
+        .onConflictDoUpdate({
+          target: indexerCursor.id,
+          set: { lastLedger: ledger, updatedAt: new Date() },
+        });
+    },
+
+    async getEventsInWindow(fromLedger: number): Promise<StoredEventRef[]> {
+      return db
+        .select({
+          ledger: indexerEvents.ledger,
+          txHash: indexerEvents.txHash,
+          opIndex: indexerEvents.opIndex,
+          id: indexerEvents.eventId,
+        })
+        .from(indexerEvents)
+        .where(gte(indexerEvents.ledger, fromLedger));
+    },
+
+    async insertEventIgnoreDuplicate(event: RawEvent): Promise<void> {
+      await db
+        .insert(indexerEvents)
+        .values({
+          eventId: event.id,
+          ledger: event.ledger,
+          txHash: event.txHash,
+          opIndex: event.opIndex,
+          contractId: event.contractId,
+          topicXdr: event.topicXdr,
+          valueXdr: event.valueXdr,
+          ledgerClosedAt: event.ledgerClosedAt,
+        })
+        .onConflictDoNothing();
+    },
+
+    async deleteFromLedger(fromLedger: number): Promise<void> {
+      // Wrapped in a transaction: predictions → markets → events
+      // (predictions FK-reference markets; delete child rows first)
+      await db.transaction(async (tx) => {
+        const orphanedMarkets = await tx
+          .select({ id: markets.id })
+          .from(markets)
+          .where(gte(markets.indexedLedger, fromLedger));
+
+        if (orphanedMarkets.length > 0) {
+          await tx.delete(predictions).where(
+            inArray(predictions.marketId, orphanedMarkets.map((m) => m.id)),
+          );
+        }
+
+        await tx.delete(markets).where(gte(markets.indexedLedger, fromLedger));
+        await tx.delete(indexerEvents).where(gte(indexerEvents.ledger, fromLedger));
+      });
+    },
+  };
+}

--- a/tests/indexerService.test.ts
+++ b/tests/indexerService.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tests for IndexerService reorg handling and deduplication.
+ *
+ * The production Drizzle store and Soroban RPC client are replaced by an
+ * in-memory store and a mock fetcher, so these tests run with no database
+ * or network dependency.
+ */
+
+import {
+  IndexerService,
+  IndexerStore,
+  RawEvent,
+  StoredEventRef,
+  eventKey,
+  parseOpIndex,
+} from "../src/services/indexerService";
+
+// ── In-memory IndexerStore ────────────────────────────────────────────────────
+
+class MemoryIndexerStore implements IndexerStore {
+  private cursor = 0;
+  private events: RawEvent[] = [];
+  /** Tracks deleteFromLedger calls so tests can assert rollback behaviour */
+  readonly deletedFromLedgers: number[] = [];
+
+  async getLastLedger(): Promise<number> {
+    return this.cursor;
+  }
+
+  async setLastLedger(ledger: number): Promise<void> {
+    this.cursor = ledger;
+  }
+
+  async getEventsInWindow(fromLedger: number): Promise<StoredEventRef[]> {
+    return this.events
+      .filter((e) => e.ledger >= fromLedger)
+      .map((e) => ({ ledger: e.ledger, txHash: e.txHash, opIndex: e.opIndex, id: e.id }));
+  }
+
+  async insertEventIgnoreDuplicate(event: RawEvent): Promise<void> {
+    const exists = this.events.some(
+      (e) => e.ledger === event.ledger && e.txHash === event.txHash && e.opIndex === event.opIndex,
+    );
+    if (!exists) this.events.push({ ...event });
+  }
+
+  async deleteFromLedger(fromLedger: number): Promise<void> {
+    this.deletedFromLedgers.push(fromLedger);
+    this.events = this.events.filter((e) => e.ledger < fromLedger);
+  }
+
+  /** Test helper: read all stored events */
+  all(): RawEvent[] {
+    return [...this.events];
+  }
+}
+
+// ── Event builder ─────────────────────────────────────────────────────────────
+
+function makeEvent(ledger: number, txHash: string, opIndex: number): RawEvent {
+  return {
+    ledger,
+    txHash,
+    opIndex,
+    id: `${String(ledger).padStart(11, "0")}-${String(0).padStart(11, "0")}-${String(opIndex).padStart(11, "0")}`,
+    contractId: "CTEST_CONTRACT",
+    topicXdr: ["AAAAAA=="],
+    valueXdr: "AAAAAA==",
+    ledgerClosedAt: new Date("2024-01-01T00:00:00Z"),
+  };
+}
+
+const CONFIG = { contractId: "CTEST", startLedger: 90, rewindLedgers: 10 };
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeService(store: MemoryIndexerStore, events: RawEvent[]) {
+  return new IndexerService(store, async () => events, CONFIG);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("parseOpIndex", () => {
+  it("extracts the last segment as a number", () => {
+    expect(parseOpIndex("00000000100-00000000001-00000000003")).toBe(3);
+  });
+
+  it("returns 0 for an unparseable id", () => {
+    expect(parseOpIndex("bad-id")).toBe(0);
+  });
+});
+
+describe("eventKey", () => {
+  it("produces a stable composite key", () => {
+    expect(eventKey({ ledger: 100, txHash: "abc", opIndex: 2 })).toBe("100:abc:2");
+  });
+});
+
+describe("IndexerService.pollOnce — normal ingestion", () => {
+  it("inserts events and advances the cursor", async () => {
+    const store = new MemoryIndexerStore();
+    const events = [
+      makeEvent(100, "tx1", 0),
+      makeEvent(101, "tx2", 0),
+      makeEvent(102, "tx3", 0),
+    ];
+    await makeService(store, events).pollOnce();
+
+    expect(store.all()).toHaveLength(3);
+    expect(await store.getLastLedger()).toBe(102);
+  });
+
+  it("skips the poll when startLedger is 0 and no cursor exists", async () => {
+    const store = new MemoryIndexerStore();
+    const cfg = { ...CONFIG, startLedger: 0 };
+    const svc = new IndexerService(store, async () => [], cfg);
+    await svc.pollOnce();
+
+    expect(store.all()).toHaveLength(0);
+    expect(await store.getLastLedger()).toBe(0);
+  });
+
+  it("does nothing when the RPC returns no events", async () => {
+    const store = new MemoryIndexerStore();
+    await new IndexerService(store, async () => [], CONFIG).pollOnce();
+    expect(store.all()).toHaveLength(0);
+  });
+
+  it("uses the rewind window on subsequent ticks", async () => {
+    const store = new MemoryIndexerStore();
+    // Seed cursor at 105
+    await store.setLastLedger(105);
+
+    let capturedFrom: number | undefined;
+    const svc = new IndexerService(
+      store,
+      async (from) => {
+        capturedFrom = from;
+        return [makeEvent(105, "tx1", 0)];
+      },
+      CONFIG,
+    );
+    await svc.pollOnce();
+
+    // windowStart = max(startLedger=90, 105 - rewind=10) = 95
+    expect(capturedFrom).toBe(95);
+  });
+});
+
+describe("IndexerService.pollOnce — deduplication", () => {
+  it("silently drops events already present in the store", async () => {
+    const store = new MemoryIndexerStore();
+    const events = [makeEvent(100, "tx1", 0), makeEvent(101, "tx2", 0)];
+
+    // First ingest
+    await makeService(store, events).pollOnce();
+    expect(store.all()).toHaveLength(2);
+
+    // Second ingest of the same events (simulates tick overlap in rewind window)
+    await makeService(store, events).pollOnce();
+    expect(store.all()).toHaveLength(2);
+  });
+
+  it("adds only genuinely new events on subsequent ticks", async () => {
+    const store = new MemoryIndexerStore();
+    const first = [makeEvent(100, "tx1", 0)];
+    await makeService(store, first).pollOnce();
+
+    const second = [makeEvent(100, "tx1", 0), makeEvent(101, "tx2", 0)];
+    await makeService(store, second).pollOnce();
+
+    expect(store.all()).toHaveLength(2);
+  });
+});
+
+describe("IndexerService.pollOnce — reorg handling", () => {
+  it("detects orphaned events and rolls back to the earliest orphaned ledger", async () => {
+    const store = new MemoryIndexerStore();
+
+    // ── First tick: ingest canonical chain ──────────────────────────────────
+    const firstPass = [
+      makeEvent(100, "tx1", 0), // will be orphaned by reorg
+      makeEvent(100, "tx1", 1), // will be orphaned by reorg
+      makeEvent(101, "tx2", 0), // canonical — still in RPC after reorg
+    ];
+    await makeService(store, firstPass).pollOnce();
+    expect(store.all()).toHaveLength(3);
+    await store.setLastLedger(101);
+
+    // ── Second tick: RPC returns a reorged chain ─────────────────────────────
+    // Ledger 100 now has different events; ledger 101 is unchanged.
+    const reorgedPass = [
+      makeEvent(100, "tx1_reorged", 0), // replaces the two orphaned events
+      makeEvent(101, "tx2", 0),          // unchanged
+    ];
+    await makeService(store, reorgedPass).pollOnce();
+
+    // Rollback deleted from ledger 100 (the first orphaned ledger)
+    expect(store.deletedFromLedgers).toContain(100);
+
+    // After rollback + re-ingest: tx1_reorged@100 and tx2@101 are present
+    const stored = store.all();
+    expect(stored).toHaveLength(2);
+    expect(stored.some((e) => e.txHash === "tx1_reorged" && e.ledger === 100)).toBe(true);
+    expect(stored.some((e) => e.txHash === "tx2" && e.ledger === 101)).toBe(true);
+
+    // The original orphaned events must be gone
+    expect(stored.some((e) => e.txHash === "tx1")).toBe(false);
+  });
+
+  it("rolls back to the minimum orphaned ledger when multiple ledgers are affected", async () => {
+    const store = new MemoryIndexerStore();
+
+    const firstPass = [
+      makeEvent(100, "txA", 0),
+      makeEvent(101, "txB", 0),
+      makeEvent(102, "txC", 0), // orphaned at the lowest ledger
+    ];
+    await makeService(store, firstPass).pollOnce();
+    await store.setLastLedger(102);
+
+    // Reorg removes everything from 100 onwards
+    const reorgedPass = [makeEvent(103, "txD", 0)];
+    await makeService(store, reorgedPass).pollOnce();
+
+    expect(store.deletedFromLedgers[store.deletedFromLedgers.length - 1]).toBe(100);
+  });
+
+  it("does NOT trigger a rollback when all persisted events match the fresh set", async () => {
+    const store = new MemoryIndexerStore();
+    const events = [makeEvent(100, "tx1", 0), makeEvent(101, "tx2", 0)];
+
+    await makeService(store, events).pollOnce();
+    await store.setLastLedger(101);
+
+    // Same events returned — no reorg
+    await makeService(store, events).pollOnce();
+
+    expect(store.deletedFromLedgers).toHaveLength(0);
+    expect(store.all()).toHaveLength(2);
+  });
+
+  it("re-ingests canonical events for reorged ledgers after rollback", async () => {
+    const store = new MemoryIndexerStore();
+
+    // Seed an orphaned event
+    await store.insertEventIgnoreDuplicate(makeEvent(100, "orphaned_tx", 0));
+    await store.setLastLedger(100);
+
+    // Fresh tick: ledger 100 now has a different event (reorg)
+    const canonical = [makeEvent(100, "canonical_tx", 0)];
+    await makeService(store, canonical).pollOnce();
+
+    expect(store.all()).toHaveLength(1);
+    expect(store.all()[0].txHash).toBe("canonical_tx");
+  });
+
+  it("zero orphaned events: no rollback, no extra inserts", async () => {
+    const store = new MemoryIndexerStore();
+    // Store is empty — first tick, nothing to compare
+    const events = [makeEvent(200, "tx1", 0)];
+    await makeService(store, events).pollOnce();
+
+    expect(store.deletedFromLedgers).toHaveLength(0);
+    expect(store.all()).toHaveLength(1);
+  });
+});
+
+describe("IndexerService.pollOnce — cursor management", () => {
+  it("advances the cursor to the highest ledger in the fresh batch", async () => {
+    const store = new MemoryIndexerStore();
+    const events = [makeEvent(100, "tx1", 0), makeEvent(105, "tx2", 0), makeEvent(103, "tx3", 0)];
+    await makeService(store, events).pollOnce();
+    expect(await store.getLastLedger()).toBe(105);
+  });
+
+  it("does not regress the cursor when fresh events are all within the rewind window", async () => {
+    const store = new MemoryIndexerStore();
+    await store.setLastLedger(110);
+    // Fresh events only cover ledgers up to 108 (below current cursor)
+    const events = [makeEvent(105, "tx1", 0), makeEvent(108, "tx2", 0)];
+    await makeService(store, events).pollOnce();
+    // Cursor stays at 110 because maxLedger(108) is not > cursor(110)
+    expect(await store.getLastLedger()).toBe(110);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,15 @@
+// Provide the minimum env vars needed for test suites that import src/config/env.ts.
+// Values are only applied when not already set (e.g. by a CI system).
+const defaults: Record<string, string> = {
+  NODE_ENV: "test",
+  DATABASE_URL: "postgres://user:pass@localhost:5432/predictify_test",
+  JWT_SECRET: "test-jwt-secret-that-is-at-least-32-characters-long",
+  SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org",
+  HORIZON_URL: "https://horizon-testnet.stellar.org",
+  PREDICTIFY_CONTRACT_ID: "CTEST_CONTRACT_ID",
+  INDEXER_REWIND_LEDGERS: "100",
+};
+
+for (const [key, value] of Object.entries(defaults)) {
+  if (!process.env[key]) process.env[key] = value;
+}


### PR DESCRIPTION
## Summary

- Adds `INDEXER_REWIND_LEDGERS` env var (default `100`) — each tick the indexer re-reads the last N ledgers from Soroban RPC instead of resuming at the cursor tip
- Adds `indexer_events` table with a unique index on `(ledger, tx_hash, op_index)`; events are inserted with `ON CONFLICT DO NOTHING` so duplicates are silently dropped
- Reorg detection: compares fresh RPC events for the rewind window against persisted events; any stored event absent from the fresh response is an orphan — the indexer rolls back all derived rows (`markets`, `predictions`, `indexer_events`) from the earliest orphaned ledger in a single transaction, then re-ingests the canonical events
- Logs a structured `indexer_reorg_detected` event with `from` / `to` ledger numbers and orphan count
- `IndexerStore` interface separates the algorithm from the database, so tests run without a live PG or RPC node

## Key files

| File | Purpose |
|---|---|
| `src/services/indexerService.ts` | Algorithm + `IndexerStore` interface + `createDrizzleStore` / `createSorobanFetcher` factories |
| `src/db/schema.ts` | `indexer_events` table with unique dedup index |
| `drizzle/0001_add_indexer_events.sql` | SQL migration |
| `tests/indexerService.test.ts` | 16 unit tests — `MemoryIndexerStore` + mock fetcher |

## Reorg flow

```
tick N   →  fetch ledgers [cursor - 100 … latestLedger]
         →  diff fresh vs. persisted in window
         →  orphans found → log indexer_reorg_detected
                          → deleteFromLedger(minOrphanedLedger)  [tx]
         →  insert all fresh events ON CONFLICT DO NOTHING
         →  advance cursor to max(freshLedger)
```

## Test plan

- [ ] `npm test` — all 17 tests pass (16 indexer + 1 health)
- [ ] Normal ingestion: events inserted, cursor advances
- [ ] Dedup: re-feeding the same window silently skips duplicates
- [ ] Reorg: orphaned events deleted, derived state rolled back, canonical events re-ingested, `indexer_reorg_detected` logged
- [ ] Zero-orphan tick: no rollback triggered
- [ ] No start ledger: poll skips cleanly with a warning

## Structured log output (reorg)

```json
{
  "event": "indexer_reorg_detected",
  "from": 100,
  "to": 101,
  "orphanedCount": 2,
  "msg": "reorg detected — rolling back derived state"
}
```

Closes #69