### PR TITLE
feat: add POST /api/admin/markets/disable endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { createDocsRouter } from "./routes/docs";
 import { notificationsRouter } from "./routes/notifications";
 import { socialRouter } from "./routes/social";
 import { adminAuditRouter } from "./routes/admin/audit";
+import { adminMarketsRouter } from "./routes/admin/markets";
 import { errorHandler } from "./middleware/errorHandler";
 import { requestContextStorage } from "./lib/requestContext";
 import { REQUEST_ID_HEADER } from "./lib/http";
@@ -92,6 +93,7 @@ export function createApp(): express.Express {
   app.use("/api/users", socialRouter);
   app.use("/api/users", usersRouter);
   app.use("/api/admin/audit", adminAuditRouter);
+  app.use("/api/admin/markets", adminMarketsRouter);
 
   app.get("/metrics", async (req, res) => {
     const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;

--- a/src/routes/admin/markets.ts
+++ b/src/routes/admin/markets.ts
@@ -1,0 +1,53 @@
+/**
+ * POST /api/admin/markets/disable — disable a market for moderation (#213).
+ *
+ * Admin-only. Marks a market as disabled and records a structured audit entry
+ * with the supplied reason. Idempotent at the row level: re-disabling an
+ * already-disabled market returns 409.
+ */
+import { Router } from "express";
+import { z } from "zod";
+import { requireAdmin, AuthenticatedRequest } from "../../middleware/auth";
+import {
+  disableMarket,
+  MarketAlreadyDisabledError,
+} from "../../services/marketService";
+import { logger } from "../../config/logger";
+
+const disableBodySchema = z
+  .object({
+    marketId: z.string().min(1, "marketId is required"),
+    reason: z.string().min(1, "reason is required").max(500),
+  })
+  .strict();
+
+export const adminMarketsRouter = Router();
+
+adminMarketsRouter.use(requireAdmin);
+
+adminMarketsRouter.post("/disable", async (req: AuthenticatedRequest, res, next) => {
+  try {
+    const parsed = disableBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: { code: "validation_error", details: parsed.error.issues },
+      });
+    }
+
+    const { marketId, reason } = parsed.data;
+    const adminAddress = req.user!.stellarAddress;
+
+    const updated = await disableMarket(marketId, reason, adminAddress);
+
+    logger.info({ marketId, adminAddress }, "admin_market_disabled");
+    return res.status(200).json({ data: updated });
+  } catch (e) {
+    if (e instanceof MarketAlreadyDisabledError) {
+      return res.status(409).json({ error: { code: "already_disabled" } });
+    }
+    if ((e as { status?: number }).status === 404) {
+      return res.status(404).json({ error: { code: "not_found" } });
+    }
+    return next(e);
+  }
+});

--- a/src/services/marketService.ts
+++ b/src/services/marketService.ts
@@ -136,3 +136,64 @@ export async function updateMarket(
   return result;
 }
 
+export class MarketAlreadyDisabledError extends Error {
+  status = 409;
+  code = "already_disabled";
+  constructor() {
+    super("Market already disabled");
+    Object.setPrototypeOf(this, MarketAlreadyDisabledError.prototype);
+  }
+}
+
+/**
+ * Disable a market for editorial moderation (#213).
+ *
+ * Sets `status = "disabled"` and records a structured audit entry. Idempotency
+ * is enforced at the row level: a market that is already disabled yields a 409
+ * rather than a duplicate audit entry. Returns the updated market row.
+ */
+export async function disableMarket(
+  id: string,
+  reason: string,
+  adminAddress: string,
+): Promise<any> {
+  const result = await db.transaction(async (tx) => {
+    const existing = await tx.select().from(markets).where(eq(markets.id, id)).limit(1);
+    if (existing.length === 0) {
+      const err = new Error("Market not found");
+      (err as any).status = 404;
+      throw err;
+    }
+
+    const current = existing[0];
+    if (current.status === "disabled") {
+      throw new MarketAlreadyDisabledError();
+    }
+
+    const updated = await tx
+      .update(markets)
+      .set({ status: "disabled", version: current.version + 1 })
+      .where(eq(markets.id, id))
+      .returning();
+
+    await tx.insert(marketAuditLog).values({
+      marketId: id,
+      adminAddress,
+      action: "disable",
+      beforeState: { status: current.status, version: current.version },
+      afterState: { status: "disabled", version: updated[0].version, reason },
+    });
+
+    return updated[0];
+  });
+
+  emitMarketEvent(LogEvent.MARKET_UPDATED, {
+    marketId: id,
+    actor: adminAddress,
+    version: result.version,
+    fieldsUpdated: ["status"],
+  });
+
+  return result;
+}
+

--- a/tests/adminMarketsDisable.test.ts
+++ b/tests/adminMarketsDisable.test.ts
@@ -1,0 +1,83 @@
+// Env setup must precede imports that parse it.
+process.env.JWT_SECRET = "super-secret-key-that-is-at-least-32-bytes-long";
+process.env.JWT_ISSUER = process.env.JWT_ISSUER || "predictify";
+process.env.JWT_AUDIENCE = process.env.JWT_AUDIENCE || "predictify-app";
+process.env.ADMIN_ALLOWLIST = "GADMIN";
+
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+
+jest.mock("../src/services/marketService", () => ({
+  disableMarket: jest.fn(),
+  MarketAlreadyDisabledError: class extends Error {},
+}));
+
+jest.mock("../src/config/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { adminMarketsRouter } from "../src/routes/admin/markets";
+import {
+  disableMarket,
+  MarketAlreadyDisabledError,
+} from "../src/services/marketService";
+
+const mockDisable = disableMarket as jest.MockedFunction<typeof disableMarket>;
+
+function adminJwt(): string {
+  return jwt.sign({ sub: "GADMIN" }, process.env.JWT_SECRET as string, {
+    issuer: process.env.JWT_ISSUER,
+    audience: process.env.JWT_AUDIENCE,
+    expiresIn: "1h",
+  });
+}
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/admin/markets", adminMarketsRouter);
+  return app;
+}
+
+describe("POST /api/admin/markets/disable", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("disables a market and returns the updated row", async () => {
+    mockDisable.mockResolvedValue({ id: "m1", status: "disabled" });
+    const res = await request(makeApp())
+      .post("/api/admin/markets/disable")
+      .set("Authorization", `Bearer ${adminJwt()}`)
+      .send({ marketId: "m1", reason: "spam" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("disabled");
+    expect(mockDisable).toHaveBeenCalledWith("m1", "spam", "GADMIN");
+  });
+
+  it("rejects requests without admin auth", async () => {
+    const res = await request(makeApp())
+      .post("/api/admin/markets/disable")
+      .send({ marketId: "m1", reason: "spam" });
+    expect(res.status).toBe(401);
+  });
+
+  it("validates the body", async () => {
+    const res = await request(makeApp())
+      .post("/api/admin/markets/disable")
+      .set("Authorization", `Bearer ${adminJwt()}`)
+      .send({ marketId: "m1" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("returns 409 when already disabled", async () => {
+    mockDisable.mockRejectedValue(new MarketAlreadyDisabledError());
+    const res = await request(makeApp())
+      .post("/api/admin/markets/disable")
+      .set("Authorization", `Bearer ${adminJwt()}`)
+      .send({ marketId: "m1", reason: "spam" });
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("already_disabled");
+  });
+});


### PR DESCRIPTION
Closes #213.

Adds an admin-only endpoint to disable a market for editorial moderation. `disableMarket` (in marketService) sets `status = "disabled"`, bumps the version, and writes a structured `market_audit_log` entry with the supplied reason; re-disabling an already-disabled market returns 409. Route in `src/routes/admin/markets.ts`, mounted at `/api/admin/markets`; includes route tests covering auth, validation, success and conflict paths.