### PR TITLE
Add /api/admin/audit/export streaming endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Once running:
 
 - **Swagger UI** → http://localhost:3000/docs *(non-production only; set `ENABLE_DOCS=true` to enable in production)*
 - **OpenAPI JSON** → http://localhost:3000/openapi.json *(always available)*
+- **Audit export** → `GET /api/admin/audit/export` streams admin audit logs as `application/x-ndjson`
 
 ## Indexer gap scan
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { createDocsRouter } from "./routes/docs";
 import { notificationsRouter } from "./routes/notifications";
 import { socialRouter } from "./routes/social";
 import { adminAuditRouter } from "./routes/admin/audit";
+import { adminAuditExportRouter } from "./routes/admin/audit/export";
 import { errorHandler } from "./middleware/errorHandler";
 import { requestContextStorage } from "./lib/requestContext";
 import { REQUEST_ID_HEADER } from "./lib/http";
@@ -92,6 +93,8 @@ export function createApp(): express.Express {
   app.use("/api/users", socialRouter);
   app.use("/api/users", usersRouter);
   app.use("/api/admin/audit", adminAuditRouter);
+  app.use("/api/admin/audit", adminAuditExportRouter);
+
 
   app.get("/metrics", async (req, res) => {
     const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;

--- a/src/openapi/registry.ts
+++ b/src/openapi/registry.ts
@@ -573,3 +573,43 @@ registry.registerPath({
     },
   },
 });
+
+registry.registerPath({
+  method: "get",
+  path: "/api/admin/audit/export",
+  tags: ["Admin"],
+  summary: "Export audit log as NDJSON",
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: z.object({
+      action: z.string().optional(),
+      actor: z.string().optional(),
+      startDate: z.string().datetime().optional(),
+      endDate: z.string().datetime().optional(),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Audit log export stream in NDJSON format",
+      content: {
+        "application/x-ndjson": { schema: z.string() },
+      },
+    },
+    400: {
+      description: "Validation error",
+      content: { "application/json": { schema: ValidationErrorBody } },
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    403: {
+      description: "Forbidden",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    429: {
+      description: "Rate limit exceeded",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+  },
+});

--- a/src/repositories/auditLogRepo.ts
+++ b/src/repositories/auditLogRepo.ts
@@ -79,3 +79,45 @@ export async function getAuditLogs(filters: AuditLogFilters): Promise<Page<Audit
         : null,
   };
 }
+
+
+
+
+/**
+ * Stream audit logs matching the given filter criteria using an async generator.
+ *
+ * Fetches all matching records from the database and yields them one by one.
+ * For very large datasets, consider implementing cursor-based batching.
+ *
+ * @param filters - Filter criteria (without pagination fields)
+ * @returns An async generator yielding AuditLogItem objects
+ */
+export async function* getAuditLogsStream(
+  filters: Omit<AuditLogFilters, 'cursor' | 'limit'>,
+): AsyncGenerator<AuditLogItem, void, undefined> {
+  const conditions = [];
+  if (filters.action) {
+    conditions.push(eq(auditLogs.action, filters.action));
+  }
+  if (filters.actor) {
+    conditions.push(eq(auditLogs.walletAddress, filters.actor));
+  }
+  if (filters.startDate) {
+    conditions.push(gte(auditLogs.createdAt, filters.startDate));
+  }
+  if (filters.endDate) {
+    conditions.push(lte(auditLogs.createdAt, filters.endDate));
+  }
+
+  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+  const rows = await db
+    .select()
+    .from(auditLogs)
+    .where(whereClause)
+    .orderBy(desc(auditLogs.createdAt), desc(auditLogs.id));
+
+  for (const row of rows) {
+    yield row as AuditLogItem;
+  }
+}

--- a/src/routes/admin/audit/export.ts
+++ b/src/routes/admin/audit/export.ts
@@ -1,0 +1,212 @@
+import { Router } from "express";
+import { rateLimit } from "express-rate-limit";
+import { z } from "zod";
+import { Transform } from "stream";
+import { requireAdmin } from "../../../middleware/requireAdmin";
+import { getAuditLogsStream } from "../../../repositories/auditLogRepo";
+import { getRequestId } from "../../../lib/requestContext";
+import { logger } from "../../../config/logger";
+
+export interface AdminAuditExportRouterOptions {
+  rateLimitPerMinute?: number;
+  maxRecords?: number;
+}
+
+const exportQuerySchema = z.object({
+  action: z.string().optional(),
+  actor: z.string().optional(),
+  startDate: z.string()
+    .datetime({ message: "startDate must be a valid ISO 8601 datetime string" })
+    .transform((val) => new Date(val))
+    .optional(),
+  endDate: z.string()
+    .datetime({ message: "endDate must be a valid ISO 8601 datetime string" })
+    .transform((val) => new Date(val))
+    .optional(),
+});
+
+export function createAdminAuditExportRouter(
+  opts: AdminAuditExportRouterOptions = {},
+): Router {
+  const router = Router();
+  const rateLimitPerMinute = opts.rateLimitPerMinute ?? 10;
+  const maxRecords = opts.maxRecords ?? 100_000;
+
+  router.use(
+    rateLimit({
+      windowMs: 60_000,
+      limit: rateLimitPerMinute,
+      keyGenerator: (req) =>
+        (req.headers.authorization as string | undefined) ?? req.ip ?? "unknown",
+      standardHeaders: "draft-6",
+      legacyHeaders: false,
+      message: { error: { code: "rate_limit_exceeded" } },
+    }),
+  );
+
+  router.use(requireAdmin);
+
+  router.get("/export", async (req, res, next) => {
+    const requestId = getRequestId();
+
+    try {
+      const parseResult = exportQuerySchema.safeParse(req.query);
+      if (!parseResult.success) {
+        const reqId = getRequestId();
+        res.status(400).json({
+          error: {
+            code: "validation_error",
+            message: parseResult.error.issues[0]?.message ?? "invalid query parameters",
+            requestId: reqId,
+          },
+        });
+        return;
+      }
+
+      const filters = parseResult.data;
+
+      logger.info(
+        {
+          event: "audit_export_started",
+          requestId,
+          adminAddress: req.adminAddress,
+          filters,
+        },
+        "Starting audit log export stream",
+      );
+
+      res.setHeader("Content-Type", "application/x-ndjson");
+      res.setHeader("X-Content-Type-Options", "nosniff");
+      res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate");
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="audit-export-${Date.now()}.ndjson"`,
+      );
+
+      let recordCount = 0;
+
+      const ndjsonTransform = new Transform({
+        writableObjectMode: true,
+        readableObjectMode: false,
+        transform(chunk: unknown, _encoding, callback) {
+          try {
+            const line = JSON.stringify(chunk) + "\n";
+            callback(null, line);
+          } catch (err) {
+            callback(err instanceof Error ? err : new Error(String(err)));
+          }
+        },
+      });
+
+      ndjsonTransform.on("error", (err) => {
+        logger.error(
+          {
+            event: "audit_export_stream_error",
+            requestId,
+            error: err.message,
+          },
+          "Error in NDJSON transform stream",
+        );
+      });
+
+      ndjsonTransform.pipe(res);
+
+      const stream = getAuditLogsStream(filters);
+
+      (async () => {
+        try {
+          for await (const record of stream) {
+            recordCount++;
+
+            if (recordCount > maxRecords) {
+              ndjsonTransform.end();
+              logger.warn(
+                {
+                  event: "audit_export_max_records_reached",
+                  requestId,
+                  maxRecords,
+                },
+                "Audit export reached maximum record limit",
+              );
+              return;
+            }
+
+            if (recordCount % 10_000 === 0) {
+              logger.info(
+                {
+                  event: "audit_export_progress",
+                  requestId,
+                  recordCount,
+                },
+                "Audit export streaming progress",
+              );
+            }
+
+            ndjsonTransform.write(record);
+          }
+
+          ndjsonTransform.end();
+          logger.info(
+            {
+              event: "audit_export_completed",
+              requestId,
+              recordCount,
+            },
+            "Audit export stream completed successfully",
+          );
+        } catch (err) {
+          logger.error(
+            {
+              event: "audit_export_db_stream_error",
+              requestId,
+              error: err instanceof Error ? err.message : String(err),
+            },
+            "Error streaming audit logs for export",
+          );
+
+          if (!res.headersSent) {
+            res.status(500).json({
+              error: {
+                code: "export_error",
+                message: "Failed to stream audit logs",
+                requestId,
+              },
+            });
+          } else {
+            ndjsonTransform.destroy(
+              err instanceof Error ? err : new Error(String(err)),
+            );
+          }
+        }
+      })();
+
+      req.on("close", () => {
+        if (!res.writableEnded) {
+          logger.info(
+            {
+              event: "audit_export_client_disconnect",
+              requestId,
+              recordCount,
+            },
+            "Client disconnected before audit export completed",
+          );
+          ndjsonTransform.destroy();
+        }
+      });
+    } catch (err) {
+      logger.error(
+        {
+          event: "audit_export_unexpected_error",
+          requestId,
+          error: err instanceof Error ? err.message : String(err),
+        },
+        "Unexpected error in audit export endpoint",
+      );
+      next(err);
+    }
+  });
+
+  return router;
+}
+
+export const adminAuditExportRouter = createAdminAuditExportRouter();

--- a/src/routes/admin/audit/index.ts
+++ b/src/routes/admin/audit/index.ts
@@ -1,0 +1,86 @@
+import { Router } from "express";
+import { rateLimit } from "express-rate-limit";
+import { z } from "zod";
+import { requireAdmin } from "../../../middleware/requireAdmin";
+import { getAuditLogs } from "../../../repositories/auditLogRepo";
+import { getRequestId } from "../../../lib/requestContext";
+
+export interface AdminAuditRouterOptions {
+  /** Requests per minute per admin token. Default: 60 */
+  rateLimitPerMinute?: number;
+}
+
+const auditQuerySchema = z.object({
+  action: z.string().optional(),
+  actor: z.string().optional(),
+  startDate: z.string()
+    .datetime({ message: "startDate must be a valid ISO 8601 datetime string" })
+    .transform((val) => new Date(val))
+    .optional(),
+  endDate: z.string()
+    .datetime({ message: "endDate must be a valid ISO 8601 datetime string" })
+    .transform((val) => new Date(val))
+    .optional(),
+  cursor: z.string().optional(),
+  limit: z.string()
+    .regex(/^\d+$/, { message: "limit must be a positive integer" })
+    .transform((val) => parseInt(val, 10))
+    .optional(),
+});
+
+export function createAdminAuditRouter(opts: AdminAuditRouterOptions = {}): Router {
+  const router = Router();
+  const limit = opts.rateLimitPerMinute ?? 60;
+
+  // ── Rate limiter ────────────────────────────────────────────────────────────
+  // Key on the raw Authorization header so each distinct admin token gets its
+  // own bucket. Falls back to IP for unauthenticated requests so they are
+  // still throttled before reaching requireAdmin.
+  router.use(
+    rateLimit({
+      windowMs: 60_000,
+      limit,
+      keyGenerator: (req) =>
+        (req.headers.authorization as string | undefined) ?? req.ip ?? "unknown",
+      standardHeaders: "draft-6",
+      legacyHeaders: false,
+      message: { error: { code: "rate_limit_exceeded" } },
+    }),
+  );
+
+  // ── Admin guard ─────────────────────────────────────────────────────────────
+  router.use(requireAdmin);
+
+  // ── GET / ───────────────────────────────────────────────────────────────────
+  router.get("/", async (req, res, next) => {
+    try {
+      const parseResult = auditQuerySchema.safeParse(req.query);
+      if (!parseResult.success) {
+        const reqId = getRequestId();
+        res.status(400).json({
+          error: {
+            code: "validation_error",
+            message: parseResult.error.issues[0]?.message ?? "invalid query parameters",
+            requestId: reqId,
+          },
+        });
+        return;
+      }
+
+      const filters = parseResult.data;
+      const page = await getAuditLogs(filters);
+
+      res.json({
+        data: page.data,
+        nextCursor: page.nextCursor,
+      });
+    } catch (e) {
+      next(e);
+    }
+  });
+
+  return router;
+}
+
+// Default export wired into src/index.ts
+export const adminAuditRouter = createAdminAuditRouter();

--- a/tests/adminAudit.test.ts
+++ b/tests/adminAudit.test.ts
@@ -2,14 +2,16 @@ import request from "supertest";
 import express from "express";
 import jwt from "jsonwebtoken";
 import { createAdminAuditRouter } from "../src/routes/admin/audit";
+import { createAdminAuditExportRouter } from "../src/routes/admin/audit/export";
 import { errorHandler } from "../src/middleware/errorHandler";
 
 // ── Mock Repository ─────────────────────────────────────────────────────────
 
 jest.mock("../src/repositories/auditLogRepo");
 
-import { getAuditLogs } from "../src/repositories/auditLogRepo";
+import { getAuditLogs, getAuditLogsStream } from "../src/repositories/auditLogRepo";
 const mockGetAuditLogs = getAuditLogs as jest.MockedFunction<typeof getAuditLogs>;
+const mockGetAuditLogsStream = getAuditLogsStream as jest.MockedFunction<typeof getAuditLogsStream>;
 
 // ── DB Mock (Prevents connection at import time) ─────────────────────────────
 
@@ -33,10 +35,11 @@ const userJwt  = signJwt({ sub: USER_ADDRESS,  role: "user" });
 
 // ── App Factory ──────────────────────────────────────────────────────────────
 
-function makeApp(rateLimitPerMinute = 60): express.Express {
+function makeApp(rateLimitPerMinute = 60, maxRecords = 100_000): express.Express {
   const app = express();
   app.use(express.json());
   app.use("/api/admin/audit", createAdminAuditRouter({ rateLimitPerMinute }));
+  app.use("/api/admin/audit", createAdminAuditExportRouter({ rateLimitPerMinute, maxRecords }));
   app.use(errorHandler);
   return app;
 }
@@ -156,6 +159,117 @@ describe("GET /api/admin/audit", () => {
         ],
         nextCursor: null,
       });
+    });
+  });
+
+  describe("GET /api/admin/audit/export", () => {
+    it("returns 403 with no Authorization header", async () => {
+      const res = await request(makeApp()).get("/api/admin/audit/export");
+      expect(res.status).toBe(403);
+      expect(res.body).toEqual({ error: { code: "forbidden" } });
+    });
+
+    it("returns 403 with a non-admin JWT", async () => {
+      const res = await request(makeApp())
+        .get("/api/admin/audit/export")
+        .set("Authorization", `Bearer ${userJwt}`);
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 400 for invalid startDate format", async () => {
+      const res = await request(makeApp())
+        .get("/api/admin/audit/export?startDate=2024-01-01")
+        .set("Authorization", `Bearer ${adminJwt}`);
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+      expect(res.body.error.message).toContain("startDate must be a valid ISO 8601 datetime string");
+    });
+
+    it("returns 400 for invalid endDate format", async () => {
+      const res = await request(makeApp())
+        .get("/api/admin/audit/export?endDate=2024-13-45T25:00:00Z")
+        .set("Authorization", `Bearer ${adminJwt}`);
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+      expect(res.body.error.message).toContain("endDate must be a valid ISO 8601 datetime string");
+    });
+
+    it("streams audit records as NDJSON with correct headers", async () => {
+      mockGetAuditLogsStream.mockImplementation(async function* () {
+        yield {
+          id: "1",
+          action: "market.create",
+          walletAddress: ADMIN_ADDRESS,
+          ip: "127.0.0.1",
+          correlationId: "corr-1",
+          rateLimitContext: null,
+          createdAt: new Date("2026-06-27T12:00:00Z"),
+        };
+      });
+
+      const res = await request(makeApp())
+        .get("/api/admin/audit/export?action=market.create&actor=" + ADMIN_ADDRESS)
+        .set("Authorization", `Bearer ${adminJwt}`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toMatch(/application\/x-ndjson/);
+      expect(res.headers["x-content-type-options"]).toBe("nosniff");
+      expect(res.headers["content-disposition"]).toMatch(/^attachment; filename="audit-export-\d+\.ndjson"$/);
+      expect(res.text).toBe(
+        JSON.stringify({
+          id: "1",
+          action: "market.create",
+          walletAddress: ADMIN_ADDRESS,
+          ip: "127.0.0.1",
+          correlationId: "corr-1",
+          rateLimitContext: null,
+          createdAt: new Date("2026-06-27T12:00:00Z"),
+        }) + "\n",
+      );
+      expect(mockGetAuditLogsStream).toHaveBeenCalledWith({
+        action: "market.create",
+        actor: ADMIN_ADDRESS,
+      });
+    });
+
+    it("enforces maxRecords and stops streaming after the limit", async () => {
+      mockGetAuditLogsStream.mockImplementation(async function* () {
+        yield {
+          id: "1",
+          action: "market.create",
+          walletAddress: ADMIN_ADDRESS,
+          ip: "127.0.0.1",
+          correlationId: "corr-1",
+          rateLimitContext: null,
+          createdAt: new Date("2026-06-27T12:00:00Z"),
+        };
+        yield {
+          id: "2",
+          action: "market.update",
+          walletAddress: ADMIN_ADDRESS,
+          ip: "127.0.0.1",
+          correlationId: "corr-2",
+          rateLimitContext: null,
+          createdAt: new Date("2026-06-27T12:30:00Z"),
+        };
+      });
+
+      const res = await request(makeApp(60, 1))
+        .get("/api/admin/audit/export")
+        .set("Authorization", `Bearer ${adminJwt}`);
+
+      expect(res.status).toBe(200);
+      expect(res.text).toBe(
+        JSON.stringify({
+          id: "1",
+          action: "market.create",
+          walletAddress: ADMIN_ADDRESS,
+          ip: "127.0.0.1",
+          correlationId: "corr-1",
+          rateLimitContext: null,
+          createdAt: new Date("2026-06-27T12:00:00Z"),
+        }) + "\n",
+      );
     });
   });
 });


### PR DESCRIPTION
##closes #187 

`feat: streaming audit export`

## PR Description

- Adds a new admin export endpoint: `GET /api/admin/audit/export`
- Streams audit logs as `application/x-ndjson`
- Secures the endpoint with admin auth and rate limiting
- Adds focused tests covering:
  - auth guard
  - validation errors
  - NDJSON response headers
  - max-records enforcement
- Adds OpenAPI documentation for the new endpoint
- Adds README mention for the export route

## Testing

- `npm test -- tests/adminAudit.test.ts` ✅