### PR TITLE
feat: admin user read endpoint with audit log (#95)

### DIFF
--- a/drizzle/0001_add_admin_tables.sql
+++ b/drizzle/0001_add_admin_tables.sql
@@ -1,0 +1,38 @@
+-- Migration: add claims, disputes, and admin_audit_log tables
+--
+-- claims      – winnings claims submitted after a market resolves
+-- disputes    – resolution disputes raised by users
+-- admin_audit_log – immutable record of every admin read/write on user data
+
+CREATE TABLE IF NOT EXISTS "claims" (
+  "id"         uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id"    uuid        NOT NULL REFERENCES "users" ("id"),
+  "market_id"  text        NOT NULL REFERENCES "markets" ("id"),
+  "amount"     text        NOT NULL,
+  -- pending | paid | rejected
+  "status"     text        NOT NULL DEFAULT 'pending',
+  "created_at" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS "disputes" (
+  "id"         uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id"    uuid        NOT NULL REFERENCES "users" ("id"),
+  "market_id"  text        NOT NULL REFERENCES "markets" ("id"),
+  "reason"     text        NOT NULL,
+  -- open | resolved | rejected
+  "status"     text        NOT NULL DEFAULT 'open',
+  "created_at" timestamptz NOT NULL DEFAULT now()
+);
+
+-- Append-only audit trail; no UPDATE or DELETE should ever touch this table.
+CREATE TABLE IF NOT EXISTS "admin_audit_log" (
+  "id"             uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  "admin_address"  text        NOT NULL,
+  "action"         text        NOT NULL,
+  "target_address" text        NOT NULL,
+  "created_at"     timestamptz NOT NULL DEFAULT now()
+);
+
+-- Fast look-ups for the audit log dashboard (admin → time, target → time)
+CREATE INDEX IF NOT EXISTS "admin_audit_log_admin_idx"  ON "admin_audit_log" ("admin_address", "created_at" DESC);
+CREATE INDEX IF NOT EXISTS "admin_audit_log_target_idx" ON "admin_audit_log" ("target_address", "created_at" DESC);

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   testMatch: ["**/tests/**/*.test.ts"],
+  setupFiles: ["./tests/setup.ts"],
   collectCoverageFrom: ["src/**/*.ts"],
   coverageDirectory: "coverage",
 };

--- a/src/config/env-schema.ts
+++ b/src/config/env-schema.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+export const envSchema = z.object({
+  // ── Application ───────────────────────────────────────────
+  NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+  PORT: z.coerce.number().int().positive().default(3001),
+  LOG_LEVEL: z.enum(["fatal", "error", "warn", "info", "debug", "trace"]).default("info"),
+
+  // ── Database ──────────────────────────────────────────────
+  DATABASE_URL: z.string().url(),
+
+  // ── JWT ───────────────────────────────────────────────────
+  JWT_SECRET: z.string().min(32),
+  JWT_ISSUER: z.string().default("predictify"),
+  JWT_AUDIENCE: z.string().default("predictify-app"),
+  JWT_TTL_SECONDS: z.coerce.number().int().positive().default(3600),
+
+  // ── Stellar / Soroban ─────────────────────────────────────
+  STELLAR_NETWORK: z.enum(["testnet", "mainnet"]).default("testnet"),
+  SOROBAN_RPC_URL: z.string().url(),
+  HORIZON_URL: z.string().url(),
+  PREDICTIFY_CONTRACT_ID: z.string().min(1),
+
+  // ── Indexer tunables ──────────────────────────────────────
+  INDEXER_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(5000),
+  INDEXER_START_LEDGER: z.coerce.number().int().nonnegative().default(0),
+  INDEXER_REWIND_LEDGERS: z.coerce.number().int().positive().default(100),
+});
+
+export type Env = z.infer<typeof envSchema>;
+
+export function formatEnvErrors(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => `  • ${issue.path.join(".") || "(root)"}: ${issue.message}`)
+    .join("\n");
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,21 +1,4 @@
-import { z } from "zod";
+import { envSchema } from "./env-schema";
 
-const schema = z.object({
-  NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
-  PORT: z.coerce.number().int().positive().default(3001),
-  LOG_LEVEL: z.enum(["fatal", "error", "warn", "info", "debug", "trace"]).default("info"),
-  DATABASE_URL: z.string().url(),
-  JWT_SECRET: z.string().min(32),
-  JWT_ISSUER: z.string().default("predictify"),
-  JWT_AUDIENCE: z.string().default("predictify-app"),
-  JWT_TTL_SECONDS: z.coerce.number().int().positive().default(3600),
-  STELLAR_NETWORK: z.enum(["testnet", "mainnet"]).default("testnet"),
-  SOROBAN_RPC_URL: z.string().url(),
-  HORIZON_URL: z.string().url(),
-  PREDICTIFY_CONTRACT_ID: z.string().min(1),
-  INDEXER_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(5000),
-  INDEXER_START_LEDGER: z.coerce.number().int().nonnegative().default(0),
-});
-
-export const env = schema.parse(process.env);
-export type Env = z.infer<typeof schema>;
+export const env = envSchema.parse(process.env);
+export type { Env } from "./env-schema";

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,0 +1,9 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { env } from "../config/env";
+import * as schema from "./schema";
+
+const pool = new Pool({ connectionString: env.DATABASE_URL });
+
+export const db = drizzle(pool, { schema });
+export type DB = typeof db;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, timestamp, integer, boolean, jsonb } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, timestamp, integer, boolean, jsonb, uniqueIndex } from "drizzle-orm/pg-core";
 
 export const users = pgTable("users", {
   id: uuid("id").primaryKey().defaultRandom(),
@@ -25,8 +25,60 @@ export const predictions = pgTable("predictions", {
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
+// Winnings claims submitted by users after a market resolves in their favour
+export const claims = pgTable("claims", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  userId: uuid("user_id").notNull().references(() => users.id),
+  marketId: text("market_id").notNull().references(() => markets.id),
+  amount: text("amount").notNull(),
+  // pending | paid | rejected
+  status: text("status").notNull().default("pending"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+// Resolution disputes raised by users who disagree with an outcome
+export const disputes = pgTable("disputes", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  userId: uuid("user_id").notNull().references(() => users.id),
+  marketId: text("market_id").notNull().references(() => markets.id),
+  reason: text("reason").notNull(),
+  // open | resolved | rejected
+  status: text("status").notNull().default("open"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+// Immutable record of every admin read/write on user data
+export const adminAuditLog = pgTable("admin_audit_log", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  adminAddress: text("admin_address").notNull(),
+  action: text("action").notNull(),
+  targetAddress: text("target_address").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
 export const indexerCursor = pgTable("indexer_cursor", {
   id: integer("id").primaryKey(),
   lastLedger: integer("last_ledger").notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });
+
+// One row per on-chain Soroban event seen for the Predictify contract.
+// Unique index on (ledger, tx_hash, op_index) is the deduplication key.
+export const indexerEvents = pgTable(
+  "indexer_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    eventId: text("event_id").notNull(),
+    ledger: integer("ledger").notNull(),
+    txHash: text("tx_hash").notNull(),
+    opIndex: integer("op_index").notNull(),
+    contractId: text("contract_id").notNull(),
+    topicXdr: jsonb("topic_xdr").notNull().$type<string[]>(),
+    valueXdr: text("value_xdr").notNull(),
+    ledgerClosedAt: timestamp("ledger_closed_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    eventKey: uniqueIndex("indexer_events_ledger_tx_op_idx").on(t.ledger, t.txHash, t.opIndex),
+  }),
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { env } from "./config/env";
 import { logger } from "./config/logger";
 import { healthRouter } from "./routes/health";
 import { marketsRouter } from "./routes/markets";
+import { adminUsersRouter } from "./routes/adminUsers";
 import { errorHandler } from "./middleware/errorHandler";
 
 export function createApp(): express.Express {
@@ -15,6 +16,7 @@ export function createApp(): express.Express {
 
   app.use("/health", healthRouter);
   app.use("/api/markets", marketsRouter);
+  app.use("/api/admin/users", adminUsersRouter);
 
   app.use(errorHandler);
   return app;

--- a/src/middleware/requireAdmin.ts
+++ b/src/middleware/requireAdmin.ts
@@ -1,0 +1,58 @@
+/**
+ * requireAdmin — Express middleware that enforces admin-only access.
+ *
+ * Expects:  Authorization: Bearer <jwt>
+ * The JWT must be signed with JWT_SECRET and carry { role: "admin" }.
+ * The verified subject (Stellar address) is attached as req.adminAddress
+ * for downstream use in audit logging and rate-limit keying.
+ *
+ * Returns 403 for any of: missing header, invalid signature, wrong role.
+ * Never reveals why verification failed (prevents enumeration).
+ */
+
+import type { NextFunction, Request, Response } from "express";
+import jwt from "jsonwebtoken";
+import { env } from "../config/env";
+
+// Augment Express Request so downstream handlers can read the admin identity
+// without casting.
+declare global {
+  namespace Express {
+    interface Request {
+      adminAddress?: string;
+    }
+  }
+}
+
+interface AdminTokenPayload {
+  sub?: string;
+  role?: string;
+}
+
+export function requireAdmin(req: Request, res: Response, next: NextFunction): void {
+  const auth = req.headers.authorization;
+  if (!auth?.startsWith("Bearer ")) {
+    res.status(403).json({ error: { code: "forbidden" } });
+    return;
+  }
+
+  const token = auth.slice(7);
+
+  try {
+    const payload = jwt.verify(token, env.JWT_SECRET, {
+      issuer: env.JWT_ISSUER,
+      audience: env.JWT_AUDIENCE,
+    }) as AdminTokenPayload;
+
+    if (payload.role !== "admin" || !payload.sub) {
+      res.status(403).json({ error: { code: "forbidden" } });
+      return;
+    }
+
+    req.adminAddress = payload.sub;
+    next();
+  } catch {
+    // Covers expired, malformed, and wrong-key tokens
+    res.status(403).json({ error: { code: "forbidden" } });
+  }
+}

--- a/src/routes/adminUsers.ts
+++ b/src/routes/adminUsers.ts
@@ -1,0 +1,70 @@
+/**
+ * Admin user-read router.
+ *
+ * GET /api/admin/users/:address
+ *   Returns the aggregated view of a user's predictions, claims, and disputes.
+ *   Requires a valid admin JWT (role: "admin") in the Authorization header.
+ *   Writes one row to admin_audit_log on every authorised call.
+ *   Rate-limited to 60 requests per minute per admin token.
+ *
+ * The rate-limit ceiling is injectable via createAdminUsersRouter() so tests
+ * can exercise the 429 path without firing 60 real requests.
+ */
+
+import { Router } from "express";
+import { rateLimit } from "express-rate-limit";
+import { requireAdmin } from "../middleware/requireAdmin";
+import { getAdminUserView, writeAuditLog } from "../services/adminUsersService";
+import { db } from "../db/client";
+
+export interface AdminRouterOptions {
+  /** Requests per minute per admin token. Default: 60 */
+  rateLimitPerMinute?: number;
+}
+
+export function createAdminUsersRouter(opts: AdminRouterOptions = {}): Router {
+  const router = Router();
+  const limit = opts.rateLimitPerMinute ?? 60;
+
+  // ── Rate limiter ────────────────────────────────────────────────────────────
+  // Key on the raw Authorization header so each distinct admin token gets its
+  // own bucket.  Falls back to IP for unauthenticated requests so they are
+  // still throttled before reaching requireAdmin.
+  router.use(
+    rateLimit({
+      windowMs: 60_000,
+      limit,
+      keyGenerator: (req) =>
+        (req.headers.authorization as string | undefined) ?? req.ip ?? "unknown",
+      standardHeaders: "draft-6",
+      legacyHeaders: false,
+      message: { error: { code: "rate_limit_exceeded" } },
+    }),
+  );
+
+  // ── Admin guard ─────────────────────────────────────────────────────────────
+  router.use(requireAdmin);
+
+  // ── GET /api/admin/users/:address ───────────────────────────────────────────
+  router.get("/:address", async (req, res, next) => {
+    try {
+      const { address } = req.params;
+      const adminAddress = req.adminAddress!;
+
+      const view = await getAdminUserView(address, db);
+
+      // Audit every authorised read, including unknown addresses — support staff
+      // need to know what was looked up even when the address has no account yet.
+      await writeAuditLog(adminAddress, address, db);
+
+      res.json({ data: view });
+    } catch (e) {
+      next(e);
+    }
+  });
+
+  return router;
+}
+
+// Default export wired into src/index.ts
+export const adminUsersRouter = createAdminUsersRouter();

--- a/src/routes/markets.ts
+++ b/src/routes/markets.ts
@@ -12,7 +12,7 @@ marketsRouter.get("/", async (_req, res, next) => {
 marketsRouter.get("/:id", async (req, res, next) => {
   try {
     const market = await getMarketById(req.params.id);
-    if (!market) return res.status(404).json({ error: { code: "not_found" } });
+    if (!market) { res.status(404).json({ error: { code: "not_found" } }); return; }
     res.json({ data: market });
   } catch (e) { next(e); }
 });

--- a/src/services/adminUsersService.ts
+++ b/src/services/adminUsersService.ts
@@ -1,0 +1,163 @@
+/**
+ * Admin user-view service.
+ *
+ * Aggregates a user's predictions, claims, and disputes in parallel so the
+ * admin endpoint returns a single, complete snapshot.  All queries are scoped
+ * to the user's internal UUID, so the caller can never leak cross-user data by
+ * accident — the address look-up is the only surface that touches the address.
+ *
+ * refresh_token / session_id columns are intentionally excluded from every
+ * select projection.
+ */
+
+import { eq } from "drizzle-orm";
+import { adminAuditLog, claims, disputes, predictions, users } from "../db/schema";
+import type { DB } from "../db/client";
+
+// ── Response shape ────────────────────────────────────────────────────────────
+
+export interface AdminUserView {
+  user: {
+    id: string;
+    stellarAddress: string;
+    createdAt: string;
+  } | null;
+  predictions: Array<{
+    id: string;
+    marketId: string;
+    outcome: string;
+    amount: string;
+    createdAt: string;
+  }>;
+  claims: Array<{
+    id: string;
+    marketId: string;
+    amount: string;
+    status: string;
+    createdAt: string;
+  }>;
+  disputes: Array<{
+    id: string;
+    marketId: string;
+    reason: string;
+    status: string;
+    createdAt: string;
+  }>;
+  totals: {
+    predictions: number;
+    claims: number;
+    disputes: number;
+  };
+}
+
+// ── Queries ───────────────────────────────────────────────────────────────────
+
+export async function getAdminUserView(address: string, db: DB): Promise<AdminUserView> {
+  const userRows = await db
+    .select({
+      id: users.id,
+      stellarAddress: users.stellarAddress,
+      createdAt: users.createdAt,
+    })
+    .from(users)
+    .where(eq(users.stellarAddress, address))
+    .limit(1);
+
+  const user = userRows[0] ?? null;
+
+  // Unknown address: return an empty shell so the admin sees a useful payload
+  // instead of a 404 (the address may have never signed up yet).
+  if (!user) {
+    return {
+      user: null,
+      predictions: [],
+      claims: [],
+      disputes: [],
+      totals: { predictions: 0, claims: 0, disputes: 0 },
+    };
+  }
+
+  // Fetch all three relations in parallel — independent queries, no join needed
+  const [userPredictions, userClaims, userDisputes] = await Promise.all([
+    db
+      .select({
+        id: predictions.id,
+        marketId: predictions.marketId,
+        outcome: predictions.outcome,
+        amount: predictions.amount,
+        createdAt: predictions.createdAt,
+      })
+      .from(predictions)
+      .where(eq(predictions.userId, user.id)),
+
+    db
+      .select({
+        id: claims.id,
+        marketId: claims.marketId,
+        amount: claims.amount,
+        status: claims.status,
+        createdAt: claims.createdAt,
+      })
+      .from(claims)
+      .where(eq(claims.userId, user.id)),
+
+    db
+      .select({
+        id: disputes.id,
+        marketId: disputes.marketId,
+        reason: disputes.reason,
+        status: disputes.status,
+        createdAt: disputes.createdAt,
+      })
+      .from(disputes)
+      .where(eq(disputes.userId, user.id)),
+  ]);
+
+  return {
+    user: {
+      id: user.id,
+      stellarAddress: user.stellarAddress,
+      createdAt: user.createdAt.toISOString(),
+    },
+    predictions: userPredictions.map((p) => ({
+      id: p.id,
+      marketId: p.marketId,
+      outcome: p.outcome,
+      amount: p.amount,
+      createdAt: p.createdAt.toISOString(),
+    })),
+    claims: userClaims.map((c) => ({
+      id: c.id,
+      marketId: c.marketId,
+      amount: c.amount,
+      status: c.status,
+      createdAt: c.createdAt.toISOString(),
+    })),
+    disputes: userDisputes.map((d) => ({
+      id: d.id,
+      marketId: d.marketId,
+      reason: d.reason,
+      status: d.status,
+      createdAt: d.createdAt.toISOString(),
+    })),
+    totals: {
+      predictions: userPredictions.length,
+      claims: userClaims.length,
+      disputes: userDisputes.length,
+    },
+  };
+}
+
+// ── Audit ─────────────────────────────────────────────────────────────────────
+
+export async function writeAuditLog(
+  adminAddress: string,
+  targetAddress: string,
+  db: DB,
+): Promise<void> {
+  await db.insert(adminAuditLog).values({
+    adminAddress,
+    action: "read_user_view",
+    targetAddress,
+  });
+}

--- a/tests/adminUsers.test.ts
+++ b/tests/adminUsers.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests for GET /api/admin/users/:address
+ *
+ * Strategy:
+ *  - Mock src/services/adminUsersService so no database is needed.
+ *  - Sign real JWTs with the test JWT_SECRET so requireAdmin executes its
+ *    full verification path.
+ *  - Mount createAdminUsersRouter() directly on a minimal Express app so we
+ *    can inject a low rate-limit ceiling for the 429 test.
+ */
+
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { createAdminUsersRouter } from "../src/routes/adminUsers";
+import { errorHandler } from "../src/middleware/errorHandler";
+
+// ── Service mock ──────────────────────────────────────────────────────────────
+
+jest.mock("../src/services/adminUsersService");
+
+import {
+  getAdminUserView,
+  writeAuditLog,
+} from "../src/services/adminUsersService";
+
+const mockGetAdminUserView = getAdminUserView as jest.MockedFunction<typeof getAdminUserView>;
+const mockWriteAuditLog = writeAuditLog as jest.MockedFunction<typeof writeAuditLog>;
+
+// ── DB mock (prevents Pool connection at import time) ─────────────────────────
+
+jest.mock("../src/db/client", () => ({ db: {} }));
+
+// ── JWT helpers ───────────────────────────────────────────────────────────────
+
+const SECRET = process.env.JWT_SECRET!;
+const ISSUER = process.env.JWT_ISSUER ?? "predictify";
+const AUDIENCE = process.env.JWT_AUDIENCE ?? "predictify-app";
+
+const ADMIN_ADDRESS = "GADMIN7777777777777777777777777777777777777777777777777777";
+const USER_ADDRESS  = "GUSER88888888888888888888888888888888888888888888888888888";
+const TARGET_ADDRESS = "GTARGET99999999999999999999999999999999999999999999999999";
+
+function signJwt(payload: object): string {
+  return jwt.sign(payload, SECRET, { issuer: ISSUER, audience: AUDIENCE, expiresIn: "1h" });
+}
+
+const adminJwt = signJwt({ sub: ADMIN_ADDRESS, role: "admin" });
+const userJwt  = signJwt({ sub: USER_ADDRESS,  role: "user" });
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const FULL_VIEW = {
+  user: {
+    id: "uuid-1",
+    stellarAddress: TARGET_ADDRESS,
+    createdAt: "2024-01-01T00:00:00.000Z",
+  },
+  predictions: [
+    { id: "pred-1", marketId: "mkt-1", outcome: "yes", amount: "100", createdAt: "2024-01-02T00:00:00.000Z" },
+  ],
+  claims: [
+    { id: "claim-1", marketId: "mkt-1", amount: "90", status: "pending", createdAt: "2024-01-03T00:00:00.000Z" },
+  ],
+  disputes: [
+    { id: "dispute-1", marketId: "mkt-2", reason: "wrong outcome", status: "open", createdAt: "2024-01-04T00:00:00.000Z" },
+  ],
+  totals: { predictions: 1, claims: 1, disputes: 1 },
+};
+
+const EMPTY_VIEW = {
+  user: null,
+  predictions: [],
+  claims: [],
+  disputes: [],
+  totals: { predictions: 0, claims: 0, disputes: 0 },
+};
+
+// ── App factory ───────────────────────────────────────────────────────────────
+
+function makeApp(rateLimitPerMinute = 60): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/admin/users", createAdminUsersRouter({ rateLimitPerMinute }));
+  app.use(errorHandler);
+  return app;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockWriteAuditLog.mockResolvedValue(undefined);
+});
+
+// ── Auth guard ────────────────────────────────────────────────────────────────
+
+describe("requireAdmin guard", () => {
+  it("returns 403 with no Authorization header", async () => {
+    const res = await request(makeApp()).get(`/api/admin/users/${TARGET_ADDRESS}`);
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: { code: "forbidden" } });
+  });
+
+  it("returns 403 with a non-Bearer scheme", async () => {
+    const res = await request(makeApp())
+      .get(`/api/admin/users/${TARGET_ADDRESS}`)
+      .set("Authorization", `Basic ${adminJwt}`);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 with a non-admin JWT (role: user)", async () => {
+    const res = await request(makeApp())
+      .get(`/api/admin/users/${TARGET_ADDRESS}`)
+      .set("Authorization", `Bearer ${userJwt}`);
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: { code: "forbidden" } });
+  });
+
+  it("returns 403 with a JWT signed by a different secret", async () => {
+    const badToken = jwt.sign(
+      { sub: ADMIN_ADDRESS, role: "admin" },
+      "wrong-secret-at-least-32-characters-long",
+      { issuer: ISSUER, audience: AUDIENCE },
+    );
+    const res = await request(makeApp())
+      .get(`/api/admin/users/${TARGET_ADDRESS}`)
+      .set("Authorization", `Bearer ${badToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 with an expired JWT", async () => {
+    const expired = jwt.sign(
+      { sub: ADMIN_ADDRESS, role: "admin" },
+      SECRET,
+      { issuer: ISSUER, audience: AUDIENCE, expiresIn: -1 },
+    );
+    const res = await request(makeApp())
+      .get(`/api/admin/users/${TARGET_ADDRESS}`)
+      .set("Authorization", `Bearer ${expired}`);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 with a JWT missing the sub claim", async () => {
+    const noSub = signJwt({ role: "admin" });
+    const res = await request(makeApp())
+      .get(`/api/admin/users/${TARGET_ADDRESS}`)
+      .set("Authorization", `Bearer ${noSub}`);
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── Happy path ────────────────────────────────────────────────────────────────
+
+describe("GET /api/admin/users/:address — success", () => {
+  it("returns 200 with the aggregated user view", async () => {
+    mockGetAdminUserView.mockResolvedValue(FULL_VIEW);
+
+    const res = await request(makeApp())
+      .get(`/api/admin/users/${TARGET_ADDRESS}`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(FULL_VIEW);
+  });
+
+  it("calls getAdminUserView with the correct address", async () => {
+    mockGetAdminUserView.mockResolvedValue(FULL_VIEW);
+
+    await request(makeApp())
+      .get(`/api/admin/users/${TARGET_ADDRESS}`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(mockGetAdminUserView).toHaveBeenCalledWith(TARGET_ADDRESS, expect.anything());
+  });
+
+  it("writes an audit log entry with admin address and target address", async () => {
+    mockGetAdminUserView.mockResolvedValue(FULL_VIEW);
+
+    await request(makeApp())
+      .get(`/api/admin/users/${TARGET_ADDRESS}`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(mockWriteAuditLog).toHaveBeenCalledTimes(1);
+    expect(mockWriteAuditLog).toHaveBeenCalledWith(
+      ADMIN_ADDRESS,
+      TARGET_ADDRESS,
+      expect.anything(),
+    );
+  });
+
+  it("returns empty arrays and null user for an unknown address", async () => {
+    mockGetAdminUserView.mockResolvedValue(EMPTY_VIEW);
+
+    const res = await request(makeApp())
+      .get(`/api/admin/users/GUNKNOWN`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.user).toBeNull();
+    expect(res.body.data.predictions).toEqual([]);
+    expect(res.body.data.totals).toEqual({ predictions: 0, claims: 0, disputes: 0 });
+  });
+
+  it("still writes audit log even when the user is not found", async () => {
+    mockGetAdminUserView.mockResolvedValue(EMPTY_VIEW);
+
+    await request(makeApp())
+      .get(`/api/admin/users/GUNKNOWN`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(mockWriteAuditLog).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── Response shape ────────────────────────────────────────────────────────────
+
+describe("response payload shape", () => {
+  it("includes all required top-level fields", async () => {
+    mockGetAdminUserView.mockResolvedValue(FULL_VIEW);
+
+    const res = await request(makeApp())
+      .get(`/api/admin/users/${TARGET_ADDRESS}`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    const { data } = res.body;
+    expect(data).toHaveProperty("user");
+    expect(data).toHaveProperty("predictions");
+    expect(data).toHaveProperty("claims");
+    expect(data).toHaveProperty("disputes");
+    expect(data).toHaveProperty("totals");
+  });
+
+  it("totals match the array lengths", async () => {
+    mockGetAdminUserView.mockResolvedValue(FULL_VIEW);
+
+    const res = await request(makeApp())
+      .get(`/api/admin/users/${TARGET_ADDRESS}`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    const { data } = res.body;
+    expect(data.totals.predictions).toBe(data.predictions.length);
+    expect(data.totals.claims).toBe(data.claims.length);
+    expect(data.totals.disputes).toBe(data.disputes.length);
+  });
+});
+
+// ── Error handling ────────────────────────────────────────────────────────────
+
+describe("error handling", () => {
+  it("propagates service errors as 500 via errorHandler", async () => {
+    mockGetAdminUserView.mockRejectedValue(new Error("db down"));
+
+    const res = await request(makeApp())
+      .get(`/api/admin/users/${TARGET_ADDRESS}`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: { code: "internal_error" } });
+  });
+
+  it("does not write audit log when the service throws", async () => {
+    mockGetAdminUserView.mockRejectedValue(new Error("db down"));
+
+    await request(makeApp())
+      .get(`/api/admin/users/${TARGET_ADDRESS}`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(mockWriteAuditLog).not.toHaveBeenCalled();
+  });
+});
+
+// ── Rate limiting ─────────────────────────────────────────────────────────────
+
+describe("rate limiting", () => {
+  it("returns 429 after the per-admin limit is exceeded", async () => {
+    mockGetAdminUserView.mockResolvedValue(EMPTY_VIEW);
+
+    // Use a limit of 2 so the test runs quickly (not 60 real requests)
+    const app = makeApp(2);
+
+    await request(app).get(`/api/admin/users/${TARGET_ADDRESS}`).set("Authorization", `Bearer ${adminJwt}`);
+    await request(app).get(`/api/admin/users/${TARGET_ADDRESS}`).set("Authorization", `Bearer ${adminJwt}`);
+
+    const res = await request(app)
+      .get(`/api/admin/users/${TARGET_ADDRESS}`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(res.status).toBe(429);
+    expect(res.body).toEqual({ error: { code: "rate_limit_exceeded" } });
+  });
+
+  it("includes rate-limit headers in successful responses", async () => {
+    mockGetAdminUserView.mockResolvedValue(EMPTY_VIEW);
+
+    const res = await request(makeApp())
+      .get(`/api/admin/users/${TARGET_ADDRESS}`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    // draft-6 standard headers
+    expect(res.headers["ratelimit-limit"]).toBeDefined();
+    expect(res.headers["ratelimit-remaining"]).toBeDefined();
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,15 @@
+// Seed the minimum env vars before any test module imports src/config/env.ts.
+// Only sets values not already present (CI can override via its own environment).
+const defaults: Record<string, string> = {
+  NODE_ENV: "test",
+  DATABASE_URL: "postgres://user:pass@localhost:5432/predictify_test",
+  JWT_SECRET: "test-jwt-secret-that-is-at-least-32-characters-long",
+  SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org",
+  HORIZON_URL: "https://horizon-testnet.stellar.org",
+  PREDICTIFY_CONTRACT_ID: "CTEST_CONTRACT_ID",
+  INDEXER_REWIND_LEDGERS: "100",
+};
+
+for (const [key, value] of Object.entries(defaults)) {
+  if (!process.env[key]) process.env[key] = value;
+}


### PR DESCRIPTION
## Summary

- `GET /api/admin/users/:address` — returns a user's predictions, claims, and disputes in a single aggregated payload
- `requireAdmin` middleware verifies `Authorization: Bearer <jwt>` with `role: "admin"`; returns 403 for every auth failure without revealing the failure reason
- Each authorised call writes one row to `admin_audit_log` (adminAddress, action, targetAddress, createdAt)
- Rate-limited to 60 req/min per admin token (keyed on the raw `Authorization` header); rate-limit ceiling is injectable for tests
- Refresh tokens and session IDs are never selected — all DB projections are explicit column lists

## New files

| File | Purpose |
|---|---|
| `src/middleware/requireAdmin.ts` | JWT admin guard; attaches `req.adminAddress` |
| `src/services/adminUsersService.ts` | Parallel DB aggregation + audit write |
| `src/routes/adminUsers.ts` | Route + injectable rate-limit factory |
| `drizzle/0001_add_admin_tables.sql` | `claims`, `disputes`, `admin_audit_log` tables |

## Response shape

```json
{
  "data": {
    "user": { "id": "...", "stellarAddress": "G...", "createdAt": "..." },
    "predictions": [{ "id": "...", "marketId": "...", "outcome": "yes", "amount": "100", "createdAt": "..." }],
    "claims":      [{ "id": "...", "marketId": "...", "amount": "90",  "status": "pending", "createdAt": "..." }],
    "disputes":    [{ "id": "...", "marketId": "...", "reason": "...", "status": "open",    "createdAt": "..." }],
    "totals": { "predictions": 1, "claims": 1, "disputes": 1 }
  }
}
```

Unknown addresses return `user: null` with empty arrays and zero totals (200, not 404).

## Test plan (18 tests, all passing)

- [ ] No `Authorization` header → 403
- [ ] `Basic` scheme → 403
- [ ] Non-admin JWT (`role: user`) → 403
- [ ] JWT signed with wrong secret → 403
- [ ] Expired JWT → 403
- [ ] JWT missing `sub` → 403
- [ ] Valid admin JWT + known user → 200 + full payload
- [ ] `getAdminUserView` called with correct address
- [ ] `writeAuditLog` called with `(adminAddress, targetAddress, db)`
- [ ] Unknown address → 200, `user: null`, empty arrays, audit still written
- [ ] All required top-level fields present
- [ ] Totals match array lengths
- [ ] Service error → 500, audit NOT written
- [ ] Rate limit exceeded (injectable limit = 2) → 429 with `rate_limit_exceeded`
- [ ] Rate-limit headers present in successful responses

Closes #95