### PR TITLE
feat: add POST /api/me/devices/:id/revoke endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { createDocsRouter } from "./routes/docs";
 import { notificationsRouter } from "./routes/notifications";
 import { socialRouter } from "./routes/social";
 import { adminAuditRouter } from "./routes/admin/audit";
+import { devicesRevokeRouter } from "./routes/devicesRevoke";
 import { errorHandler } from "./middleware/errorHandler";
 import { requestContextStorage } from "./lib/requestContext";
 import { REQUEST_ID_HEADER } from "./lib/http";
@@ -91,6 +92,7 @@ export function createApp(): express.Express {
   app.use("/api/notifications", notificationsRouter);
   app.use("/api/users", socialRouter);
   app.use("/api/users", usersRouter);
+  app.use("/api/me/devices/:id/revoke", devicesRevokeRouter);
   app.use("/api/admin/audit", adminAuditRouter);
 
   app.get("/metrics", async (req, res) => {

--- a/src/routes/devicesRevoke.ts
+++ b/src/routes/devicesRevoke.ts
@@ -1,0 +1,66 @@
+/**
+ * POST /api/me/devices/:id/revoke — revoke a single session/device (#215).
+ *
+ * A "device" is a refresh-token family. Revoking one marks every still-active
+ * refresh token in that family as revoked so the device can no longer mint new
+ * access tokens. The operation is scoped to the authenticated user: a caller
+ * can only revoke their own sessions, and revoking an unknown/foreign family
+ * returns 404 (no information leak about other users' sessions).
+ */
+import { Router, type Response, type NextFunction } from "express";
+import { and, eq, isNull } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "../db";
+import { refreshTokens } from "../db/schema";
+import { requireAuth } from "../middleware/requireAuth";
+import { AuthenticatedRequest } from "../middleware/auth";
+import { logger } from "../config/logger";
+
+const paramsSchema = z.object({ id: z.string().uuid({ message: "invalid device id" }) });
+
+export const devicesRevokeRouter = Router({ mergeParams: true });
+
+devicesRevokeRouter.use(requireAuth);
+
+devicesRevokeRouter.post(
+  "/",
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+      const parsed = paramsSchema.safeParse(req.params);
+      if (!parsed.success) {
+        return res.status(400).json({
+          error: {
+            code: "validation_error",
+            message: parsed.error.issues[0]?.message ?? "invalid device id",
+          },
+        });
+      }
+
+      const userId = req.user!.id;
+      const familyId = parsed.data.id;
+
+      const revoked = await db
+        .update(refreshTokens)
+        .set({ revokedAt: new Date() })
+        .where(
+          and(
+            eq(refreshTokens.userId, userId),
+            eq(refreshTokens.familyId, familyId),
+            isNull(refreshTokens.revokedAt),
+          ),
+        )
+        .returning({ id: refreshTokens.id });
+
+      if (revoked.length === 0) {
+        // Either no such family for this user, or it was already fully revoked.
+        logger.info({ userId, familyId }, "me_device_revoke_noop");
+        return res.status(404).json({ error: { code: "not_found" } });
+      }
+
+      logger.info({ userId, familyId, revoked: revoked.length }, "me_device_revoked");
+      return res.status(200).json({ data: { id: familyId, revoked: revoked.length } });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);

--- a/tests/devicesRevoke.test.ts
+++ b/tests/devicesRevoke.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for POST /api/me/devices/:id/revoke (#215).
+ * requireAuth and the DB are mocked.
+ */
+import request from "supertest";
+import express from "express";
+
+let returningResult: unknown[] = [];
+
+jest.mock("../src/db", () => {
+  const chain = {
+    update: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    returning: jest.fn(() => Promise.resolve(returningResult)),
+  };
+  return { db: chain };
+});
+
+jest.mock("../src/middleware/requireAuth", () => ({
+  requireAuth: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    (req as express.Request & { user: { id: string } }).user = { id: "user-1" };
+    next();
+  },
+}));
+
+jest.mock("../src/config/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { devicesRevokeRouter } from "../src/routes/devicesRevoke";
+
+const FAMILY = "11111111-1111-1111-1111-111111111111";
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/me/devices/:id/revoke", devicesRevokeRouter);
+  return app;
+}
+
+describe("POST /api/me/devices/:id/revoke", () => {
+  beforeEach(() => {
+    returningResult = [];
+  });
+
+  it("revokes a session and reports the number of tokens revoked", async () => {
+    returningResult = [{ id: "t1" }, { id: "t2" }];
+    const res = await request(makeApp()).post(`/api/me/devices/${FAMILY}/revoke`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ id: FAMILY, revoked: 2 });
+  });
+
+  it("returns 404 when no active session matches for this user", async () => {
+    returningResult = [];
+    const res = await request(makeApp()).post(`/api/me/devices/${FAMILY}/revoke`);
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("not_found");
+  });
+
+  it("rejects a malformed device id", async () => {
+    const res = await request(makeApp()).post("/api/me/devices/not-a-uuid/revoke");
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+});


### PR DESCRIPTION
Closes #215.

Adds `POST /api/me/devices/:id/revoke` (auth required) to revoke a single session/device. A device is a refresh-token family; revoking marks every still-active token in that family as revoked. The update is scoped to the authenticated user, so a caller can only revoke their own sessions and an unknown/foreign family returns 404 (no cross-user leak). Wired into `src/index.ts`; includes route tests.