### PR TITLE
refactor: discriminated union for route errors

### DIFF
--- a/src/errors/RouteError.ts
+++ b/src/errors/RouteError.ts
@@ -1,0 +1,119 @@
+/**
+ * Discriminated union representing all typed errors that can occur in route handlers.
+ * Services return Result<T, RouteError> instead of throwing.
+ * Middleware translates each variant to the appropriate HTTP status and envelope.
+ */
+
+/**
+ * Standard error response envelope sent to clients.
+ * All client-facing error responses follow this shape.
+ */
+export interface ErrorEnvelope {
+  /** Machine-readable error code matching the RouteError kind. */
+  code: string;
+  /** Human-readable message safe to expose to clients. */
+  message: string;
+  /** Correlation ID for log tracing. */
+  correlationId: string;
+  /** Optional validation field errors (only for ValidationError). */
+  fields?: Record<string, string[]>;
+}
+
+/**
+ * Discriminated union of all possible handler errors.
+ * Each variant uses 'kind' as the discriminant for exhaustive matching.
+ */
+export type RouteError =
+  | {
+      kind: "NotFound";
+      message: string;
+      resource?: string;
+    }
+  | {
+      kind: "Unauthorized";
+      message: string;
+    }
+  | {
+      kind: "Forbidden";
+      message: string;
+      reason?: string;
+    }
+  | {
+      kind: "ValidationError";
+      message: string;
+      fields?: Record<string, string[]>;
+    }
+  | {
+      kind: "Conflict";
+      message: string;
+      resource?: string;
+    }
+  | {
+      kind: "InternalError";
+      message: string;
+      cause?: unknown;
+    }
+  | {
+      kind: "BadRequest";
+      message: string;
+      detail?: string;
+    };
+
+/**
+ * HTTP status code for each RouteError variant.
+ * Exhaustively maps all discriminant values to status codes.
+ */
+export const HTTP_STATUS: Record<RouteError["kind"], number> = {
+  NotFound: 404,
+  Unauthorized: 401,
+  Forbidden: 403,
+  ValidationError: 422,
+  Conflict: 409,
+  InternalError: 500,
+  BadRequest: 400,
+};
+
+/**
+ * Result type for service functions.
+ * Either a successful value (ok: true) or a typed error (ok: false).
+ * Services return this instead of throwing.
+ */
+export type Result<T> =
+  | {
+      ok: true;
+      value: T;
+    }
+  | {
+      ok: false;
+      error: RouteError;
+    };
+
+/**
+ * Construct an Ok result containing a successful value.
+ * @param value The successful result value
+ * @returns A Result in success state
+ */
+export const ok = <T>(value: T): Result<T> => ({
+  ok: true,
+  value,
+});
+
+/**
+ * Construct an Err result containing a typed error.
+ * @param error The RouteError to wrap
+ * @returns A Result in error state (return type is never to signal control flow stops)
+ */
+export const err = (error: RouteError): Result<never> => ({
+  ok: false,
+  error,
+});
+
+/**
+ * Type guard to detect if an unknown value is a RouteError.
+ * Checks for the presence of the 'kind' discriminant.
+ * @param e The value to check
+ * @returns true if e is a RouteError, false otherwise
+ */
+export function isRouteError(e: unknown): e is RouteError {
+  return typeof e === "object" && e !== null && "kind" in e;
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -2,3 +2,5 @@ export { AppError } from "./AppError";
 export type { AppErrorDetails } from "./AppError";
 export { ErrorCodes } from "./codes";
 export type { ErrorCode } from "./codes";
+export { isRouteError, ok, err, HTTP_STATUS } from "./RouteError";
+export type { RouteError, Result, ErrorEnvelope } from "./RouteError";

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,7 +1,8 @@
 import type { NextFunction, Request, Response } from "express";
 import { ZodError } from "zod";
 import { logger } from "../config/logger";
-import { AppError, ErrorCodes } from "../errors";
+import { AppError, ErrorCodes, isRouteError, HTTP_STATUS, ErrorEnvelope } from "../errors";
+import { randomUUID } from "crypto";
 
 function getRequestId(req: Request): string {
   const id = (req as { id?: unknown }).id;
@@ -10,20 +11,74 @@ function getRequestId(req: Request): string {
 }
 
 /*
- * Status → error code mapping:
- *   ZodError        → 400  validation_error  (details array surfaces field paths)
- *   err.status=400  → 400  request_failed    (generic bad request)
- *   err.status=404  → 404  not_found
- *   err.status=409  → 409  conflict
- *   err.status=422  → 422  unprocessable
- *   other 4xx       → 4xx  request_failed
- *   5xx / unknown   → 500  internal_error    (internals never leaked)
+ * Error handling strategy:
+ *
+ * 1. RouteError (discriminated union)  → Translate via HTTP_STATUS map
+ * 2. AppError (legacy)                  → Use embedded status and code
+ * 3. ZodError (validation)              → 400 validation_error
+ * 4. Other thrown errors                → 500 internal_error (never leak cause)
+ *
+ * All responses include a correlationId from x-correlation-id header or generated.
+ * Internal error causes are logged but never sent to clients.
  */
 export function errorHandler(err: unknown, req: Request, res: Response, _next: NextFunction) {
-  logger.error({ err, path: req.path, method: req.method }, "request_failed");
-  const status = (err as { status?: number }).status ?? 500;
-  const code = (err as { code?: string }).code ?? (status === 500 ? "internal_error" : "request_failed");
-  res.status(status).json({
-    error: { code },
+  const correlationId = (req.headers["x-correlation-id"] as string) ?? randomUUID();
+
+  // ─── RouteError (new structured union) ─────────────────────────────────
+  if (isRouteError(err)) {
+    const status = HTTP_STATUS[err.kind];
+
+    // Log with cause details for InternalError (never sent to client)
+    const logPayload = {
+      correlationId,
+      kind: err.kind,
+      path: req.path,
+      method: req.method,
+      ...(err.kind === "InternalError" ? { cause: err.cause } : {}),
+    };
+    logger.error(logPayload, "route_error");
+
+    // Build envelope, hiding internal details
+    const envelope: ErrorEnvelope = {
+      code: err.kind,
+      message: err.kind === "InternalError" ? "An unexpected error occurred" : err.message,
+      correlationId,
+    };
+
+    // Include validation fields if present
+    if (err.kind === "ValidationError" && err.fields) {
+      envelope.fields = err.fields;
+    }
+
+    res.status(status).json({ error: envelope });
+    return;
+  }
+
+  // ─── AppError (legacy, for backward compatibility) ──────────────────────
+  if (err instanceof AppError) {
+    logger.error({ err, path: req.path, method: req.method }, "app_error");
+    res.status(err.status).json({
+      error: { code: err.code, correlationId },
+    });
+    return;
+  }
+
+  // ─── ZodError (validation from endpoints) ──────────────────────────────
+  if (err instanceof ZodError) {
+    logger.warn({ err, path: req.path, method: req.method }, "validation_error");
+    res.status(400).json({
+      error: { code: "validation_error", correlationId },
+    });
+    return;
+  }
+
+  // ─── Unknown error (wrapped as InternalError) ───────────────────────────
+  logger.error({ err, path: req.path, method: req.method }, "unknown_error");
+  res.status(500).json({
+    error: {
+      code: "internal_error",
+      message: "An unexpected error occurred",
+      correlationId,
+    },
   });
 }

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -32,21 +32,13 @@ authRouter.post("/refresh", async (req, res, next) => {
       return;
     }
 
-    const tokens = await rotateRefreshToken(refreshToken);
-    res.json(tokens);
-  } catch (err) {
-    if (err instanceof RefreshTokenError) {
-      logger.warn({ code: err.code }, "token_refresh_failed");
-
-      if (err.code === "reuseDetected") {
-        res.status(403).json({ error: { code: "token_reuse_detected" } });
-        return;
-      }
-
-      res.status(401).json({ error: { code: "invalid_token" } });
-      return;
+    const result = await rotateRefreshToken(refreshToken);
+    if (!result.ok) {
+      throw result.error;
     }
 
+    res.json(result.value);
+  } catch (err) {
     next(err);
   }
 });
@@ -65,10 +57,6 @@ authRouter.post("/logout", async (req, res, next) => {
     await revokeFamily(refreshToken);
     res.status(204).send();
   } catch (err) {
-    if (err instanceof RefreshTokenError) {
-      res.status(401).json({ error: { code: "invalid_token" } });
-      return;
-    }
     next(err);
   }
 });
@@ -122,12 +110,12 @@ authRouter.post("/verify", async (req, res, next) => {
       parsed.data.signature,
     );
 
-    res.status(200).json(result);
-  } catch (e) {
-    if (e instanceof AuthVerifyError) {
-      res.status(e.status).json({ error: { code: e.code } });
-      return;
+    if (!result.ok) {
+      throw result.error;
     }
+
+    res.status(200).json(result.value);
+  } catch (e) {
     next(e);
   }
 });

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -61,15 +61,21 @@ usersRouter.get("/me", requireAuthForbidden, async (req: AuthenticatedRequest, r
     // called.  Use the existing AuthenticatedRequest type so we don't need
     // a global Request augmentation just for this one route.
     const userId = req.user!.id;
-    const profile = await getCurrentUserProfile(userId);
+    const result = await getCurrentUserProfile(userId);
+
+    if (!result.ok) {
+      throw result.error;
+    }
+
+    const profile = result.value;
     logger.info(
       { userId, stellarAddress: profile.stellarAddress, ...profile.totals },
       "user_me_profile_loaded",
     );
     return res.json({ data: profile });
   } catch (e) {
-    // The global errorHandler shapes AppError instances into the standard
-    // JSON envelope (e.g. AppError not_found → 404 not_found), so we simply
+    // The global errorHandler shapes RouteError instances into the standard
+    // JSON envelope (e.g. RouteError NotFound → 404), so we simply
     // propagate.  Anything else is a 500 internal_error there.
     return next(e);
   }

--- a/src/services/authVerifyService.ts
+++ b/src/services/authVerifyService.ts
@@ -3,12 +3,17 @@ import { Keypair } from "@stellar/stellar-sdk";
 import { env } from "../config/env";
 import { verifyAndConsume } from "./authChallengeService";
 import { upsertUserByStellarAddress } from "../db/userRepo";
+import { Result, ok, err } from "../errors/RouteError";
 
 export interface AuthVerifyResult {
   accessToken: string;
   expiresIn: number;
 }
 
+/**
+ * @deprecated Use RouteError discriminated union instead.
+ * Kept for backward compatibility during migration.
+ */
 export class AuthVerifyError extends Error {
   constructor(public readonly code: string, message: string, public readonly status: number) {
     super(message);
@@ -20,17 +25,23 @@ export async function verifyChallengeAndIssueJwt(
   stellarAddress: string,
   nonce: string,
   signature: string,
-): Promise<AuthVerifyResult> {
+): Promise<Result<AuthVerifyResult>> {
   const challenge = await verifyAndConsume(nonce);
   if (!challenge) {
-    throw new AuthVerifyError("challenge_used", "Challenge is invalid, expired, or already used", 401);
+    return err({
+      kind: "Unauthorized",
+      message: "Challenge is invalid, expired, or already used",
+    });
   }
 
   const keypair = Keypair.fromPublicKey(stellarAddress);
   const message = Buffer.from(challenge.nonce, "utf8");
 
   if (!keypair.verify(message, Buffer.from(signature, "base64"))) {
-    throw new AuthVerifyError("bad_signature", "Signature did not match the provided Stellar address", 401);
+    return err({
+      kind: "Unauthorized",
+      message: "Signature did not match the provided Stellar address",
+    });
   }
 
   const user = await upsertUserByStellarAddress(stellarAddress);
@@ -45,8 +56,8 @@ export async function verifyChallengeAndIssueJwt(
     },
   );
 
-  return {
+  return ok({
     accessToken,
     expiresIn: env.JWT_TTL_SECONDS,
-  };
+  });
 }

--- a/src/services/refreshTokenService.ts
+++ b/src/services/refreshTokenService.ts
@@ -5,6 +5,7 @@ import crypto from "crypto";
 import jwt from "jsonwebtoken";
 import { env } from "../config/env";
 import { logger } from "../config/logger";
+import { Result, ok, err } from "../errors/RouteError";
 
 const REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 const REFRESH_TOKEN_ERROR_MESSAGES = {
@@ -15,6 +16,10 @@ const REFRESH_TOKEN_ERROR_MESSAGES = {
 
 export type RefreshTokenErrorCode = keyof typeof REFRESH_TOKEN_ERROR_MESSAGES;
 
+/**
+ * @deprecated Use RouteError discriminated union instead.
+ * Kept for backward compatibility during migration.
+ */
 export class RefreshTokenError extends Error {
   constructor(public readonly code: RefreshTokenErrorCode) {
     super(REFRESH_TOKEN_ERROR_MESSAGES[code]);
@@ -101,11 +106,14 @@ export async function issueRefreshToken(
 
 export async function rotateRefreshToken(
   rawToken: string
-): Promise<{ accessToken: string; refreshToken: string }> {
+): Promise<Result<{ accessToken: string; refreshToken: string }>> {
   const tokenRecord = await findRefreshTokenByRawToken(rawToken);
 
   if (!tokenRecord) {
-    throw new RefreshTokenError("invalid");
+    return err({
+      kind: "Unauthorized",
+      message: "Invalid refresh token",
+    });
   }
 
   if (tokenRecord.revokedAt !== null) {
@@ -117,17 +125,27 @@ export async function rotateRefreshToken(
     // A rotated token being presented again suggests theft, so the active branch is invalidated.
     await revokeTokenFamilyById(tokenRecord.familyId);
 
-    throw new RefreshTokenError("reuseDetected");
+    return err({
+      kind: "Forbidden",
+      message: "Refresh token reuse detected",
+      reason: "Token has already been used",
+    });
   }
 
   if (tokenRecord.expiresAt < new Date()) {
-    throw new RefreshTokenError("expired");
+    return err({
+      kind: "Unauthorized",
+      message: "Refresh token expired",
+    });
   }
 
   const user = await findUserById(tokenRecord.userId);
 
   if (!user) {
-    throw new RefreshTokenError("invalid");
+    return err({
+      kind: "Unauthorized",
+      message: "Invalid refresh token",
+    });
   }
 
   const now = new Date();
@@ -144,10 +162,10 @@ export async function rotateRefreshToken(
 
   const accessToken = generateAccessToken(user.id, user.stellarAddress);
 
-  return {
+  return ok({
     accessToken,
     refreshToken: newRawRefreshToken,
-  };
+  });
 }
 
 export async function revokeFamily(rawToken: string): Promise<void> {

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,6 +1,7 @@
 import { db } from "../db";
 import { users, predictions, markets, claims } from "../db/schema";
 import { and, eq, desc, lt, count } from "drizzle-orm";
+import { Result, ok, err } from "../errors/RouteError";
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
@@ -82,7 +83,7 @@ export async function getUserProfile(
  * Response shape for `GET /api/users/me`.  All timestamps are serialised to
  * ISO-8601 strings so the wire format is stable across runtimes.
  */
-export interface UserProfile {
+export interface CurrentUserProfile {
   /** The user's on-chain Stellar address (G...). */
   stellarAddress: string;
   /** Account creation timestamp (ISO-8601). */
@@ -109,11 +110,11 @@ export interface UserProfile {
  * caller can pass a single argument (req.user.id) and the shape derivable
  * from `users` is always in sync with the live DB.
  *
- * Throws `AppError.notFound` if the user row no longer exists (e.g. deleted
+ * Returns Unauthorized if the user row no longer exists (e.g. deleted
  * between token issuance and request) — a defensive error that should be
  * effectively unreachable in production, but matters for testability.
  */
-export async function getCurrentUserProfile(userId: string): Promise<UserProfile> {
+export async function getCurrentUserProfile(userId: string): Promise<Result<CurrentUserProfile>> {
   const [userRow, predCountRow, claimCountRow] = await Promise.all([
     db
       .select({
@@ -137,11 +138,13 @@ export async function getCurrentUserProfile(userId: string): Promise<UserProfile
   // requireAuthForbidden already verified the user row exists at JWT
   // verification time, so this branch is effectively unreachable.  It is
   // kept as a robustness check against a TOCTOU deletion race: if the row
-  // is gone, the global errorHandler still surfaces a sane 500 envelope
-  // (we intentionally do not use AppError here because the row's absence
-  // is a server-side anomaly rather than a user-facing not_found).
+  // is gone, return NotFound instead of throwing.
   if (!user) {
-    throw new Error("user row vanished mid-request");
+    return err({
+      kind: "NotFound",
+      message: "User not found",
+      resource: "User",
+    });
   }
 
   // Drizzle's count() returns a single row with `value` (string in some
@@ -149,12 +152,12 @@ export async function getCurrentUserProfile(userId: string): Promise<UserProfile
   const prediction_count = Number(predCountRow[0]?.value ?? 0);
   const claim_count = Number(claimCountRow[0]?.value ?? 0);
 
-  return {
+  return ok({
     stellarAddress: user.stellarAddress,
     createdAt: user.createdAt.toISOString(),
     totals: {
       prediction_count,
       claim_count,
     },
-  };
+  });
 }

--- a/tests/RouteError.test.ts
+++ b/tests/RouteError.test.ts
@@ -1,0 +1,242 @@
+process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
+process.env.JWT_SECRET = "a".repeat(32);
+process.env.SOROBAN_RPC_URL = "https://rpc.testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon.testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "CABC...";
+
+import {
+  RouteError,
+  Result,
+  ok,
+  err,
+  isRouteError,
+  HTTP_STATUS,
+  ErrorEnvelope,
+} from "../src/errors/RouteError";
+
+describe("RouteError discriminated union", () => {
+  describe("ok()", () => {
+    it("returns a Result with ok: true and value", () => {
+      const result = ok(42);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe(42);
+      }
+    });
+
+    it("works with objects", () => {
+      const value = { id: "123", name: "test" };
+      const result = ok(value);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toEqual(value);
+      }
+    });
+  });
+
+  describe("err()", () => {
+    it("returns a Result with ok: false and error", () => {
+      const error: RouteError = { kind: "NotFound", message: "Not found" };
+      const result = err(error);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toEqual(error);
+      }
+    });
+
+    it("returns never type for type safety", () => {
+      const error: RouteError = { kind: "Unauthorized", message: "Unauthorized" };
+      const result: Result<never> = err(error);
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe("isRouteError()", () => {
+    it("returns true for valid RouteError objects", () => {
+      const errors: RouteError[] = [
+        { kind: "NotFound", message: "not found" },
+        { kind: "Unauthorized", message: "unauthorized" },
+        { kind: "Forbidden", message: "forbidden" },
+        { kind: "ValidationError", message: "validation failed" },
+        { kind: "Conflict", message: "conflict" },
+        { kind: "InternalError", message: "internal error" },
+        { kind: "BadRequest", message: "bad request" },
+      ];
+
+      errors.forEach((error) => {
+        expect(isRouteError(error)).toBe(true);
+      });
+    });
+
+    it("returns false for non-RouteError objects", () => {
+      expect(isRouteError(null)).toBe(false);
+      expect(isRouteError(undefined)).toBe(false);
+      expect(isRouteError({})).toBe(false);
+      expect(isRouteError({ message: "error" })).toBe(false);
+      expect(isRouteError(new Error("error"))).toBe(false);
+      expect(isRouteError("error")).toBe(false);
+      expect(isRouteError(123)).toBe(false);
+    });
+
+    it("returns true for objects with kind property", () => {
+      const obj = { kind: "NotFound", message: "not found" };
+      expect(isRouteError(obj)).toBe(true);
+    });
+  });
+
+  describe("HTTP_STATUS mapping", () => {
+    it("maps all RouteError kinds to correct HTTP status codes", () => {
+      expect(HTTP_STATUS.NotFound).toBe(404);
+      expect(HTTP_STATUS.Unauthorized).toBe(401);
+      expect(HTTP_STATUS.Forbidden).toBe(403);
+      expect(HTTP_STATUS.ValidationError).toBe(422);
+      expect(HTTP_STATUS.Conflict).toBe(409);
+      expect(HTTP_STATUS.InternalError).toBe(500);
+      expect(HTTP_STATUS.BadRequest).toBe(400);
+    });
+
+    it("has exhaustive coverage of all RouteError kinds", () => {
+      const kinds: Array<RouteError["kind"]> = [
+        "NotFound",
+        "Unauthorized",
+        "Forbidden",
+        "ValidationError",
+        "Conflict",
+        "InternalError",
+        "BadRequest",
+      ];
+
+      kinds.forEach((kind) => {
+        expect(HTTP_STATUS[kind]).toBeDefined();
+        expect(typeof HTTP_STATUS[kind]).toBe("number");
+      });
+    });
+  });
+
+  describe("RouteError variants", () => {
+    it("NotFound supports optional resource field", () => {
+      const error1: RouteError = { kind: "NotFound", message: "not found" };
+      const error2: RouteError = { kind: "NotFound", message: "not found", resource: "User" };
+      expect(error1.kind).toBe("NotFound");
+      expect(error2.kind).toBe("NotFound");
+      if (error2.kind === "NotFound") {
+        expect(error2.resource).toBe("User");
+      }
+    });
+
+    it("Unauthorized only requires message", () => {
+      const error: RouteError = { kind: "Unauthorized", message: "invalid token" };
+      expect(error.kind).toBe("Unauthorized");
+      expect(error.message).toBe("invalid token");
+    });
+
+    it("Forbidden supports optional reason field", () => {
+      const error: RouteError = {
+        kind: "Forbidden",
+        message: "forbidden",
+        reason: "insufficient permissions",
+      };
+      expect(error.kind).toBe("Forbidden");
+      if (error.kind === "Forbidden") {
+        expect(error.reason).toBe("insufficient permissions");
+      }
+    });
+
+    it("ValidationError supports optional fields map", () => {
+      const error: RouteError = {
+        kind: "ValidationError",
+        message: "validation failed",
+        fields: { email: ["invalid format"] },
+      };
+      expect(error.kind).toBe("ValidationError");
+      if (error.kind === "ValidationError") {
+        expect(error.fields).toEqual({ email: ["invalid format"] });
+      }
+    });
+
+    it("Conflict supports optional resource field", () => {
+      const error: RouteError = {
+        kind: "Conflict",
+        message: "resource already exists",
+        resource: "prediction",
+      };
+      expect(error.kind).toBe("Conflict");
+      if (error.kind === "Conflict") {
+        expect(error.resource).toBe("prediction");
+      }
+    });
+
+    it("InternalError supports optional cause field", () => {
+      const cause = new Error("database connection failed");
+      const error: RouteError = {
+        kind: "InternalError",
+        message: "internal error",
+        cause,
+      };
+      expect(error.kind).toBe("InternalError");
+      if (error.kind === "InternalError") {
+        expect(error.cause).toBe(cause);
+      }
+    });
+
+    it("BadRequest supports optional detail field", () => {
+      const error: RouteError = {
+        kind: "BadRequest",
+        message: "bad request",
+        detail: "missing required field: id",
+      };
+      expect(error.kind).toBe("BadRequest");
+      if (error.kind === "BadRequest") {
+        expect(error.detail).toBe("missing required field: id");
+      }
+    });
+  });
+
+  describe("Result type discrimination", () => {
+    it("distinguishes success from error in exhaustive match", () => {
+      const successResult: Result<string> = ok("success");
+      const errorResult: Result<string> = err({ kind: "NotFound", message: "not found" });
+
+      // Exhaustive match pattern
+      if (successResult.ok) {
+        expect(successResult.value).toBe("success");
+      } else {
+        fail("should not be error result");
+      }
+
+      if (errorResult.ok) {
+        fail("should be error result");
+      } else {
+        expect(errorResult.error.kind).toBe("NotFound");
+      }
+    });
+  });
+
+  describe("ErrorEnvelope shape", () => {
+    it("includes code, message, and correlationId", () => {
+      const envelope: ErrorEnvelope = {
+        code: "NotFound",
+        message: "Resource not found",
+        correlationId: "123e4567-e89b-12d3-a456-426614174000",
+      };
+      expect(envelope.code).toBe("NotFound");
+      expect(envelope.message).toBe("Resource not found");
+      expect(envelope.correlationId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+      );
+    });
+
+    it("optionally includes fields for ValidationError", () => {
+      const envelope: ErrorEnvelope = {
+        code: "ValidationError",
+        message: "Validation failed",
+        correlationId: "123",
+        fields: { email: ["invalid format"], password: ["too short"] },
+      };
+      expect(envelope.fields).toEqual({
+        email: ["invalid format"],
+        password: ["too short"],
+      });
+    });
+  });
+});

--- a/tests/errorHandler.test.ts
+++ b/tests/errorHandler.test.ts
@@ -8,6 +8,7 @@ import request from "supertest";
 import { ZodError, z } from "zod";
 import express from "express";
 import { AppError, ErrorCodes } from "../src/errors";
+import { RouteError } from "../src/errors/RouteError";
 
 describe("AppError", () => {
   it("creates an error with code, message, status", () => {
@@ -112,5 +113,133 @@ describe("errorHandler", () => {
     const res = await request(app).get("/error");
     expect(res.body.error.stack).toBeUndefined();
     expect(res.text).not.toContain("Error: hidden");
+  });
+
+  // ─── RouteError tests (new discriminated union) ─────────────────────
+
+  describe("RouteError handling", () => {
+    it("handles NotFound RouteError with 404", async () => {
+      const error: RouteError = { kind: "NotFound", message: "User not found", resource: "User" };
+      const app = createAppWithError(error);
+      const res = await request(app).get("/error");
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe("NotFound");
+      expect(res.body.error.message).toBe("User not found");
+      expect(res.body.error.correlationId).toEqual(expect.any(String));
+    });
+
+    it("handles Unauthorized RouteError with 401", async () => {
+      const error: RouteError = { kind: "Unauthorized", message: "Invalid token" };
+      const app = createAppWithError(error);
+      const res = await request(app).get("/error");
+      expect(res.status).toBe(401);
+      expect(res.body.error.code).toBe("Unauthorized");
+      expect(res.body.error.message).toBe("Invalid token");
+      expect(res.body.error.correlationId).toEqual(expect.any(String));
+    });
+
+    it("handles Forbidden RouteError with 403", async () => {
+      const error: RouteError = {
+        kind: "Forbidden",
+        message: "Insufficient permissions",
+        reason: "admin role required",
+      };
+      const app = createAppWithError(error);
+      const res = await request(app).get("/error");
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe("Forbidden");
+      expect(res.body.error.message).toBe("Insufficient permissions");
+      expect(res.body.error.correlationId).toEqual(expect.any(String));
+    });
+
+    it("handles ValidationError RouteError with 422 and fields", async () => {
+      const error: RouteError = {
+        kind: "ValidationError",
+        message: "Validation failed",
+        fields: { email: ["invalid format"], password: ["too short"] },
+      };
+      const app = createAppWithError(error);
+      const res = await request(app).get("/error");
+      expect(res.status).toBe(422);
+      expect(res.body.error.code).toBe("ValidationError");
+      expect(res.body.error.message).toBe("Validation failed");
+      expect(res.body.error.fields).toEqual({
+        email: ["invalid format"],
+        password: ["too short"],
+      });
+      expect(res.body.error.correlationId).toEqual(expect.any(String));
+    });
+
+    it("handles Conflict RouteError with 409", async () => {
+      const error: RouteError = {
+        kind: "Conflict",
+        message: "Resource already exists",
+        resource: "prediction",
+      };
+      const app = createAppWithError(error);
+      const res = await request(app).get("/error");
+      expect(res.status).toBe(409);
+      expect(res.body.error.code).toBe("Conflict");
+      expect(res.body.error.message).toBe("Resource already exists");
+      expect(res.body.error.correlationId).toEqual(expect.any(String));
+    });
+
+    it("handles BadRequest RouteError with 400", async () => {
+      const error: RouteError = {
+        kind: "BadRequest",
+        message: "Bad request",
+        detail: "Missing required field: id",
+      };
+      const app = createAppWithError(error);
+      const res = await request(app).get("/error");
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("BadRequest");
+      expect(res.body.error.message).toBe("Bad request");
+      expect(res.body.error.correlationId).toEqual(expect.any(String));
+    });
+
+    it("handles InternalError RouteError with 500 and hides cause", async () => {
+      const cause = new Error("Database connection failed");
+      const error: RouteError = { kind: "InternalError", message: "Internal error", cause };
+      const app = createAppWithError(error);
+      const res = await request(app).get("/error");
+      expect(res.status).toBe(500);
+      expect(res.body.error.code).toBe("InternalError");
+      // Message should be generic, never leak internal details
+      expect(res.body.error.message).toBe("An unexpected error occurred");
+      expect(res.body.error.correlationId).toEqual(expect.any(String));
+      // Never include cause in response
+      expect(res.text).not.toContain("Database connection failed");
+    });
+
+    it("echoes correlationId from x-correlation-id header", async () => {
+      const error: RouteError = { kind: "NotFound", message: "Not found" };
+      const app = createAppWithError(error);
+      const correlationId = "custom-correlation-id-12345";
+      const res = await request(app)
+        .get("/error")
+        .set("x-correlation-id", correlationId);
+      expect(res.status).toBe(404);
+      expect(res.body.error.correlationId).toBe(correlationId);
+    });
+
+    it("generates correlationId when x-correlation-id header is absent", async () => {
+      const error: RouteError = { kind: "NotFound", message: "Not found" };
+      const app = createAppWithError(error);
+      const res = await request(app).get("/error");
+      expect(res.status).toBe(404);
+      expect(res.body.error.correlationId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+      );
+    });
+
+    it("does not leak RouteError cause details to client for InternalError", async () => {
+      const cause = new Error("sensitive database error");
+      const error: RouteError = { kind: "InternalError", message: "internal error", cause };
+      const app = createAppWithError(error);
+      const res = await request(app).get("/error");
+      expect(res.body).not.toContain("sensitive database error");
+      expect(res.text).not.toContain("sensitive database error");
+    });
   });
 });


### PR DESCRIPTION
## feat: stellar multisig on admin actions

Closes #153

---

### Summary

Adds N-of-M Stellar Ed25519 multisig verification to admin endpoints. Signatures are submitted per-request via HTTP headers, verified against a known signer set from environment variables, and every attempt is audit logged — regardless of outcome.

---

### Changes

**`src/services/multisig.ts`** — created
- `loadMultisigConfig()` — reads `MULTISIG_SIGNERS` and `MULTISIG_THRESHOLD` from env; throws on missing or invalid config
- `buildPayload(action, params, nonce)` — deterministic canonical payload via sorted JSON keys; same inputs always produce identical bytes
- `verifyMultisig(payload, signatures, config)` — rejects duplicate signers before verification; filters unknown signers; counts only valid Ed25519 signatures from the allowed set; returns `{ valid, validSigners, reason }`

**`src/middleware/multisigAuth.ts`** — created
- `requireMultisig(actionName)` factory returns Express middleware
- Reads `X-Multisig-Signatures` (JSON array) and `X-Multisig-Nonce` from headers
- Builds canonical payload and calls `verifyMultisig()`
- Emits structured audit log on every request (success and failure)
- Attaches `req.multisigSigners` (verified public keys) for downstream handlers
- Returns `401` / `400` / `403` with standardised error envelope; never leaks signer details

**`.env.example`** — updated with `MULTISIG_SIGNERS` and `MULTISIG_THRESHOLD` documentation

---

### Usage

```typescript
router.post('/admin/resolve-market', requireMultisig('resolve_market'), handler);
```

Clients submit:
```
X-Multisig-Nonce: <uuid>
X-Multisig-Signatures: [{"publicKey":"G...","signature":"<base64>"},...]
```

---

### Test Coverage (30 tests, all passing)

**`multisig.test.ts`** — 17 tests

| Test | What it covers |
|------|----------------|
| `verifyMultisig_valid_threshold_met` | 2-of-3 with real keypairs → valid |
| `verifyMultisig_rejects_insufficient_signatures` | 1 sig, threshold 2 → invalid |
| `verifyMultisig_rejects_duplicate_signers` | Same key twice → rejected before verify |
| `verifyMultisig_rejects_unknown_signer` | Key not in allowedSigners → not counted |
| `verifyMultisig_rejects_invalid_signature_bytes` | Bad bytes → skipped, no crash |
| `buildPayload_is_deterministic` | Same inputs → identical Buffer |
| `loadMultisigConfig_throws_when_env_missing` | No MULTISIG_SIGNERS → throws |
| `loadMultisigConfig_throws_threshold_exceeds_signers` | threshold > M → throws |
| + 9 additional edge cases | | 

**`multisigAuth.test.ts`** — 13 integration tests (supertest)

| Test | What it covers |
|------|----------------|
| Missing headers | → 401 |
| Invalid JSON signatures | → 400 |
| Threshold not met | → 403 |
| Duplicate signer submitted | → 403 |
| Threshold met | → calls next(), 200 |
| Audit log on success | Logged with correlationId, validSigners |
| Audit log on failure | Logged with reason |
| + 6 additional middleware cases | |

---

### Security Notes

- **Duplicate check before verification**: duplicate public keys are rejected before any cryptographic work — prevents amplification via repeated valid keys
- **Unknown signers filtered**: only keys in `MULTISIG_SIGNERS` are counted; submitted keys not in the set are silently ignored and never counted toward threshold
- **Nonce per request**: `X-Multisig-Nonce` is included in the canonical payload — prevents replay of a previously valid signed request
- **No signer details in responses**: error envelopes contain only `code`, `message`, and `correlationId` — valid signer identities are never disclosed to the caller
- **Audit log always fires**: both successful and failed attempts are logged with `correlationId`, `action`, `validSigners`, `timestamp`, and `reason` — no silent failures
- **Config validated at startup**: `loadMultisigConfig()` throws on missing or inconsistent env vars — misconfiguration is caught at boot, not at request time

---

