### PR TITLE
feat: non-prod sample market seed endpoint

### DIFF
--- a/docs/seed.md
+++ b/docs/seed.md
@@ -1,0 +1,38 @@
+# Admin seed endpoint
+
+`POST /api/admin/seed` inserts a small set of demo markets for local E2E flows,
+staging smoke tests, and product demos.
+
+The endpoint is intentionally limited:
+
+- It only runs outside `NODE_ENV=production`.
+- It requires the same admin bearer token as other admin endpoints.
+- It is idempotent. Seed markets use fixed IDs and `ON CONFLICT DO NOTHING`.
+- Seeded rows are tracked with `metadata.seeded=true` and
+  `metadata.seedKey="sample-markets-v1"`.
+
+Example:
+
+```bash
+curl -X POST http://localhost:3001/api/admin/seed \
+  -H "Authorization: Bearer $ADMIN_JWT"
+```
+
+Response:
+
+```json
+{
+  "data": {
+    "seedKey": "sample-markets-v1",
+    "requested": 3,
+    "inserted": 3,
+    "marketIds": [
+      "seed-market-btc-100k-2026",
+      "seed-market-stellar-tvl-2026",
+      "seed-market-ai-agent-checkout"
+    ]
+  }
+}
+```
+
+Running the endpoint again returns the same `marketIds` with `inserted: 0`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { healthRouter } from "./routes/health";
 import { marketsRouter } from "./routes/markets";
 import { usersRouter } from "./routes/users";
 import { createDocsRouter } from "./routes/docs";
+import { adminSeedRouter } from "./routes/admin/seed";
 import { errorHandler } from "./middleware/errorHandler";
 import { connectWithRetry, closeDb } from "./db/client";
 
@@ -36,6 +37,7 @@ export function createApp(): express.Express {
   );
 
   app.use("/api/auth", authRouter);
+  app.use("/api/admin/seed", adminSeedRouter);
   app.use("/api/markets", marketsRouter);
   app.use("/api/users", usersRouter);
 

--- a/src/routes/admin/seed.ts
+++ b/src/routes/admin/seed.ts
@@ -1,0 +1,31 @@
+import { Router } from "express";
+import { env } from "../../config/env";
+import { logger } from "../../config/logger";
+import { requireAdmin } from "../../middleware/requireAdmin";
+import { seedSampleMarkets } from "../../services/seedService";
+
+export const adminSeedRouter = Router();
+
+adminSeedRouter.post("/", requireAdmin, async (req, res, next) => {
+  try {
+    if (env.NODE_ENV === "production") {
+      res.status(404).json({ error: { code: "not_found" } });
+      return;
+    }
+
+    const result = await seedSampleMarkets();
+    logger.info(
+      {
+        adminAddress: req.adminAddress,
+        inserted: result.inserted,
+        requested: result.requested,
+        seedKey: result.seedKey,
+      },
+      "admin_seed_markets_completed",
+    );
+
+    res.status(201).json({ data: result });
+  } catch (e) {
+    next(e);
+  }
+});

--- a/src/services/seedService.ts
+++ b/src/services/seedService.ts
@@ -1,0 +1,83 @@
+import { sql } from "drizzle-orm";
+import { db } from "../db";
+
+export interface SeedMarket {
+  id: string;
+  question: string;
+  status: "active";
+  resolutionTime: Date;
+  metadata: Record<string, unknown>;
+  indexedLedger: number;
+}
+
+export interface SeedResult {
+  seedKey: string;
+  requested: number;
+  inserted: number;
+  marketIds: string[];
+}
+
+export const sampleMarketSeedKey = "sample-markets-v1";
+
+export const sampleMarkets: SeedMarket[] = [
+  {
+    id: "seed-market-btc-100k-2026",
+    question: "Will BTC trade above $100,000 before the end of 2026?",
+    status: "active",
+    resolutionTime: new Date("2026-12-31T23:59:59.000Z"),
+    metadata: { seeded: true, seedKey: sampleMarketSeedKey, category: "crypto" },
+    indexedLedger: 0,
+  },
+  {
+    id: "seed-market-stellar-tvl-2026",
+    question: "Will Stellar DeFi TVL double before the end of 2026?",
+    status: "active",
+    resolutionTime: new Date("2026-12-31T23:59:59.000Z"),
+    metadata: { seeded: true, seedKey: sampleMarketSeedKey, category: "stellar" },
+    indexedLedger: 0,
+  },
+  {
+    id: "seed-market-ai-agent-checkout",
+    question: "Will an AI agent complete a production checkout flow this quarter?",
+    status: "active",
+    resolutionTime: new Date("2026-09-30T23:59:59.000Z"),
+    metadata: { seeded: true, seedKey: sampleMarketSeedKey, category: "ai" },
+    indexedLedger: 0,
+  },
+];
+
+export async function seedSampleMarkets(): Promise<SeedResult> {
+  const inserted = await db.execute<{ id: string }>(sql`
+    INSERT INTO markets (
+      id,
+      question,
+      status,
+      resolution_time,
+      metadata,
+      indexed_ledger
+    )
+    VALUES
+      ${sql.join(
+        sampleMarkets.map(
+          (market) => sql`(
+            ${market.id},
+            ${market.question},
+            ${market.status},
+            ${market.resolutionTime},
+            ${JSON.stringify(market.metadata)}::jsonb,
+            ${market.indexedLedger}
+          )`,
+        ),
+        sql`,`,
+      )}
+    ON CONFLICT (id) DO NOTHING
+    RETURNING id
+  `);
+
+  return {
+    seedKey: sampleMarketSeedKey,
+    requested: sampleMarkets.length,
+    inserted: inserted.rows.length,
+    marketIds: sampleMarkets.map((market) => market.id),
+  };
+}

--- a/tests/adminSeedRoutes.test.ts
+++ b/tests/adminSeedRoutes.test.ts
@@ -1,0 +1,73 @@
+import express from "express";
+import request from "supertest";
+
+const mockSeedSampleMarkets = jest.fn();
+
+jest.mock("../src/middleware/requireAdmin", () => ({
+  requireAdmin: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.adminAddress = "GADMIN";
+    next();
+  },
+}));
+
+jest.mock("../src/services/seedService", () => ({
+  seedSampleMarkets: mockSeedSampleMarkets,
+}));
+
+jest.mock("../src/config/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    fatal: jest.fn(),
+  },
+}));
+
+function createAdminSeedApp(adminSeedRouter: express.Router) {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/admin/seed", adminSeedRouter);
+  return app;
+}
+
+async function loadRouterWithNodeEnv(nodeEnv: "test" | "production") {
+  process.env.NODE_ENV = nodeEnv;
+  jest.resetModules();
+  const module = await import("../src/routes/admin/seed");
+  return module.adminSeedRouter;
+}
+
+describe("adminSeedRouter", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    jest.clearAllMocks();
+  });
+
+  it("seeds markets outside production", async () => {
+    const router = await loadRouterWithNodeEnv("test");
+    mockSeedSampleMarkets.mockResolvedValue({
+      seedKey: "sample-markets-v1",
+      requested: 3,
+      inserted: 3,
+      marketIds: ["seed-market-btc-100k-2026"],
+    });
+
+    const res = await request(createAdminSeedApp(router)).post("/api/admin/seed");
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toMatchObject({ seedKey: "sample-markets-v1", inserted: 3 });
+    expect(mockSeedSampleMarkets).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not expose the seed endpoint in production", async () => {
+    const router = await loadRouterWithNodeEnv("production");
+
+    const res = await request(createAdminSeedApp(router)).post("/api/admin/seed");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: { code: "not_found" } });
+    expect(mockSeedSampleMarkets).not.toHaveBeenCalled();
+  });
+});

--- a/tests/seedService.test.ts
+++ b/tests/seedService.test.ts
@@ -1,0 +1,43 @@
+const executeMock = jest.fn();
+
+jest.mock("../src/db", () => ({
+  db: {
+    execute: executeMock,
+  },
+}));
+
+import { sampleMarketSeedKey, sampleMarkets, seedSampleMarkets } from "../src/services/seedService";
+
+describe("seedSampleMarkets", () => {
+  beforeEach(() => {
+    executeMock.mockReset();
+  });
+
+  it("inserts fixed demo markets idempotently", async () => {
+    executeMock.mockResolvedValue({ rows: [{ id: sampleMarkets[0].id }] });
+
+    const result = await seedSampleMarkets();
+    const query = executeMock.mock.calls[0][0] as { queryChunks?: unknown[] };
+    const rendered = JSON.stringify(query.queryChunks);
+
+    expect(result).toEqual({
+      seedKey: sampleMarketSeedKey,
+      requested: sampleMarkets.length,
+      inserted: 1,
+      marketIds: sampleMarkets.map((market) => market.id),
+    });
+    expect(rendered).toContain("ON CONFLICT (id) DO NOTHING");
+    expect(rendered).toContain("RETURNING id");
+  });
+
+  it("tracks seeded rows with metadata", async () => {
+    executeMock.mockResolvedValue({ rows: [] });
+
+    await seedSampleMarkets();
+    const query = executeMock.mock.calls[0][0] as { queryChunks?: unknown[] };
+    const rendered = JSON.stringify(query.queryChunks);
+
+    expect(rendered).toContain(sampleMarketSeedKey);
+    expect(rendered).toContain("seeded");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `POST /api/admin/seed` for non-production sample market seeding and mounts it under the admin API.
- Requires the existing admin bearer middleware, rejects production with a standard `not_found` envelope, and logs the seed result.
- Seeds fixed demo market IDs idempotently with `ON CONFLICT DO NOTHING` and tracks seeded rows with `metadata.seeded` / `metadata.seedKey`.
- Documents usage, response shape, and idempotency behavior.

## Validation
- PASS: `npm test -- --runTestsByPath tests/seedService.test.ts tests/adminSeedRoutes.test.ts`
- PASS: `npx eslint src/services/seedService.ts src/routes/admin/seed.ts tests/seedService.test.ts tests/adminSeedRoutes.test.ts`
- NOTE: `npm run build` still fails on existing repo-wide TypeScript errors unrelated to this change, including missing env fields in `src/db/client.ts`, missing imports in `src/index.ts`, and missing schema/service exports in existing modules.

Closes #160
