### PR TITLE
feat: trending markets endpoint

### DIFF
--- a/drizzle/migrations/0021_markets_trending_mv.sql
+++ b/drizzle/migrations/0021_markets_trending_mv.sql
@@ -1,0 +1,22 @@
+-- Materialized view for trending markets
+-- Refresh this view periodically to update trending rankings
+CREATE MATERIALIZED VIEW IF NOT EXISTS market_trends_mv AS
+SELECT
+  m.id,
+  m.question,
+  m.status,
+  m.resolution_time,
+  m.winning_outcome,
+  m.metadata,
+  COUNT(p.id) AS total_predictions,
+  COALESCE(SUM(p.amount::numeric), 0) AS total_volume
+FROM markets m
+LEFT JOIN predictions p ON m.id = p.market_id
+WHERE m.archived = false
+  AND m.status = 'active'
+GROUP BY m.id, m.question, m.status, m.resolution_time, m.winning_outcome, m.metadata;
+
+-- Unique index required for CONCURRENTLY refresh
+CREATE UNIQUE INDEX IF NOT EXISTS idx_market_trends_mv_id ON market_trends_mv(id);
+-- Index for trending sort order
+CREATE INDEX IF NOT EXISTS idx_market_trends_mv_activity ON market_trends_mv(total_predictions DESC, total_volume DESC);

--- a/src/routes/markets.ts
+++ b/src/routes/markets.ts
@@ -3,12 +3,14 @@ import { listMarkets, getMarketById, updateMarket, VersionConflictError } from "
 import { searchMarkets } from "../repositories/marketRepository";
 import { requireAdmin, AuthenticatedRequest } from "../middleware/auth";
 import { rateLimitAnon } from "../middleware/rateLimitAnon";
+import { trendingRouter } from "./markets/trending";
 import { z } from "zod";
 import { logger } from "../config/logger";
 
 export const marketsRouter = Router();
 
 marketsRouter.use(rateLimitAnon);
+marketsRouter.use("/trending", trendingRouter);
 
 const patchMarketSchema = z.object({
   question: z.string().optional(),

--- a/src/routes/markets/trending.ts
+++ b/src/routes/markets/trending.ts
@@ -1,0 +1,24 @@
+import { Router } from "express";
+import { z } from "zod";
+import { getTrending } from "../../services/trendingService";
+import { rateLimitAnon } from "../../middleware/rateLimitAnon";
+
+export const trendingRouter = Router();
+
+trendingRouter.use(rateLimitAnon);
+
+const trendingQuerySchema = z.object({
+  limit: z.coerce.number().int().positive().max(100).default(20),
+  offset: z.coerce.number().int().nonnegative().default(0),
+});
+
+// GET /api/markets/trending - Get trending markets
+trendingRouter.get("/", async (req, res, next) => {
+  try {
+    const { limit, offset } = trendingQuerySchema.parse(req.query);
+    const data = await getTrending(limit, offset);
+    res.json({ data, meta: { limit, offset, count: data.length } });
+  } catch (e) {
+    next(e);
+  }
+});

--- a/src/services/trendingService.ts
+++ b/src/services/trendingService.ts
@@ -1,0 +1,40 @@
+import { db } from "../db";
+import { sql } from "drizzle-orm";
+
+export interface TrendingMarket extends Record<string, unknown> {
+  id: string;
+  question: string;
+  status: string;
+  resolution_time: Date;
+  winning_outcome: string | null;
+  metadata: unknown;
+  total_predictions: number;
+  total_volume: number;
+}
+
+/**
+ * Refresh the trending markets materialized view.
+ * Provided for external scheduling (e.g., pg_cron, Kubernetes CronJob).
+ */
+export async function refreshTrending(): Promise<void> {
+  await db.execute(sql`REFRESH MATERIALIZED VIEW CONCURRENTLY market_trends_mv`);
+}
+
+/**
+ * Get trending markets ordered by prediction count and volume.
+ * @param limit - Maximum number of entries to return (default: 20, max: 100)
+ * @param offset - Number of entries to skip (default: 0)
+ */
+export async function getTrending(
+  limit: number = 20,
+  offset: number = 0
+): Promise<TrendingMarket[]> {
+  const result = await db.execute<TrendingMarket>(
+    sql`SELECT id, question, status, resolution_time, winning_outcome, metadata,
+               total_predictions, total_volume
+        FROM market_trends_mv
+        ORDER BY total_predictions DESC, total_volume DESC
+        LIMIT ${limit} OFFSET ${offset}`
+  );
+  return result.rows;
+}

--- a/tests/markets-trending.test.ts
+++ b/tests/markets-trending.test.ts
@@ -1,0 +1,104 @@
+import request from "supertest";
+import { createApp } from "../src/index";
+import * as trendingService from "../src/services/trendingService";
+
+jest.mock("../src/services/trendingService");
+
+const mockedService = jest.mocked(trendingService);
+
+const mockTrendingMarkets = [
+  {
+    id: "market-1",
+    question: "Will ETH hit 5k?",
+    status: "active",
+    resolution_time: new Date("2026-08-01T00:00:00.000Z"),
+    winning_outcome: null,
+    metadata: {},
+    total_predictions: 120,
+    total_volume: 5000,
+  },
+  {
+    id: "market-2",
+    question: "Will BTC ETF be approved?",
+    status: "active",
+    resolution_time: new Date("2026-09-01T00:00:00.000Z"),
+    winning_outcome: null,
+    metadata: { source: "news" },
+    total_predictions: 85,
+    total_volume: 3200,
+  },
+];
+
+describe("GET /api/markets/trending", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns trending markets with correct shape", async () => {
+    mockedService.getTrending.mockResolvedValue(mockTrendingMarkets as any);
+
+    const res = await request(createApp()).get("/api/markets/trending");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data[0].id).toBe("market-1");
+    expect(res.body.meta).toEqual({
+      limit: 20,
+      offset: 0,
+      count: 2,
+    });
+  });
+
+  it("returns empty array when no markets exist", async () => {
+    mockedService.getTrending.mockResolvedValue([]);
+
+    const res = await request(createApp()).get("/api/markets/trending");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.meta.count).toBe(0);
+  });
+
+  it("respects limit query parameter", async () => {
+    mockedService.getTrending.mockResolvedValue([mockTrendingMarkets[0]] as any);
+
+    const res = await request(createApp()).get("/api/markets/trending?limit=5");
+
+    expect(res.status).toBe(200);
+    expect(mockedService.getTrending).toHaveBeenCalledWith(5, 0);
+    expect(res.body.meta.limit).toBe(5);
+  });
+
+  it("respects offset query parameter", async () => {
+    mockedService.getTrending.mockResolvedValue([mockTrendingMarkets[1]] as any);
+
+    const res = await request(createApp()).get("/api/markets/trending?offset=10");
+
+    expect(res.status).toBe(200);
+    expect(mockedService.getTrending).toHaveBeenCalledWith(20, 10);
+    expect(res.body.meta.offset).toBe(10);
+  });
+
+  it("rejects limit greater than 100", async () => {
+    const res = await request(createApp()).get("/api/markets/trending?limit=101");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it("rejects negative offset", async () => {
+    const res = await request(createApp()).get("/api/markets/trending?offset=-1");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it("returns 500 on database error", async () => {
+    mockedService.getTrending.mockRejectedValue(new Error("DB connection failed"));
+
+    const res = await request(createApp()).get("/api/markets/trending");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Description

Closes #181

### Summary

This PR adds a new **`/api/markets/trending`** endpoint backed by a PostgreSQL materialized view to efficiently serve the most active markets.

The implementation follows the existing `leaderboard_mv` architecture already used in the project, keeping the change small, focused, and easy to review.

### Changes

* Added `market_trends_mv` materialized view migration
* Added `trendingService.ts` for querying and refreshing the materialized view
* Added `GET /api/markets/trending`
* Mounted the new route under the existing markets router
* Added focused tests covering:

  * successful responses
  * empty results
  * pagination (`limit` / `offset`)
  * invalid query parameters
  * database failure handling

### Trending Ranking

Markets are currently ordered by:

1. `total_predictions DESC`
2. `total_volume DESC`

This provides a simple and deterministic activity-based ranking while remaining easy to adjust if the project adopts a different heuristic in the future.

### Materialized View Refresh

The repository already exposes refresh helpers for materialized views but does not currently run a background refresh scheduler.

This PR follows the existing project pattern by providing:

* `refreshTrending()`

without introducing any new scheduler, background worker, or environment configuration.

### API

**New endpoint**

```
GET /api/markets/trending
```

**Supported query parameters**

* `limit` (default: 20, max: 100)
* `offset` (default: 0)

### Testing

Implemented focused tests covering:

* [x] Returns trending markets
* [x] Returns an empty array when no markets exist
* [x] Pagination (`limit` / `offset`)
* [x] Invalid query parameter validation
* [x] Database error handling

### Verification

* [x] New files pass linting
* [x] Trending endpoint tests pass (7/7)
* [x] Existing market endpoint tests continue to pass
* [x] No regressions introduced
* [x] Migration follows the existing `leaderboard_mv` style

### Notes

This PR intentionally does **not** introduce a background scheduler. It follows the current repository architecture and keeps scheduling concerns separate from the API implementation.
