### PR TITLE
feat: add GET /api/markets/:id/audit endpoint

### DIFF
--- a/src/routes/marketAudit.ts
+++ b/src/routes/marketAudit.ts
@@ -1,0 +1,94 @@
+/**
+ * GET /api/markets/:id/audit — per-market audit log (#216).
+ *
+ * Returns structured audit entries for a single market (admin moderation
+ * actions, updates, etc.), newest first, with keyset pagination. The market
+ * must exist; otherwise a 404 is returned so callers can distinguish an
+ * unknown market from one that simply has no audit history.
+ */
+import { Router } from "express";
+import { and, desc, eq, lt, or } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "../db";
+import { markets, marketAuditLog } from "../db/schema";
+import { clampLimit, decodeCursor, encodeCursor } from "../utils/cursor";
+import { logger } from "../config/logger";
+
+const auditQuerySchema = z
+  .object({
+    cursor: z.string().optional(),
+    limit: z
+      .string()
+      .regex(/^\d+$/, { message: "limit must be a positive integer" })
+      .optional(),
+  })
+  .strict();
+
+export const marketAuditRouter = Router({ mergeParams: true });
+
+marketAuditRouter.get("/", async (req, res, next) => {
+  const reqId = String((req as { id?: string }).id ?? "anon");
+  try {
+    const parsed = auditQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: {
+          code: "validation_error",
+          message: parsed.error.issues[0]?.message ?? "invalid query parameters",
+          requestId: reqId,
+        },
+      });
+    }
+
+    const marketId = req.params.id as string;
+    const exists = await db
+      .select({ id: markets.id })
+      .from(markets)
+      .where(eq(markets.id, marketId))
+      .limit(1);
+    if (exists.length === 0) {
+      return res.status(404).json({ error: { code: "not_found" } });
+    }
+
+    const take = clampLimit(parsed.data.limit);
+    const key = decodeCursor(parsed.data.cursor);
+
+    // Keyset predicate for DESC (createdAt, id).
+    const cursorPredicate = key
+      ? or(
+          lt(marketAuditLog.createdAt, new Date(key.sortValue)),
+          and(
+            eq(marketAuditLog.createdAt, new Date(key.sortValue)),
+            lt(marketAuditLog.id, key.id),
+          ),
+        )
+      : undefined;
+
+    const rows = await db
+      .select()
+      .from(marketAuditLog)
+      .where(
+        cursorPredicate
+          ? and(eq(marketAuditLog.marketId, marketId), cursorPredicate)
+          : eq(marketAuditLog.marketId, marketId),
+      )
+      .orderBy(desc(marketAuditLog.createdAt), desc(marketAuditLog.id))
+      .limit(take + 1);
+
+    const hasMore = rows.length > take;
+    const data = hasMore ? rows.slice(0, take) : rows;
+    const last = data[data.length - 1];
+
+    logger.info({ reqId, marketId, count: data.length }, "market_audit_listed");
+
+    return res.json({
+      data,
+      nextCursor:
+        hasMore && last
+          ? encodeCursor({ sortValue: last.createdAt.toISOString(), id: last.id })
+          : null,
+    });
+  } catch (err) {
+    return next(err);
+  }
+});

--- a/src/routes/markets.ts
+++ b/src/routes/markets.ts
@@ -3,12 +3,16 @@ import { listMarkets, getMarketById, updateMarket, VersionConflictError } from "
 import { searchMarkets } from "../repositories/marketRepository";
 import { requireAdmin, AuthenticatedRequest } from "../middleware/auth";
 import { rateLimitAnon } from "../middleware/rateLimitAnon";
+import { marketAuditRouter } from "./marketAudit";
 import { z } from "zod";
 import { logger } from "../config/logger";
 
 export const marketsRouter = Router();
 
 marketsRouter.use(rateLimitAnon);
+
+// Per-market audit log: GET /api/markets/:id/audit (#216)
+marketsRouter.use("/:id/audit", marketAuditRouter);
 
 const patchMarketSchema = z.object({
   question: z.string().optional(),

--- a/tests/marketAudit.test.ts
+++ b/tests/marketAudit.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for GET /api/markets/:id/audit (#216).
+ * The DB is mocked; we assert existence handling, shape, and pagination.
+ */
+import request from "supertest";
+import express from "express";
+
+// Queue of results returned by successive `.limit(...)` terminal calls.
+const limitResults: unknown[][] = [];
+
+jest.mock("../src/db", () => {
+  const chain = {
+    select: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn(() => Promise.resolve(limitResults.shift() ?? [])),
+  };
+  return { db: chain };
+});
+
+jest.mock("../src/config/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { marketAuditRouter } from "../src/routes/marketAudit";
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  // Mirror how marketsRouter mounts it.
+  app.use("/api/markets/:id/audit", marketAuditRouter);
+  return app;
+}
+
+describe("GET /api/markets/:id/audit", () => {
+  beforeEach(() => {
+    limitResults.length = 0;
+  });
+
+  it("returns 404 when the market does not exist", async () => {
+    limitResults.push([]); // existence check → no rows
+    const res = await request(makeApp()).get("/api/markets/missing/audit");
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("not_found");
+  });
+
+  it("returns 400 for a malformed limit", async () => {
+    const res = await request(makeApp()).get("/api/markets/m1/audit?limit=abc");
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("returns audit entries with a nextCursor when more remain", async () => {
+    const now = new Date("2026-06-27T12:00:00.000Z");
+    limitResults.push([{ id: "m1" }]); // existence check
+    limitResults.push([
+      { id: "a1", marketId: "m1", action: "update", createdAt: now },
+      { id: "a2", marketId: "m1", action: "disable", createdAt: now },
+    ]); // list with take=1 → hasMore
+
+    const res = await request(makeApp()).get("/api/markets/m1/audit?limit=1");
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe("a1");
+    expect(res.body.nextCursor).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #216.

Adds a per-market audit log endpoint that returns structured entries from `market_audit_log` for a single market, newest first, with the shared keyset cursor pagination. Unknown markets get a 404 so callers can distinguish them from markets with no audit history. Implemented in `src/routes/marketAudit.ts` and mounted on `marketsRouter` at `/:id/audit`; includes route tests.