### PR TITLE
feat: PATCH /api/markets/:id for admin metadata edits with optimistic locking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,7 @@ PREDICTIFY_CONTRACT_ID=CABCDEF...
 # Indexer
 INDEXER_POLL_INTERVAL_MS=5000
 INDEXER_START_LEDGER=0
+
+# Admin Allowlist (comma separated stellar addresses)
+ADMIN_ALLOWLIST=
+

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -15,6 +15,7 @@ const schema = z.object({
   PREDICTIFY_CONTRACT_ID: z.string().min(1),
   INDEXER_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(5000),
   INDEXER_START_LEDGER: z.coerce.number().int().nonnegative().default(0),
+  ADMIN_ALLOWLIST: z.string().default("").transform((val) => val.split(",").map((s) => s.trim()).filter(Boolean)),
 });
 
 export const env = schema.parse(process.env);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,10 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { env } from "../config/env";
+import * as schema from "./schema";
+
+const pool = new Pool({
+  connectionString: env.DATABASE_URL,
+});
+
+export const db = drizzle(pool, { schema });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -14,6 +14,17 @@ export const markets = pgTable("markets", {
   metadata: jsonb("metadata"),
   indexedLedger: integer("indexed_ledger").notNull(),
   archived: boolean("archived").notNull().default(false),
+  version: integer("version").notNull().default(1),
+});
+
+export const marketAuditLog = pgTable("market_audit_log", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  marketId: text("market_id").notNull().references(() => markets.id),
+  adminAddress: text("admin_address").notNull(),
+  action: text("action").notNull(),
+  beforeState: jsonb("before_state").notNull(),
+  afterState: jsonb("after_state").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
 export const predictions = pgTable("predictions", {

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,0 +1,42 @@
+import type { Request, Response, NextFunction } from "express";
+import jwt from "jsonwebtoken";
+import { env } from "../config/env";
+
+export interface AuthenticatedRequest extends Request {
+  user?: {
+    stellarAddress: string;
+  };
+}
+
+export function requireAdmin(req: AuthenticatedRequest, res: Response, next: NextFunction): void {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      res.status(401).json({ error: { code: "unauthorized" } });
+      return;
+    }
+
+    const token = authHeader.split(" ")[1];
+    const payload = jwt.verify(token, env.JWT_SECRET, {
+      audience: env.JWT_AUDIENCE,
+      issuer: env.JWT_ISSUER,
+    }) as { sub: string };
+
+    const stellarAddress = payload.sub;
+    if (!stellarAddress) {
+      res.status(401).json({ error: { code: "unauthorized" } });
+      return;
+    }
+
+    if (!env.ADMIN_ALLOWLIST.includes(stellarAddress)) {
+      res.status(403).json({ error: { code: "forbidden" } });
+      return;
+    }
+
+    req.user = { stellarAddress };
+    next();
+  } catch (err) {
+    res.status(401).json({ error: { code: "unauthorized" } });
+  }
+}
+

--- a/src/routes/markets.ts
+++ b/src/routes/markets.ts
@@ -1,7 +1,15 @@
 import { Router } from "express";
-import { listMarkets, getMarketById } from "../services/marketService";
+import { listMarkets, getMarketById, updateMarket, VersionConflictError } from "../services/marketService";
+import { requireAdmin, AuthenticatedRequest } from "../middleware/auth";
+import { z } from "zod";
 
 export const marketsRouter = Router();
+
+const patchMarketSchema = z.object({
+  question: z.string().optional(),
+  metadata: z.any().optional(),
+  expectedVersion: z.number().int().nonnegative(),
+}).strict();
 
 marketsRouter.get("/", async (_req, res, next) => {
   try {
@@ -11,8 +19,48 @@ marketsRouter.get("/", async (_req, res, next) => {
 
 marketsRouter.get("/:id", async (req, res, next) => {
   try {
-    const market = await getMarketById(req.params.id);
-    if (!market) return res.status(404).json({ error: { code: "not_found" } });
+    const market = await getMarketById(req.params.id as string);
+    if (!market) {
+      res.status(404).json({ error: { code: "not_found" } });
+      return;
+    }
     res.json({ data: market });
   } catch (e) { next(e); }
 });
+
+marketsRouter.patch("/:id", requireAdmin, async (req: AuthenticatedRequest, res, next) => {
+  try {
+    const parsed = patchMarketSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({
+        error: {
+          code: "validation_error",
+          details: parsed.error.issues,
+        },
+      });
+      return;
+    }
+
+    const { question, metadata, expectedVersion } = parsed.data;
+    const adminAddress = req.user!.stellarAddress;
+
+    const patch: { question?: string; metadata?: any } = {};
+    if (question !== undefined) patch.question = question;
+    if (metadata !== undefined) patch.metadata = metadata;
+
+    const updated = await updateMarket(req.params.id as string, patch, expectedVersion, adminAddress);
+    res.json({ data: updated });
+  } catch (e) {
+    if (e instanceof VersionConflictError) {
+      res.status(409).json({ error: { code: "version_conflict" } });
+      return;
+    }
+    if ((e as any).status === 404) {
+      res.status(404).json({ error: { code: "not_found" } });
+      return;
+    }
+    next(e);
+  }
+});
+
+

--- a/src/services/marketService.ts
+++ b/src/services/marketService.ts
@@ -1,14 +1,82 @@
+import { db } from "../db";
+import { markets, marketAuditLog } from "../db/schema";
+import { eq } from "drizzle-orm";
+
 export interface Market {
   id: string;
   question: string;
-  status: "active" | "resolved" | "disputed";
-  resolutionTime: string;
+  status: string;
+  resolutionTime: Date;
+  metadata: any;
+  indexedLedger: number;
+  archived: boolean;
+  version: number;
 }
 
-export async function listMarkets(): Promise<Market[]> {
-  return [];
+export class VersionConflictError extends Error {
+  status = 409;
+  code = "version_conflict";
+  constructor() {
+    super("Version conflict");
+    Object.setPrototypeOf(this, VersionConflictError.prototype);
+  }
 }
 
-export async function getMarketById(_id: string): Promise<Market | null> {
-  return null;
+export async function listMarkets(): Promise<any[]> {
+  return await db.select().from(markets);
 }
+
+export async function getMarketById(id: string): Promise<any | null> {
+  const result = await db.select().from(markets).where(eq(markets.id, id)).limit(1);
+  return result[0] || null;
+}
+
+export async function updateMarket(
+  id: string,
+  patch: { question?: string; metadata?: any },
+  expectedVersion: number,
+  adminAddress: string
+): Promise<any> {
+  return await db.transaction(async (tx) => {
+    const existing = await tx.select().from(markets).where(eq(markets.id, id)).limit(1);
+    if (existing.length === 0) {
+      const err = new Error("Market not found");
+      (err as any).status = 404;
+      throw err;
+    }
+
+    const currentMarket = existing[0];
+    if (currentMarket.version !== expectedVersion) {
+      throw new VersionConflictError();
+    }
+
+    const newVersion = expectedVersion + 1;
+    const updated = await tx
+      .update(markets)
+      .set({
+        ...patch,
+        version: newVersion,
+      })
+      .where(eq(markets.id, id))
+      .returning();
+
+    await tx.insert(marketAuditLog).values({
+      marketId: id,
+      adminAddress,
+      action: "update",
+      beforeState: {
+        question: currentMarket.question,
+        metadata: currentMarket.metadata,
+        version: currentMarket.version,
+      },
+      afterState: {
+        question: updated[0].question,
+        metadata: updated[0].metadata,
+        version: updated[0].version,
+      },
+    });
+
+    return updated[0];
+  });
+}
+

--- a/tests/markets-patch.test.ts
+++ b/tests/markets-patch.test.ts
@@ -1,0 +1,189 @@
+// Set up environment variables before importing anything that parses them
+process.env.JWT_SECRET = "super-secret-key-that-is-at-least-32-bytes-long";
+process.env.DATABASE_URL = "postgres://postgres:postgres@localhost:5432/predictify";
+process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "CABCDEF";
+process.env.ADMIN_ALLOWLIST = "G-ADMIN-ADDRESS-1,G-ADMIN-ADDRESS-2";
+
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { createApp } from "../src/index";
+import { env } from "../src/config/env";
+
+// Mock the DB connection entirely
+const mockSelect = jest.fn();
+const mockUpdate = jest.fn();
+const mockInsert = jest.fn();
+
+const mockTx = {
+  select: jest.fn(() => ({
+    from: jest.fn(() => ({
+      where: jest.fn(() => ({
+        limit: jest.fn(() => mockSelect()),
+      })),
+    })),
+  })),
+  update: jest.fn(() => ({
+    set: jest.fn(() => ({
+      where: jest.fn(() => ({
+        returning: jest.fn(() => mockUpdate()),
+      })),
+    })),
+  })),
+  insert: jest.fn(() => ({
+    values: jest.fn(() => mockInsert()),
+  })),
+};
+
+jest.mock("../src/db", () => {
+  return {
+    db: {
+      transaction: jest.fn((cb) => cb(mockTx)),
+      select: jest.fn(() => ({
+        from: jest.fn(() => ({
+          where: jest.fn(() => ({
+            limit: jest.fn(() => mockSelect()),
+          })),
+        })),
+      })),
+    },
+  };
+});
+
+describe("PATCH /api/markets/:id", () => {
+  let adminToken: string;
+  let nonAdminToken: string;
+
+  beforeAll(() => {
+    adminToken = jwt.sign({ sub: "G-ADMIN-ADDRESS-1" }, env.JWT_SECRET, {
+      audience: env.JWT_AUDIENCE,
+      issuer: env.JWT_ISSUER,
+    });
+
+    nonAdminToken = jwt.sign({ sub: "G-USER-ADDRESS" }, env.JWT_SECRET, {
+      audience: env.JWT_AUDIENCE,
+      issuer: env.JWT_ISSUER,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 when no token is provided", async () => {
+    const res = await request(createApp())
+      .patch("/api/markets/market1")
+      .send({
+        question: "Updated question?",
+        expectedVersion: 1,
+      });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("unauthorized");
+  });
+
+  it("returns 403 when a non-admin token is provided", async () => {
+    const res = await request(createApp())
+      .patch("/api/markets/market1")
+      .set("Authorization", `Bearer ${nonAdminToken}`)
+      .send({
+        question: "Updated question?",
+        expectedVersion: 1,
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("forbidden");
+  });
+
+  it("returns 400 when invalid body is provided (strict schema)", async () => {
+    const res = await request(createApp())
+      .patch("/api/markets/market1")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({
+        question: "Updated question?",
+        status: "resolved", // Read-only / invalid field for PATCH
+        expectedVersion: 1,
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("returns 404 when market is not found", async () => {
+    mockSelect.mockResolvedValueOnce([]); // No market found
+
+    const res = await request(createApp())
+      .patch("/api/markets/nonexistent")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({
+        question: "New question?",
+        expectedVersion: 1,
+      });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("not_found");
+  });
+
+  it("returns 409 when there is a version conflict", async () => {
+    // Current version is 2, expectedVersion is 1
+    mockSelect.mockResolvedValueOnce([
+      {
+        id: "market1",
+        question: "Old question",
+        metadata: {},
+        version: 2,
+      },
+    ]);
+
+    const res = await request(createApp())
+      .patch("/api/markets/market1")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({
+        question: "Updated question?",
+        expectedVersion: 1,
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("version_conflict");
+  });
+
+  it("successfully updates market question, increments version, and logs audit entry", async () => {
+    mockSelect.mockResolvedValueOnce([
+      {
+        id: "market1",
+        question: "Old question",
+        metadata: { category: "crypto" },
+        version: 1,
+      },
+    ]);
+
+    mockUpdate.mockResolvedValueOnce([
+      {
+        id: "market1",
+        question: "New question?",
+        metadata: { category: "crypto" },
+        version: 2,
+      },
+    ]);
+
+    mockInsert.mockResolvedValueOnce([]);
+
+    const res = await request(createApp())
+      .patch("/api/markets/market1")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({
+        question: "New question?",
+        expectedVersion: 1,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.version).toBe(2);
+    expect(res.body.data.question).toBe("New question?");
+
+    // Verify transaction calls
+    expect(mockTx.select).toHaveBeenCalled();
+    expect(mockTx.update).toHaveBeenCalled();
+    expect(mockTx.insert).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #67

Implements a secure `PATCH /api/markets/:id` endpoint that allows admins to edit market metadata (question and metadata fields) with optimistic locking to prevent lost-update conflicts between concurrent admin edits.

---

## Tasks Completed

- [x] Added `version` column (`integer`, default `1`) to the `markets` table in the Drizzle schema
- [x] Created `market_audit_log` table to track all admin edits with before/after JSON snapshots
- [x] Initialized Drizzle database client connection (`src/db/index.ts`)
- [x] Added `ADMIN_ALLOWLIST` environment variable (comma-separated Stellar addresses) to env config and `.env.example`
- [x] Implemented `requireAdmin` JWT authentication middleware with allowlist verification
- [x] Implemented `updateMarket` service with transactional optimistic locking and audit logging
- [x] Added `PATCH /:id` route handler with Zod validation (`.strict()` schema rejects unknown fields)
- [x] Comprehensive test suite covering all edge cases (6 tests, all passing)

---

## Fixes & Implementation Details

### Security
- **JWT-based admin guard**: Verifies `Authorization: Bearer <token>` header, validates JWT signature/audience/issuer, and checks the `sub` (Stellar address) against `ADMIN_ALLOWLIST`
- **Strict schema validation**: Uses Zod `.strict()` to reject any fields beyond `question`, `metadata`, and `expectedVersion` — blocks attempts to modify `status`, `resolutionTime`, `indexedLedger`, etc.

### Optimistic Locking
- **Version column**: Each market row has an integer `version` starting at `1`
- **Conflict detection**: `expectedVersion` in the request body is compared against the current DB version inside a transaction; mismatches return `409 Conflict` with `error.code = "version_conflict"`
- **Atomic increment**: On success, `version` is incremented by 1 atomically within the same transaction

### Audit Trail
- **`market_audit_log` table**: Records `marketId`, `adminAddress`, `action`, `beforeState` (JSON), `afterState` (JSON), and `createdAt` for every edit
- Written inside the same transaction as the update for consistency

### Test Coverage (6/6 passing)
- `401 Unauthorized` — no token provided
- `403 Forbidden` — non-admin JWT token
- `400 Bad Request` — invalid/extra fields in body (strict schema)
- `404 Not Found` — market does not exist
- `409 Conflict` — stale `expectedVersion`
- `200 OK` — happy path: question updated, version incremented, audit log written

---

## Files Changed

| File | Change |
|------|--------|
| `src/db/schema.ts` | Added `version` column to `markets`, new `marketAuditLog` table |
| `src/db/index.ts` | **New** — Drizzle DB client initialization |
| `src/config/env.ts` | Added `ADMIN_ALLOWLIST` env validation |
| `src/middleware/auth.ts` | **New** — `requireAdmin` JWT + allowlist middleware |
| `src/services/marketService.ts` | Added `updateMarket()` with optimistic locking + audit |
| `src/routes/markets.ts` | Added `PATCH /:id` handler with Zod validation |
| `tests/markets-patch.test.ts` | **New** — 6 integration tests |
| `.env.example` | Documented `ADMIN_ALLOWLIST` |
