### PR TITLE
fix: version audit cursor so it survives schema migrations

### DIFF
--- a/src/utils/cursor.ts
+++ b/src/utils/cursor.ts
@@ -29,6 +29,16 @@ export interface Page<T> {
 export const DEFAULT_PAGE_SIZE = 20;
 export const MAX_PAGE_SIZE = 100;
 
+/**
+ * Cursor wire-format version. Bump this whenever the meaning of the encoded
+ * `(sortValue, id)` pair changes (e.g. a schema migration that re-types or
+ * re-orders the sort columns). Cursors minted under a different version are
+ * rejected by `decodeCursor` (treated as invalid → restart from page one)
+ * instead of being silently re-interpreted, which previously let the keyset
+ * predicate advance to the wrong offset after a migration.
+ */
+export const CURSOR_VERSION = "v1";
+
 /** Clamp a user-supplied limit into a safe range. */
 export function clampLimit(raw: unknown, fallback = DEFAULT_PAGE_SIZE): number {
   const n = typeof raw === "string" ? parseInt(raw, 10) : typeof raw === "number" ? raw : NaN;
@@ -38,7 +48,9 @@ export function clampLimit(raw: unknown, fallback = DEFAULT_PAGE_SIZE): number {
 
 /** Encode a cursor key to an opaque, URL-safe string. */
 export function encodeCursor(key: CursorKey): string {
-  return Buffer.from(`${key.sortValue}|${key.id}`, "utf8").toString("base64url");
+  return Buffer.from(`${CURSOR_VERSION}|${key.sortValue}|${key.id}`, "utf8").toString(
+    "base64url",
+  );
 }
 
 /**
@@ -50,10 +62,18 @@ export function decodeCursor(raw: unknown): CursorKey | null {
   if (typeof raw !== "string" || raw.length === 0) return null;
   try {
     const decoded = Buffer.from(raw, "base64url").toString("utf8");
-    const sep = decoded.indexOf("|");
+    // Versioned format: "<version>|<sortValue>|<id>". The version guards against
+    // re-interpreting a cursor whose encoding changed across a schema migration.
+    const firstSep = decoded.indexOf("|");
+    if (firstSep === -1) return null;
+    const version = decoded.slice(0, firstSep);
+    if (version !== CURSOR_VERSION) return null;
+
+    const rest = decoded.slice(firstSep + 1);
+    const sep = rest.indexOf("|");
     if (sep === -1) return null;
-    const sortValue = decoded.slice(0, sep);
-    const id = decoded.slice(sep + 1);
+    const sortValue = rest.slice(0, sep);
+    const id = rest.slice(sep + 1);
     if (!sortValue || !id) return null;
     return { sortValue, id };
   } catch {

--- a/tests/cursor.test.ts
+++ b/tests/cursor.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for the shared keyset cursor helper, focusing on the versioned wire
+ * format that keeps pagination correct across schema migrations.
+ */
+import {
+  CURSOR_VERSION,
+  decodeCursor,
+  encodeCursor,
+  type CursorKey,
+} from "../src/utils/cursor";
+
+describe("cursor encode/decode", () => {
+  const key: CursorKey = { sortValue: "2026-06-27T12:00:00.000Z", id: "abc-123" };
+
+  it("round-trips a cursor key", () => {
+    expect(decodeCursor(encodeCursor(key))).toEqual(key);
+  });
+
+  it("embeds the current cursor version in the encoded value", () => {
+    const decoded = Buffer.from(encodeCursor(key), "base64url").toString("utf8");
+    expect(decoded.startsWith(`${CURSOR_VERSION}|`)).toBe(true);
+  });
+
+  it("rejects a cursor minted under a different (legacy/migrated) version", () => {
+    // A pre-versioning cursor "<sortValue>|<id>" must not be re-interpreted.
+    const legacy = Buffer.from(`${key.sortValue}|${key.id}`, "utf8").toString("base64url");
+    expect(decodeCursor(legacy)).toBeNull();
+
+    const otherVersion = Buffer.from(
+      `v0|${key.sortValue}|${key.id}`,
+      "utf8",
+    ).toString("base64url");
+    expect(decodeCursor(otherVersion)).toBeNull();
+  });
+
+  it("returns null for missing, empty, or malformed cursors", () => {
+    expect(decodeCursor(undefined)).toBeNull();
+    expect(decodeCursor("")).toBeNull();
+    expect(decodeCursor(123)).toBeNull();
+    expect(decodeCursor(encodeCursor({ ...key, id: "" }))).toBeNull();
+  });
+
+  it("preserves sortValues that themselves contain a separator", () => {
+    const weird: CursorKey = { sortValue: "a|b|c", id: "id|1" };
+    expect(decodeCursor(encodeCursor(weird))).toEqual(weird);
+  });
+});


### PR DESCRIPTION
Closes #218.

The keyset cursor used by `/api/admin/audit` encoded only `sortValue|id` with no format marker, so a cursor minted before a schema change could be silently re-interpreted and advance to the wrong offset. This adds a `CURSOR_VERSION` tag to the encoded cursor; `decodeCursor` now rejects cursors from any other version (returning null → safe restart from page one) instead of mis-advancing. Adds focused tests in `tests/cursor.test.ts`.