### PR TITLE
feat: add GET /api/me/devices endpoint listing active sessions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { createDocsRouter } from "./routes/docs";
 import { notificationsRouter } from "./routes/notifications";
 import { socialRouter } from "./routes/social";
 import { adminAuditRouter } from "./routes/admin/audit";
+import { devicesRouter } from "./routes/devices";
 import { errorHandler } from "./middleware/errorHandler";
 import { requestContextStorage } from "./lib/requestContext";
 import { REQUEST_ID_HEADER } from "./lib/http";
@@ -91,6 +92,7 @@ export function createApp(): express.Express {
   app.use("/api/notifications", notificationsRouter);
   app.use("/api/users", socialRouter);
   app.use("/api/users", usersRouter);
+  app.use("/api/me/devices", devicesRouter);
   app.use("/api/admin/audit", adminAuditRouter);
 
   app.get("/metrics", async (req, res) => {

--- a/src/routes/devices.ts
+++ b/src/routes/devices.ts
@@ -1,0 +1,74 @@
+/**
+ * GET /api/me/devices — list active sessions/devices (#214).
+ *
+ * Each refresh-token "family" represents one logged-in device/session. A
+ * device is considered active when it has at least one refresh token that has
+ * not been revoked and has not expired. We never return token hashes — only
+ * non-sensitive metadata the user needs to recognise and manage a session.
+ */
+import { Router, type Response, type NextFunction } from "express";
+import { and, eq, gt, isNull } from "drizzle-orm";
+import { db } from "../db";
+import { refreshTokens } from "../db/schema";
+import { requireAuth } from "../middleware/requireAuth";
+import { AuthenticatedRequest } from "../middleware/auth";
+import { logger } from "../config/logger";
+
+export interface DeviceSummary {
+  /** Session/device identifier (refresh-token family id). */
+  id: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export const devicesRouter = Router();
+
+devicesRouter.use(requireAuth);
+
+devicesRouter.get(
+  "/",
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.user!.id;
+
+      const rows = await db
+        .select({
+          familyId: refreshTokens.familyId,
+          createdAt: refreshTokens.createdAt,
+          expiresAt: refreshTokens.expiresAt,
+        })
+        .from(refreshTokens)
+        .where(
+          and(
+            eq(refreshTokens.userId, userId),
+            isNull(refreshTokens.revokedAt),
+            gt(refreshTokens.expiresAt, new Date()),
+          ),
+        );
+
+      // Collapse the token rows into one entry per device/session family,
+      // keeping the most recent activity for each.
+      const byFamily = new Map<string, DeviceSummary>();
+      for (const row of rows) {
+        const existing = byFamily.get(row.familyId);
+        if (!existing || row.createdAt > new Date(existing.createdAt)) {
+          byFamily.set(row.familyId, {
+            id: row.familyId,
+            createdAt: row.createdAt.toISOString(),
+            expiresAt: row.expiresAt.toISOString(),
+          });
+        }
+      }
+
+      const devices = Array.from(byFamily.values()).sort((a, b) =>
+        a.createdAt < b.createdAt ? 1 : -1,
+      );
+
+      logger.info({ userId, count: devices.length }, "me_devices_listed");
+
+      return res.json({ data: { devices } });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);

--- a/tests/devices.test.ts
+++ b/tests/devices.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for GET /api/me/devices (#214).
+ * requireAuth and the DB are mocked; we assert session-family collapsing and
+ * that token hashes are never leaked.
+ */
+import request from "supertest";
+import express from "express";
+
+let whereResult: unknown[] = [];
+
+jest.mock("../src/db", () => {
+  const chain = {
+    select: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn(() => Promise.resolve(whereResult)),
+  };
+  return { db: chain };
+});
+
+jest.mock("../src/middleware/requireAuth", () => ({
+  requireAuth: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    (req as express.Request & { user: { id: string } }).user = { id: "user-1" };
+    next();
+  },
+}));
+
+jest.mock("../src/config/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { devicesRouter } from "../src/routes/devices";
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/me/devices", devicesRouter);
+  return app;
+}
+
+describe("GET /api/me/devices", () => {
+  beforeEach(() => {
+    whereResult = [];
+  });
+
+  it("collapses refresh-token families into one device each, newest first", async () => {
+    const older = new Date("2026-06-20T00:00:00.000Z");
+    const newer = new Date("2026-06-27T00:00:00.000Z");
+    const exp = new Date("2026-07-27T00:00:00.000Z");
+    whereResult = [
+      { familyId: "fam-a", createdAt: older, expiresAt: exp },
+      { familyId: "fam-a", createdAt: newer, expiresAt: exp }, // rotation within same session
+      { familyId: "fam-b", createdAt: older, expiresAt: exp },
+    ];
+
+    const res = await request(makeApp()).get("/api/me/devices");
+
+    expect(res.status).toBe(200);
+    const devices = res.body.data.devices as Array<{ id: string; createdAt: string }>;
+    expect(devices).toHaveLength(2);
+    expect(devices[0].id).toBe("fam-a"); // newest session first
+    expect(devices[0].createdAt).toBe(newer.toISOString());
+    // No token material leaked.
+    expect(JSON.stringify(res.body)).not.toContain("tokenHash");
+  });
+
+  it("returns an empty list when there are no active sessions", async () => {
+    const res = await request(makeApp()).get("/api/me/devices");
+    expect(res.status).toBe(200);
+    expect(res.body.data.devices).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #214.

Adds `GET /api/me/devices` (auth required) which lists the caller's active sessions/devices. Each refresh-token family is treated as one device; only non-revoked, non-expired tokens count, and rows are collapsed to one entry per family with the most recent activity. Returns only non-sensitive metadata (id, createdAt, expiresAt) — never token hashes. Wired into `src/index.ts`; includes route tests.