### PR TITLE
feat: captcha gate for anon (#170)

### DIFF
--- a/src/config/env-schema.ts
+++ b/src/config/env-schema.ts
@@ -30,6 +30,12 @@ export const envSchema = z.object({
   ANON_RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
   ANON_RATE_LIMIT_MAX: z.coerce.number().int().positive().default(60),
   TRUST_PROXY: z.coerce.boolean().default(false),
+
+  // ── Captcha gate (per-IP, unauthenticated endpoints) ─────
+  /** Number of requests per IP per window before captcha is required (0 = disabled) */
+  CAPTCHA_THRESHOLD: z.coerce.number().int().nonnegative().default(10),
+  /** Sliding window length for captcha threshold tracking (ms) */
+  CAPTCHA_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -24,6 +24,9 @@ const schema = z.object({
   ANON_RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
   ANON_RATE_LIMIT_MAX: z.coerce.number().int().positive().default(60),
   TRUST_PROXY: z.coerce.boolean().default(false),
+  // ── Captcha gate ──────────────────────────────────────────
+  CAPTCHA_THRESHOLD: z.coerce.number().int().nonnegative().default(10),
+  CAPTCHA_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
 });
 
 export const env = schema.parse(process.env);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,10 @@ import { healthRouter } from "./routes/health";
 import { authRouter } from "./routes/auth";
 import { marketsRouter } from "./routes/markets";
 import { usersRouter } from "./routes/users";
-import { authRouter } from "./routes/auth";
 import { leaderboardRouter } from "./routes/leaderboard";
 import { createDocsRouter } from "./routes/docs";
-import { metricsMiddleware } from "./metrics/httpMetrics";
-import { idempotency } from "./middleware/idempotency";
 import { errorHandler } from "./middleware/errorHandler";
+import { captchaGate } from "./middleware/captcha";
 import { requestContextStorage } from "./lib/requestContext";
 import { REQUEST_ID_HEADER } from "./lib/http";
 import { register } from "./metrics/registry";
@@ -80,8 +78,8 @@ export function createApp(): express.Express {
 
 
   app.use("/api/auth", authRouter);
-  app.use("/api/markets", marketsRouter);
-  app.use("/api/leaderboard", leaderboardRouter);
+  app.use("/api/markets", captchaGate, marketsRouter);
+  app.use("/api/leaderboard", captchaGate, leaderboardRouter);
   app.use("/api/users", usersRouter);
 
   app.get("/metrics", async (req, res) => {
@@ -105,7 +103,7 @@ if (require.main === module) {
     .then(() => {
       app.listen(env.PORT, () => {
         logger.info({ port: env.PORT, env: env.NODE_ENV }, "predictify-backend listening");
-        if (docsEnabled) {
+        if (env.NODE_ENV !== "production") {
           logger.info(`Swagger UI available at http://localhost:${env.PORT}/docs`);
         }
       });

--- a/src/middleware/captcha.ts
+++ b/src/middleware/captcha.ts
@@ -1,0 +1,96 @@
+/**
+ * @module captcha
+ *
+ * Per-IP captcha challenge gate for unauthenticated endpoints.
+ *
+ * After CAPTCHA_THRESHOLD requests per IP within CAPTCHA_WINDOW_MS,
+ * the middleware returns a 429 response with `captcha_required` so the
+ * client knows to solve a captcha before retrying.
+ *
+ * Authenticated callers (Bearer token present) bypass the gate entirely.
+ *
+ * Configuration (env):
+ *   CAPTCHA_THRESHOLD  — requests before challenge is issued (default 10; 0 = disabled)
+ *   CAPTCHA_WINDOW_MS  — sliding window length in ms (default 60_000)
+ */
+
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+import { env } from "../config/env";
+import { logger } from "../config/logger";
+import { getRequestId } from "../lib/requestContext";
+import { isAuthenticatedRequest, extractClientIp, SlidingWindowStore } from "./rateLimitAnon";
+
+export { SlidingWindowStore };
+
+export interface CaptchaOptions {
+  /** Number of requests per IP per window before challenge is issued. 0 = disabled. */
+  threshold: number;
+  /** Sliding window length in ms. */
+  windowMs: number;
+  /** When true, client IP is taken from X-Forwarded-For. */
+  trustProxy?: boolean;
+  /** Optional store instance (for testing). */
+  store?: SlidingWindowStore;
+}
+
+/**
+ * Factory that creates the captcha-gate middleware.
+ *
+ * @example
+ * app.use("/api", createCaptchaGate({ threshold: 10, windowMs: 60_000 }));
+ */
+export function createCaptchaGate(options: CaptchaOptions): RequestHandler {
+  const { threshold, windowMs, trustProxy = false, store = new SlidingWindowStore() } = options;
+
+  // When threshold is 0 the gate is disabled — pass through immediately.
+  if (threshold === 0) {
+    return (_req: Request, _res: Response, next: NextFunction): void => next();
+  }
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // Authenticated callers are never challenged.
+    if (isAuthenticatedRequest(req)) {
+      next();
+      return;
+    }
+
+    const now = Date.now();
+    const clientIp = extractClientIp(req, trustProxy);
+    const active = store.getTimestamps(clientIp, now, windowMs);
+
+    if (active.length >= threshold) {
+      const reqId = getRequestId();
+      logger.warn(
+        {
+          reqId,
+          clientIp,
+          path: req.path,
+          method: req.method,
+          threshold,
+          windowMs,
+          count: active.length,
+        },
+        "captcha_challenge_required",
+      );
+
+      res.status(429).json({
+        error: {
+          code: "captcha_required",
+          message: "Too many requests — please complete a captcha to continue.",
+          ...(reqId ? { requestId: reqId } : {}),
+        },
+      });
+      return;
+    }
+
+    store.record(clientIp, now, windowMs);
+    next();
+  };
+}
+
+/** Production middleware wired from env defaults. */
+export const captchaGate: RequestHandler = createCaptchaGate({
+  threshold: env.CAPTCHA_THRESHOLD,
+  windowMs: env.CAPTCHA_WINDOW_MS,
+  trustProxy: env.TRUST_PROXY,
+});

--- a/tests/captcha.test.ts
+++ b/tests/captcha.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for the per-IP captcha-challenge gate.
+ *
+ * Covers:
+ *  - Requests allowed under threshold
+ *  - 429 + captcha_required after threshold is reached
+ *  - Authenticated (Bearer) callers bypass the gate
+ *  - threshold=0 disables the gate entirely
+ *  - Per-IP isolation (different IPs get separate counters)
+ *  - requestId included in error response when available
+ *  - Standard error envelope { error: { code, message } }
+ *  - env defaults parsed correctly
+ */
+
+import request from "supertest";
+import express from "express";
+import { createCaptchaGate, SlidingWindowStore } from "../src/middleware/captcha";
+import { requestContextStorage } from "../src/lib/requestContext";
+
+function makeApp(
+  threshold = 3,
+  windowMs = 60_000,
+  trustProxy = false,
+  store = new SlidingWindowStore(),
+) {
+  const app = express();
+  app.use((_req, _res, next) => {
+    requestContextStorage.run({ requestId: "test-req-id" }, next);
+  });
+  app.use(createCaptchaGate({ threshold, windowMs, trustProxy, store }));
+  app.get("/api/markets", (_req, res) => res.json({ data: [] }));
+  app.get("/api/leaderboard", (_req, res) => res.json({ data: [] }));
+  return { app, store };
+}
+
+describe("createCaptchaGate", () => {
+  it("allows requests under the threshold", async () => {
+    const { app } = makeApp(3);
+    for (let i = 0; i < 3; i++) {
+      await request(app).get("/api/markets").expect(200);
+    }
+  });
+
+  it("issues 429 captcha_required once threshold is reached", async () => {
+    const { app } = makeApp(2);
+    await request(app).get("/api/markets").expect(200);
+    await request(app).get("/api/markets").expect(200);
+    const res = await request(app).get("/api/markets");
+
+    expect(res.status).toBe(429);
+    expect(res.body.error.code).toBe("captcha_required");
+    expect(typeof res.body.error.message).toBe("string");
+  });
+
+  it("includes requestId in error response", async () => {
+    const { app } = makeApp(1);
+    await request(app).get("/api/markets").expect(200);
+    const res = await request(app).get("/api/markets");
+
+    expect(res.status).toBe(429);
+    expect(res.body.error.requestId).toBe("test-req-id");
+  });
+
+  it("applies to /api/leaderboard", async () => {
+    const { app } = makeApp(1);
+    await request(app).get("/api/leaderboard").expect(200);
+    const res = await request(app).get("/api/leaderboard");
+    expect(res.status).toBe(429);
+    expect(res.body.error.code).toBe("captcha_required");
+  });
+
+  it("bypasses gate for Bearer-authenticated requests", async () => {
+    const { app } = makeApp(1);
+    await request(app).get("/api/markets").expect(200);
+    // Without auth — would be blocked
+    const blocked = await request(app).get("/api/markets");
+    expect(blocked.status).toBe(429);
+
+    // With auth — always passes regardless of count
+    for (let i = 0; i < 5; i++) {
+      const res = await request(app)
+        .get("/api/markets")
+        .set("Authorization", "Bearer fake-token-present");
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("maintains separate counters per IP", async () => {
+    const store = new SlidingWindowStore();
+    const { app } = makeApp(1, 60_000, true, store);
+
+    await request(app)
+      .get("/api/markets")
+      .set("x-forwarded-for", "10.0.0.1")
+      .expect(200);
+
+    // 10.0.0.1 is now over threshold, but 10.0.0.2 is not
+    const blocked = await request(app)
+      .get("/api/markets")
+      .set("x-forwarded-for", "10.0.0.1");
+    expect(blocked.status).toBe(429);
+
+    const allowed = await request(app)
+      .get("/api/markets")
+      .set("x-forwarded-for", "10.0.0.2");
+    expect(allowed.status).toBe(200);
+  });
+
+  it("is disabled when threshold is 0", async () => {
+    const { app } = makeApp(0);
+    for (let i = 0; i < 20; i++) {
+      await request(app).get("/api/markets").expect(200);
+    }
+  });
+});
+
+describe("captcha env defaults", () => {
+  it("parses CAPTCHA_THRESHOLD with default 10", async () => {
+    const { env } = await import("../src/config/env");
+    expect(env.CAPTCHA_THRESHOLD).toBe(10);
+  });
+
+  it("parses CAPTCHA_WINDOW_MS with default 60000", async () => {
+    const { env } = await import("../src/config/env");
+    expect(env.CAPTCHA_WINDOW_MS).toBe(60_000);
+  });
+});


### PR DESCRIPTION
## Summary

Implements per-IP captcha challenge middleware for unauthenticated endpoints, closing #170.

## Changes

### New: `src/middleware/captcha.ts`
- Sliding-window per-IP request counter (reuses `SlidingWindowStore` from `rateLimitAnon`)
- After `CAPTCHA_THRESHOLD` requests within `CAPTCHA_WINDOW_MS`, returns `429 captcha_required`
- Authenticated callers (Bearer token) bypass the gate entirely
- `threshold=0` disables the gate
- Exports `createCaptchaGate` factory and production `captchaGate` singleton

### Modified: `src/index.ts`
- Wire `captchaGate` onto `/api/markets` and `/api/leaderboard`
- Fix pre-existing bugs: removed duplicate imports (`authRouter`, `metricsMiddleware`, `idempotency`) and replaced undefined `docsEnabled` reference

### Modified: `src/config/env.ts` + `src/config/env-schema.ts`
- Add `CAPTCHA_THRESHOLD` (default: `10`) and `CAPTCHA_WINDOW_MS` (default: `60000`)

### New: `tests/captcha.test.ts`
- 9 tests covering: threshold enforcement, 429 envelope, requestId, leaderboard route, auth bypass, per-IP isolation, disabled state (threshold=0), env defaults

## Test Results

```
PASS tests/captcha.test.ts
  createCaptchaGate
    ✓ allows requests under the threshold
    ✓ issues 429 captcha_required once threshold is reached
    ✓ includes requestId in error response
    ✓ applies to /api/leaderboard
    ✓ bypasses gate for Bearer-authenticated requests
    ✓ maintains separate counters per IP
    ✓ is disabled when threshold is 0
  captcha env defaults
    ✓ parses CAPTCHA_THRESHOLD with default 10
    ✓ parses CAPTCHA_WINDOW_MS with default 60000

Tests: 9 passed (108 total vs 99 before this PR)
```

Pre-existing test failures (26 suites) are unrelated to this PR and were present on `main` before these changes.