### PR TITLE
docs: add webhook events catalog

### DIFF
--- a/docs/WEBHOOK_EVENTS.md
+++ b/docs/WEBHOOK_EVENTS.md
@@ -1,0 +1,79 @@
+# Webhook event catalog
+
+Predictify sends signed HTTP `POST` requests to active webhook subscriptions
+whose `events` list contains the emitted event type or the wildcard `*`.
+
+Every delivery uses:
+
+| Header | Description |
+| --- | --- |
+| `Content-Type: application/json` | Payload is JSON. |
+| `X-Predictify-Signature` | `sha256=<hex>` HMAC-SHA256 signature over the raw request body. |
+| `X-Predictify-Event` | Event type, for example `market.resolved`. |
+| `X-Predictify-Delivery` | Unique delivery identifier for idempotency and retry tracking. |
+
+## `market.resolved`
+
+Emitted after an on-chain market resolution is applied to the off-chain market
+row and predictions are marked won or lost.
+
+Producer: `src/services/marketResolutionService.ts`
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `event` | string | yes | Always `market.resolved`. |
+| `marketId` | string | yes | Predictify market identifier that was resolved. |
+| `winningOutcome` | string | yes | Outcome value selected by the resolver and used to settle predictions. |
+| `ledger` | integer | yes | Stellar ledger sequence where the resolution event was observed. |
+| `timestamp` | integer | yes | Unix timestamp, in seconds, for the observed resolution event. |
+
+Example:
+
+```json
+{
+  "event": "market.resolved",
+  "marketId": "market_01J4YC8Z7R8P9N0ABCDEF12345",
+  "winningOutcome": "YES",
+  "ledger": 521034,
+  "timestamp": 1767225600
+}
+```
+
+## `dispute.opened`
+
+Emitted when an eligible user opens a dispute against a market outcome and the
+market enters disputed status.
+
+Producer: `src/services/disputeService.ts`
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `type` | string | yes | Always `dispute.opened`. |
+| `marketId` | string | yes | Market identifier associated with the dispute. |
+| `disputeId` | string | yes | Identifier of the created dispute record. |
+| `openedBy` | string | yes | User identifier that opened the dispute. |
+| `reason` | string | yes | User-provided dispute reason. |
+| `evidenceUri` | nullable string | no | Optional URI containing evidence supplied by the disputing user. |
+| `timestamp` | ISO-8601 string | yes | Timestamp for when the dispute was created. |
+
+Example:
+
+```json
+{
+  "type": "dispute.opened",
+  "marketId": "market_01J4YC8Z7R8P9N0ABCDEF12345",
+  "disputeId": "disc_01J4YF9TP2R0E3XYZ987654321",
+  "openedBy": "550e8400-e29b-41d4-a716-446655440000",
+  "reason": "Oracle data did not match the published resolution source.",
+  "evidenceUri": "https://example.com/evidence/market_01J4YC8",
+  "timestamp": "2026-06-28T00:00:00.000Z"
+}
+```
+
+## Subscription behavior
+
+- A subscription receives an event when its `events` JSON array includes the
+  exact event type.
+- A subscription with `events: ["*"]` receives every event type.
+- Failed deliveries follow the retry and dead-letter behavior documented in
+  `docs/webhooks-dlq.md`.

--- a/src/services/webhookCatalog.ts
+++ b/src/services/webhookCatalog.ts
@@ -1,0 +1,174 @@
+export type WebhookEventType = "market.resolved" | "dispute.opened";
+
+export type WebhookPayloadFieldType =
+  | "string"
+  | "number"
+  | "integer"
+  | "iso8601"
+  | "nullable-string";
+
+export interface WebhookPayloadField {
+  name: string;
+  type: WebhookPayloadFieldType;
+  required: boolean;
+  description: string;
+  example: string | number | null;
+}
+
+export interface WebhookEventDefinition {
+  type: WebhookEventType;
+  description: string;
+  producer: string;
+  delivery: {
+    method: "POST";
+    contentType: "application/json";
+    signatureHeader: "X-Predictify-Signature";
+    eventHeader: "X-Predictify-Event";
+    deliveryHeader: "X-Predictify-Delivery";
+  };
+  payloadFields: readonly WebhookPayloadField[];
+  examplePayload: Record<string, unknown>;
+}
+
+const WEBHOOK_DELIVERY_CONTRACT = {
+  method: "POST",
+  contentType: "application/json",
+  signatureHeader: "X-Predictify-Signature",
+  eventHeader: "X-Predictify-Event",
+  deliveryHeader: "X-Predictify-Delivery",
+} as const;
+
+export const WEBHOOK_EVENT_CATALOG: readonly WebhookEventDefinition[] = [
+  {
+    type: "market.resolved",
+    description:
+      "Emitted after an on-chain market resolution is applied to the off-chain market row and predictions are marked won or lost.",
+    producer: "src/services/marketResolutionService.ts",
+    delivery: WEBHOOK_DELIVERY_CONTRACT,
+    payloadFields: [
+      {
+        name: "event",
+        type: "string",
+        required: true,
+        description: "Webhook event type. Always market.resolved for this payload.",
+        example: "market.resolved",
+      },
+      {
+        name: "marketId",
+        type: "string",
+        required: true,
+        description: "Predictify market identifier that was resolved.",
+        example: "market_01J4YC8Z7R8P9N0ABCDEF12345",
+      },
+      {
+        name: "winningOutcome",
+        type: "string",
+        required: true,
+        description: "Outcome value selected by the resolver and used to settle predictions.",
+        example: "YES",
+      },
+      {
+        name: "ledger",
+        type: "integer",
+        required: true,
+        description: "Stellar ledger sequence where the resolution event was observed.",
+        example: 521034,
+      },
+      {
+        name: "timestamp",
+        type: "integer",
+        required: true,
+        description: "Unix timestamp, in seconds, for the observed resolution event.",
+        example: 1767225600,
+      },
+    ],
+    examplePayload: {
+      event: "market.resolved",
+      marketId: "market_01J4YC8Z7R8P9N0ABCDEF12345",
+      winningOutcome: "YES",
+      ledger: 521034,
+      timestamp: 1767225600,
+    },
+  },
+  {
+    type: "dispute.opened",
+    description:
+      "Emitted when an eligible user opens a dispute against a market outcome and the market enters disputed status.",
+    producer: "src/services/disputeService.ts",
+    delivery: WEBHOOK_DELIVERY_CONTRACT,
+    payloadFields: [
+      {
+        name: "type",
+        type: "string",
+        required: true,
+        description: "Webhook event type. Always dispute.opened for this payload.",
+        example: "dispute.opened",
+      },
+      {
+        name: "marketId",
+        type: "string",
+        required: true,
+        description: "Market identifier associated with the dispute.",
+        example: "market_01J4YC8Z7R8P9N0ABCDEF12345",
+      },
+      {
+        name: "disputeId",
+        type: "string",
+        required: true,
+        description: "Identifier of the created dispute record.",
+        example: "disc_01J4YF9TP2R0E3XYZ987654321",
+      },
+      {
+        name: "openedBy",
+        type: "string",
+        required: true,
+        description: "User identifier that opened the dispute.",
+        example: "550e8400-e29b-41d4-a716-446655440000",
+      },
+      {
+        name: "reason",
+        type: "string",
+        required: true,
+        description: "User-provided dispute reason.",
+        example: "Oracle data did not match the published resolution source.",
+      },
+      {
+        name: "evidenceUri",
+        type: "nullable-string",
+        required: false,
+        description: "Optional URI containing evidence supplied by the disputing user.",
+        example: "https://example.com/evidence/market_01J4YC8",
+      },
+      {
+        name: "timestamp",
+        type: "iso8601",
+        required: true,
+        description: "ISO-8601 timestamp for when the dispute was created.",
+        example: "2026-06-28T00:00:00.000Z",
+      },
+    ],
+    examplePayload: {
+      type: "dispute.opened",
+      marketId: "market_01J4YC8Z7R8P9N0ABCDEF12345",
+      disputeId: "disc_01J4YF9TP2R0E3XYZ987654321",
+      openedBy: "550e8400-e29b-41d4-a716-446655440000",
+      reason: "Oracle data did not match the published resolution source.",
+      evidenceUri: "https://example.com/evidence/market_01J4YC8",
+      timestamp: "2026-06-28T00:00:00.000Z",
+    },
+  },
+] as const;
+
+export function listWebhookEvents(): readonly WebhookEventDefinition[] {
+  return WEBHOOK_EVENT_CATALOG;
+}
+
+export function getWebhookEventDefinition(
+  eventType: string,
+): WebhookEventDefinition | undefined {
+  return WEBHOOK_EVENT_CATALOG.find((event) => event.type === eventType);
+}
+
+export function listWebhookEventTypes(): WebhookEventType[] {
+  return WEBHOOK_EVENT_CATALOG.map((event) => event.type);
+}

--- a/tests/webhookCatalog.test.ts
+++ b/tests/webhookCatalog.test.ts
@@ -1,0 +1,62 @@
+import {
+  getWebhookEventDefinition,
+  listWebhookEvents,
+  listWebhookEventTypes,
+  WEBHOOK_EVENT_CATALOG,
+} from "../src/services/webhookCatalog";
+
+describe("webhook event catalog", () => {
+  it("exposes unique event types", () => {
+    const types = listWebhookEventTypes();
+    expect(types.length).toBeGreaterThan(0);
+    expect(new Set(types).size).toBe(types.length);
+  });
+
+  it("contains the currently emitted webhook events", () => {
+    expect(listWebhookEventTypes()).toEqual(
+      expect.arrayContaining(["market.resolved", "dispute.opened"]),
+    );
+  });
+
+  it("returns the market.resolved payload schema", () => {
+    const definition = getWebhookEventDefinition("market.resolved");
+
+    expect(definition).toBeDefined();
+    expect(definition?.producer).toBe("src/services/marketResolutionService.ts");
+    expect(definition?.delivery.signatureHeader).toBe("X-Predictify-Signature");
+    expect(definition?.payloadFields.map((field) => field.name)).toEqual([
+      "event",
+      "marketId",
+      "winningOutcome",
+      "ledger",
+      "timestamp",
+    ]);
+    expect(definition?.examplePayload).toMatchObject({
+      event: "market.resolved",
+      winningOutcome: "YES",
+    });
+  });
+
+  it("returns the dispute.opened payload schema", () => {
+    const definition = getWebhookEventDefinition("dispute.opened");
+
+    expect(definition).toBeDefined();
+    expect(definition?.producer).toBe("src/services/disputeService.ts");
+    expect(definition?.payloadFields.find((field) => field.name === "evidenceUri")).toMatchObject({
+      required: false,
+      type: "nullable-string",
+    });
+    expect(definition?.examplePayload).toMatchObject({
+      type: "dispute.opened",
+    });
+  });
+
+  it("returns undefined for unknown event types", () => {
+    expect(getWebhookEventDefinition("unknown.event")).toBeUndefined();
+  });
+
+  it("keeps exported catalog immutable from callers", () => {
+    const events = listWebhookEvents();
+    expect(events).toBe(WEBHOOK_EVENT_CATALOG);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a structured webhook event catalog service for the currently emitted Predictify webhook events.
- Documents payload schemas, delivery headers, examples, and subscription behavior in `docs/WEBHOOK_EVENTS.md`.
- Adds focused Jest coverage for event uniqueness, lookup behavior, and payload schema metadata.

## Validation
- PASS: `npm test -- --runTestsByPath tests/webhookCatalog.test.ts`
- PASS: `npx eslint src/services/webhookCatalog.ts tests/webhookCatalog.test.ts`
- NOTE: `npm run build` currently fails on pre-existing repository-wide TypeScript errors unrelated to this change, including missing schema exports and missing env properties in existing files such as `src/db/client.ts`, `src/index.ts`, and `src/services/predictionService.ts`.

Closes #173