### PR TITLE
feat: add leaderboard period filtering

### DIFF
--- a/docs/leaderboard.md
+++ b/docs/leaderboard.md
@@ -1,0 +1,25 @@
+# Leaderboard API
+
+`GET /api/leaderboard` supports period-scoped rankings:
+
+- `period=daily` reads `leaderboard_daily_mv`
+- `period=weekly` reads `leaderboard_weekly_mv`
+- `period=monthly` reads `leaderboard_monthly_mv`
+
+If `period` is omitted, the API defaults to `daily`.
+
+Examples:
+
+```bash
+curl "http://localhost:3001/api/leaderboard?period=daily&limit=25"
+curl "http://localhost:3001/api/leaderboard?period=weekly&offset=25"
+curl "http://localhost:3001/api/leaderboard/user/GB...ADDRESS?period=monthly"
+```
+
+The `period` value is strictly validated. Unknown periods return a validation
+error instead of being interpolated into SQL.
+
+Responses include the active period in `meta.period`. Leaderboard list results
+are cached per `period`, `limit`, and `offset` for a short window. Requests with
+`refresh=true` refresh the selected materialized view and invalidate only that
+period's cached results.

--- a/drizzle/0002_leaderboard_period_views.sql
+++ b/drizzle/0002_leaderboard_period_views.sql
@@ -1,0 +1,98 @@
+-- Period-specific materialized views for /api/leaderboard?period=...
+-- Each view keeps users with zero qualifying predictions so ranks remain stable.
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS leaderboard_daily_mv AS
+SELECT
+  u.id as user_id,
+  u.stellar_address,
+  COUNT(p.id) as total_predictions,
+  SUM(CASE WHEN p.outcome = m.resolution_outcome THEN 1 ELSE 0 END) as correct_predictions,
+  ROUND(
+    CASE
+      WHEN COUNT(p.id) > 0 THEN
+        100.0 * SUM(CASE WHEN p.outcome = m.resolution_outcome THEN 1 ELSE 0 END) / COUNT(p.id)
+      ELSE 0
+    END,
+    2
+  ) as accuracy_percentage,
+  ROW_NUMBER() OVER (ORDER BY
+    CASE
+      WHEN COUNT(p.id) > 0 THEN
+        100.0 * SUM(CASE WHEN p.outcome = m.resolution_outcome THEN 1 ELSE 0 END) / COUNT(p.id)
+      ELSE 0
+    END DESC,
+    COUNT(p.id) DESC
+  ) as rank
+FROM users u
+LEFT JOIN predictions p
+  ON u.id = p.user_id
+  AND p.created_at >= now() - interval '1 day'
+LEFT JOIN markets m ON p.market_id = m.id AND m.status IN ('resolved', 'disputed')
+GROUP BY u.id, u.stellar_address;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS leaderboard_weekly_mv AS
+SELECT
+  u.id as user_id,
+  u.stellar_address,
+  COUNT(p.id) as total_predictions,
+  SUM(CASE WHEN p.outcome = m.resolution_outcome THEN 1 ELSE 0 END) as correct_predictions,
+  ROUND(
+    CASE
+      WHEN COUNT(p.id) > 0 THEN
+        100.0 * SUM(CASE WHEN p.outcome = m.resolution_outcome THEN 1 ELSE 0 END) / COUNT(p.id)
+      ELSE 0
+    END,
+    2
+  ) as accuracy_percentage,
+  ROW_NUMBER() OVER (ORDER BY
+    CASE
+      WHEN COUNT(p.id) > 0 THEN
+        100.0 * SUM(CASE WHEN p.outcome = m.resolution_outcome THEN 1 ELSE 0 END) / COUNT(p.id)
+      ELSE 0
+    END DESC,
+    COUNT(p.id) DESC
+  ) as rank
+FROM users u
+LEFT JOIN predictions p
+  ON u.id = p.user_id
+  AND p.created_at >= now() - interval '7 days'
+LEFT JOIN markets m ON p.market_id = m.id AND m.status IN ('resolved', 'disputed')
+GROUP BY u.id, u.stellar_address;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS leaderboard_monthly_mv AS
+SELECT
+  u.id as user_id,
+  u.stellar_address,
+  COUNT(p.id) as total_predictions,
+  SUM(CASE WHEN p.outcome = m.resolution_outcome THEN 1 ELSE 0 END) as correct_predictions,
+  ROUND(
+    CASE
+      WHEN COUNT(p.id) > 0 THEN
+        100.0 * SUM(CASE WHEN p.outcome = m.resolution_outcome THEN 1 ELSE 0 END) / COUNT(p.id)
+      ELSE 0
+    END,
+    2
+  ) as accuracy_percentage,
+  ROW_NUMBER() OVER (ORDER BY
+    CASE
+      WHEN COUNT(p.id) > 0 THEN
+        100.0 * SUM(CASE WHEN p.outcome = m.resolution_outcome THEN 1 ELSE 0 END) / COUNT(p.id)
+      ELSE 0
+    END DESC,
+    COUNT(p.id) DESC
+  ) as rank
+FROM users u
+LEFT JOIN predictions p
+  ON u.id = p.user_id
+  AND p.created_at >= now() - interval '30 days'
+LEFT JOIN markets m ON p.market_id = m.id AND m.status IN ('resolved', 'disputed')
+GROUP BY u.id, u.stellar_address;
+
+CREATE INDEX IF NOT EXISTS idx_leaderboard_daily_stellar_address ON leaderboard_daily_mv(stellar_address);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_leaderboard_daily_user_id ON leaderboard_daily_mv(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_leaderboard_weekly_stellar_address ON leaderboard_weekly_mv(stellar_address);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_leaderboard_weekly_user_id ON leaderboard_weekly_mv(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_leaderboard_monthly_stellar_address ON leaderboard_monthly_mv(stellar_address);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_leaderboard_monthly_user_id ON leaderboard_monthly_mv(user_id);

--- a/src/routes/leaderboard.ts
+++ b/src/routes/leaderboard.ts
@@ -1,10 +1,16 @@
 import { Router } from "express";
 import { z } from "zod";
-import { getLeaderboard, getLeaderboardWithRefresh, getUserLeaderboardEntry } from "../services/leaderboardService";
+import {
+  getLeaderboard,
+  getLeaderboardWithRefresh,
+  getUserLeaderboardEntry,
+  leaderboardPeriods,
+} from "../services/leaderboardService";
 
 export const leaderboardRouter = Router();
 
 const leaderboardQuerySchema = z.object({
+  period: z.enum(leaderboardPeriods).default("daily"),
   limit: z.coerce.number().int().positive().max(100).default(50),
   offset: z.coerce.number().int().nonnegative().default(0),
   refresh: z.coerce.boolean().default(false),
@@ -13,15 +19,16 @@ const leaderboardQuerySchema = z.object({
 // GET /api/leaderboard - Get leaderboard with optional refresh
 leaderboardRouter.get("/", async (req, res, next) => {
   try {
-    const { limit, offset, refresh } = leaderboardQuerySchema.parse(req.query);
+    const { period, limit, offset, refresh } = leaderboardQuerySchema.parse(req.query);
     
     const data = refresh 
-      ? await getLeaderboardWithRefresh(limit, offset)
-      : await getLeaderboard(limit, offset);
+      ? await getLeaderboardWithRefresh(period, limit, offset)
+      : await getLeaderboard(period, limit, offset);
     
     res.json({ 
       data,
       meta: {
+        period,
         limit,
         offset,
         count: data.length,
@@ -36,12 +43,13 @@ leaderboardRouter.get("/", async (req, res, next) => {
 // GET /api/leaderboard/user/:stellarAddress - Get specific user's leaderboard entry
 leaderboardRouter.get("/user/:stellarAddress", async (req, res, next) => {
   try {
-    const entry = await getUserLeaderboardEntry(req.params.stellarAddress);
+    const { period } = leaderboardQuerySchema.pick({ period: true }).parse(req.query);
+    const entry = await getUserLeaderboardEntry(req.params.stellarAddress, period);
     if (!entry) {
       return res.status(404).json({ error: { code: "not_found" } });
     }
-    res.json({ data: entry });
+    return res.json({ data: entry, meta: { period } });
   } catch (e) {
-    next(e);
+    return next(e);
   }
 });

--- a/src/services/leaderboardService.ts
+++ b/src/services/leaderboardService.ts
@@ -1,7 +1,20 @@
 import { db } from "../db";
 import { sql } from "drizzle-orm";
 
+export const leaderboardPeriods = ["daily", "weekly", "monthly"] as const;
+export type LeaderboardPeriod = (typeof leaderboardPeriods)[number];
+
+const leaderboardViews: Record<LeaderboardPeriod, string> = {
+  daily: "leaderboard_daily_mv",
+  weekly: "leaderboard_weekly_mv",
+  monthly: "leaderboard_monthly_mv",
+};
+
+const CACHE_TTL_MS = 30_000;
+const cache = new Map<string, { expiresAt: number; rows: LeaderboardEntry[] }>();
+
 export interface LeaderboardEntry {
+  [key: string]: unknown;
   user_id: string;
   stellar_address: string;
   total_predictions: number;
@@ -10,48 +23,80 @@ export interface LeaderboardEntry {
   rank: number;
 }
 
+function viewForPeriod(period: LeaderboardPeriod) {
+  return sql.identifier(leaderboardViews[period]);
+}
+
+function cacheKey(period: LeaderboardPeriod, limit: number, offset: number): string {
+  return `${period}:${limit}:${offset}`;
+}
+
+function clearPeriodCache(period: LeaderboardPeriod): void {
+  for (const key of cache.keys()) {
+    if (key.startsWith(`${period}:`)) {
+      cache.delete(key);
+    }
+  }
+}
+
+export function clearLeaderboardCacheForTests(): void {
+  cache.clear();
+}
+
 /**
  * Refresh the leaderboard materialized view
  * This should be called periodically (e.g., via cron or after market resolutions)
  */
-export async function refreshLeaderboard(): Promise<void> {
-  await db.execute(sql`REFRESH MATERIALIZED VIEW CONCURRENTLY leaderboard_mv`);
+export async function refreshLeaderboard(period: LeaderboardPeriod = "daily"): Promise<void> {
+  await db.execute(sql`REFRESH MATERIALIZED VIEW CONCURRENTLY ${viewForPeriod(period)}`);
+  clearPeriodCache(period);
 }
 
 /**
  * Get the leaderboard with optional limit and offset
+ * @param period - Ranking window to read
  * @param limit - Maximum number of entries to return (default: 50)
  * @param offset - Number of entries to skip (default: 0)
  */
 export async function getLeaderboard(
+  period: LeaderboardPeriod = "daily",
   limit: number = 50,
   offset: number = 0
 ): Promise<LeaderboardEntry[]> {
+  const key = cacheKey(period, limit, offset);
+  const cached = cache.get(key);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.rows;
+  }
+
   const result = await db.execute<LeaderboardEntry>(
     sql`
       SELECT user_id, stellar_address, total_predictions, correct_predictions, 
              accuracy_percentage, rank
-      FROM leaderboard_mv
+      FROM ${viewForPeriod(period)}
       ORDER BY rank ASC
       LIMIT ${limit}
       OFFSET ${offset}
     `
   );
+  cache.set(key, { expiresAt: Date.now() + CACHE_TTL_MS, rows: result.rows });
   return result.rows;
 }
 
 /**
  * Get a specific user's leaderboard entry by stellar address
  * @param stellarAddress - The user's Stellar address
+ * @param period - Ranking window to read
  */
 export async function getUserLeaderboardEntry(
-  stellarAddress: string
+  stellarAddress: string,
+  period: LeaderboardPeriod = "daily"
 ): Promise<LeaderboardEntry | null> {
   const result = await db.execute<LeaderboardEntry>(
     sql`
       SELECT user_id, stellar_address, total_predictions, correct_predictions, 
              accuracy_percentage, rank
-      FROM leaderboard_mv
+      FROM ${viewForPeriod(period)}
       WHERE stellar_address = ${stellarAddress}
       LIMIT 1
     `
@@ -65,9 +110,10 @@ export async function getUserLeaderboardEntry(
  * Use this when you need the most up-to-date data
  */
 export async function getLeaderboardWithRefresh(
+  period: LeaderboardPeriod = "daily",
   limit: number = 50,
   offset: number = 0
 ): Promise<LeaderboardEntry[]> {
-  await refreshLeaderboard();
-  return getLeaderboard(limit, offset);
+  await refreshLeaderboard(period);
+  return getLeaderboard(period, limit, offset);
 }

--- a/tests/leaderboardRoutes.test.ts
+++ b/tests/leaderboardRoutes.test.ts
@@ -1,0 +1,98 @@
+import express, { type NextFunction, type Request, type Response } from "express";
+import request from "supertest";
+import { ZodError } from "zod";
+import { leaderboardRouter } from "../src/routes/leaderboard";
+import {
+  getLeaderboard,
+  getLeaderboardWithRefresh,
+  getUserLeaderboardEntry,
+} from "../src/services/leaderboardService";
+
+jest.mock("../src/services/leaderboardService", () => ({
+  leaderboardPeriods: ["daily", "weekly", "monthly"],
+  getLeaderboard: jest.fn(),
+  getLeaderboardWithRefresh: jest.fn(),
+  getUserLeaderboardEntry: jest.fn(),
+}));
+
+const mockedGetLeaderboard = getLeaderboard as jest.MockedFunction<typeof getLeaderboard>;
+const mockedGetLeaderboardWithRefresh = getLeaderboardWithRefresh as jest.MockedFunction<typeof getLeaderboardWithRefresh>;
+const mockedGetUserLeaderboardEntry = getUserLeaderboardEntry as jest.MockedFunction<typeof getUserLeaderboardEntry>;
+
+function createLeaderboardApp() {
+  const app = express();
+  app.use("/api/leaderboard", leaderboardRouter);
+  app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+    if (err instanceof ZodError) {
+      res.status(400).json({ error: { code: "invalid_query" } });
+      return;
+    }
+    res.status(500).json({ error: { code: "internal_error" } });
+  });
+  return app;
+}
+
+describe("leaderboardRouter period query", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("passes the requested period to the service and returns it in meta", async () => {
+    mockedGetLeaderboard.mockResolvedValue([]);
+
+    const res = await request(createLeaderboardApp()).get("/api/leaderboard?period=weekly&limit=20&offset=10");
+
+    expect(res.status).toBe(200);
+    expect(mockedGetLeaderboard).toHaveBeenCalledWith("weekly", 20, 10);
+    expect(res.body.meta).toMatchObject({ period: "weekly", limit: 20, offset: 10, refresh: false });
+  });
+
+  it("defaults the period to daily", async () => {
+    mockedGetLeaderboard.mockResolvedValue([]);
+
+    const res = await request(createLeaderboardApp()).get("/api/leaderboard");
+
+    expect(res.status).toBe(200);
+    expect(mockedGetLeaderboard).toHaveBeenCalledWith("daily", 50, 0);
+    expect(res.body.meta.period).toBe("daily");
+  });
+
+  it("refreshes only the selected period", async () => {
+    mockedGetLeaderboardWithRefresh.mockResolvedValue([]);
+
+    const res = await request(createLeaderboardApp()).get("/api/leaderboard?period=monthly&refresh=true");
+
+    expect(res.status).toBe(200);
+    expect(mockedGetLeaderboardWithRefresh).toHaveBeenCalledWith("monthly", 50, 0);
+  });
+
+  it("rejects unknown periods", async () => {
+    const res = await request(createLeaderboardApp()).get("/api/leaderboard?period=yearly");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: { code: "invalid_query" } });
+    expect(mockedGetLeaderboard).not.toHaveBeenCalled();
+  });
+
+  it("passes period to user leaderboard lookup", async () => {
+    mockedGetUserLeaderboardEntry.mockResolvedValue({
+      user_id: "user-1",
+      stellar_address: "GBBD47UZQ5DXGX23UKMHLGG5TZPJJKISVQYER3SPRINGS57LVEDSTQCEO",
+      total_predictions: 3,
+      correct_predictions: 2,
+      accuracy_percentage: 66.67,
+      rank: 1,
+    });
+
+    const res = await request(createLeaderboardApp()).get(
+      "/api/leaderboard/user/GBBD47UZQ5DXGX23UKMHLGG5TZPJJKISVQYER3SPRINGS57LVEDSTQCEO?period=monthly",
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockedGetUserLeaderboardEntry).toHaveBeenCalledWith(
+      "GBBD47UZQ5DXGX23UKMHLGG5TZPJJKISVQYER3SPRINGS57LVEDSTQCEO",
+      "monthly",
+    );
+    expect(res.body.meta.period).toBe("monthly");
+  });
+});

--- a/tests/leaderboardService.test.ts
+++ b/tests/leaderboardService.test.ts
@@ -1,0 +1,67 @@
+const executeMock = jest.fn();
+
+jest.mock("../src/db", () => ({
+  db: {
+    execute: executeMock,
+  },
+}));
+
+import {
+  clearLeaderboardCacheForTests,
+  getLeaderboard,
+  getLeaderboardWithRefresh,
+  getUserLeaderboardEntry,
+} from "../src/services/leaderboardService";
+
+function queryHasIdentifier(query: unknown, identifier: string): boolean {
+  const chunks = (query as { queryChunks?: unknown[] }).queryChunks ?? [];
+  return chunks.some((chunk) => (chunk as { value?: unknown }).value === identifier);
+}
+
+describe("leaderboardService period views", () => {
+  beforeEach(() => {
+    executeMock.mockReset();
+    clearLeaderboardCacheForTests();
+  });
+
+  it("reads the materialized view for the requested period", async () => {
+    executeMock.mockResolvedValue({ rows: [] });
+
+    await getLeaderboard("weekly", 25, 5);
+
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    expect(queryHasIdentifier(executeMock.mock.calls[0][0], "leaderboard_weekly_mv")).toBe(true);
+  });
+
+  it("caches leaderboard pages separately by period", async () => {
+    executeMock.mockResolvedValue({ rows: [] });
+
+    await getLeaderboard("daily", 10, 0);
+    await getLeaderboard("daily", 10, 0);
+    await getLeaderboard("monthly", 10, 0);
+
+    expect(executeMock).toHaveBeenCalledTimes(2);
+    expect(queryHasIdentifier(executeMock.mock.calls[0][0], "leaderboard_daily_mv")).toBe(true);
+    expect(queryHasIdentifier(executeMock.mock.calls[1][0], "leaderboard_monthly_mv")).toBe(true);
+  });
+
+  it("refreshes and invalidates only the requested period", async () => {
+    executeMock.mockResolvedValue({ rows: [] });
+
+    await getLeaderboard("daily", 10, 0);
+    await getLeaderboard("weekly", 10, 0);
+    await getLeaderboardWithRefresh("daily", 10, 0);
+
+    expect(executeMock).toHaveBeenCalledTimes(4);
+    expect(queryHasIdentifier(executeMock.mock.calls[2][0], "leaderboard_daily_mv")).toBe(true);
+    expect(queryHasIdentifier(executeMock.mock.calls[3][0], "leaderboard_daily_mv")).toBe(true);
+  });
+
+  it("uses the period view for a user lookup", async () => {
+    executeMock.mockResolvedValue({ rows: [] });
+
+    await getUserLeaderboardEntry("GBBD47UZQ5DXGX23UKMHLGG5TZPJJKISVQYER3SPRINGS57LVEDSTQCEO", "monthly");
+
+    expect(queryHasIdentifier(executeMock.mock.calls[0][0], "leaderboard_monthly_mv")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds strict `period=daily|weekly|monthly` validation for `/api/leaderboard` and user leaderboard lookups.
- Reads period-specific materialized views via a safe whitelist/identifier mapping and caches leaderboard pages per period, limit, and offset.
- Adds daily/weekly/monthly leaderboard materialized view migration plus docs for usage and refresh behavior.

## Validation
- PASS: `npm test -- --runTestsByPath tests/leaderboardService.test.ts tests/leaderboardRoutes.test.ts`
- PASS: `npx eslint src/services/leaderboardService.ts src/routes/leaderboard.ts tests/leaderboardService.test.ts tests/leaderboardRoutes.test.ts`
- NOTE: `npm run build` still fails on pre-existing repo-wide TypeScript errors unrelated to this leaderboard change, including missing env fields in `src/db/client.ts`, missing imports in `src/index.ts`, and missing schema/service exports in several existing modules.

Closes #161
