### PR TITLE
feat: add idempotency-key cleanup job + internal trigger endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,11 @@ STELLAR_NETWORK=testnet
 # Observability
 METRICS_AUTH_TOKEN=
 
+# Shared secret for internal job-trigger endpoints under /api/internal/jobs
+# (e.g. POST /api/internal/jobs/cleanup-idempotency-keys). Leave unset to
+# disable those endpoints entirely (they return 404).
+INTERNAL_JOB_TOKEN=
+
 # Indexer
 INDEXER_POLL_INTERVAL_MS=5000
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { createDocsRouter } from "./routes/docs";
 import { notificationsRouter } from "./routes/notifications";
 import { socialRouter } from "./routes/social";
 import { adminAuditRouter } from "./routes/admin/audit";
+import { internalJobsRouter } from "./routes/internal/jobs";
 import { errorHandler } from "./middleware/errorHandler";
 import { requestContextStorage } from "./lib/requestContext";
 import { REQUEST_ID_HEADER } from "./lib/http";
@@ -92,6 +93,7 @@ export function createApp(): express.Express {
   app.use("/api/users", socialRouter);
   app.use("/api/users", usersRouter);
   app.use("/api/admin/audit", adminAuditRouter);
+  app.use("/api/internal/jobs", internalJobsRouter);
 
   app.get("/metrics", async (req, res) => {
     const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;

--- a/src/routes/internal/jobs.ts
+++ b/src/routes/internal/jobs.ts
@@ -1,0 +1,46 @@
+/**
+ * Internal job-trigger routes (#212).
+ *
+ * POST /api/internal/jobs/cleanup-idempotency-keys
+ *   Purges expired idempotency keys on demand (e.g. from an external cron).
+ *
+ * These routes are not for public callers. They are gated behind a shared
+ * secret supplied via the `INTERNAL_JOB_TOKEN` env var and sent as
+ * `Authorization: Bearer <token>`. When the token is unset the route is
+ * disabled (404) so it can never be hit unauthenticated in production.
+ */
+import { Router, type Request, type Response, type NextFunction } from "express";
+import { cleanupIdempotencyKeys } from "../../workers/cleanupIdempotency";
+import { logger } from "../../config/logger";
+
+export const internalJobsRouter = Router();
+
+function requireInternalToken(req: Request, res: Response, next: NextFunction): void {
+  const expected = process.env.INTERNAL_JOB_TOKEN;
+  // Disabled when no token is configured — fail closed.
+  if (!expected) {
+    res.status(404).json({ error: { code: "not_found" } });
+    return;
+  }
+  const header = req.headers.authorization;
+  if (header !== `Bearer ${expected}`) {
+    res.status(401).json({ error: { code: "unauthorized" } });
+    return;
+  }
+  next();
+}
+
+internalJobsRouter.use(requireInternalToken);
+
+internalJobsRouter.post(
+  "/cleanup-idempotency-keys",
+  async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+      const deleted = await cleanupIdempotencyKeys();
+      logger.info({ deleted }, "internal_cleanup_idempotency_triggered");
+      return res.status(200).json({ data: { deleted } });
+    } catch (err) {
+      return next(err);
+    }
+  },
+);

--- a/src/workers/cleanupIdempotency.ts
+++ b/src/workers/cleanupIdempotency.ts
@@ -1,0 +1,45 @@
+/**
+ * Idempotency-Key Cleanup Worker (#212)
+ *
+ * Purges expired rows from `idempotency_records`. Expired keys serve no
+ * purpose (their stored responses can no longer be replayed) and left
+ * unchecked the table grows unbounded, slowing the idempotency middleware's
+ * hot-path lookups.
+ *
+ * Exposed three ways:
+ *   - `cleanupIdempotencyKeys()` — run one pass, returns rows deleted.
+ *   - `startIdempotencyCleanup()` — schedule it on a recurring interval.
+ *   - `POST /api/internal/jobs/cleanup-idempotency-keys` — trigger on demand
+ *     (see src/routes/internal/jobs.ts), e.g. from an external cron.
+ */
+import { lt } from "drizzle-orm";
+import { db } from "../db";
+import { idempotencyRecords } from "../db/schema";
+import { logger } from "../config/logger";
+
+const DEFAULT_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+
+/** Delete every idempotency record whose `expiresAt` is in the past. */
+export async function cleanupIdempotencyKeys(now: Date = new Date()): Promise<number> {
+  const result = await db
+    .delete(idempotencyRecords)
+    .where(lt(idempotencyRecords.expiresAt, now));
+  const deleted = (result as { rowCount?: number }).rowCount ?? 0;
+  logger.info({ deleted }, "idempotency_cleanup");
+  return deleted;
+}
+
+/**
+ * Schedule the cleanup on a recurring interval. Returns the timer handle so the
+ * caller can `clearInterval` it on shutdown. Failures are logged and never
+ * crash the timer loop.
+ */
+export function startIdempotencyCleanup(
+  intervalMs: number = DEFAULT_INTERVAL_MS,
+): NodeJS.Timeout {
+  return setInterval(() => {
+    cleanupIdempotencyKeys().catch((err) => {
+      logger.error({ err }, "idempotency_cleanup_failed");
+    });
+  }, intervalMs);
+}

--- a/tests/cleanupIdempotency.test.ts
+++ b/tests/cleanupIdempotency.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for the idempotency-key cleanup worker and internal trigger route (#212).
+ */
+import request from "supertest";
+import express from "express";
+
+const whereMock = jest.fn();
+
+jest.mock("../src/db", () => ({
+  db: {
+    delete: jest.fn(() => ({ where: whereMock })),
+  },
+}));
+
+jest.mock("../src/config/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { cleanupIdempotencyKeys } from "../src/workers/cleanupIdempotency";
+import { internalJobsRouter } from "../src/routes/internal/jobs";
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/internal/jobs", internalJobsRouter);
+  return app;
+}
+
+describe("cleanupIdempotencyKeys", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("deletes expired rows and returns the rowCount", async () => {
+    whereMock.mockResolvedValue({ rowCount: 7 });
+    const deleted = await cleanupIdempotencyKeys();
+    expect(deleted).toBe(7);
+  });
+
+  it("returns 0 when rowCount is absent", async () => {
+    whereMock.mockResolvedValue({});
+    expect(await cleanupIdempotencyKeys()).toBe(0);
+  });
+});
+
+describe("POST /api/internal/jobs/cleanup-idempotency-keys", () => {
+  const ORIGINAL = process.env.INTERNAL_JOB_TOKEN;
+  afterEach(() => {
+    process.env.INTERNAL_JOB_TOKEN = ORIGINAL;
+    jest.clearAllMocks();
+  });
+
+  it("404s when no internal token is configured (fail closed)", async () => {
+    delete process.env.INTERNAL_JOB_TOKEN;
+    const res = await request(makeApp()).post(
+      "/api/internal/jobs/cleanup-idempotency-keys",
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("401s with a wrong token", async () => {
+    process.env.INTERNAL_JOB_TOKEN = "secret";
+    const res = await request(makeApp())
+      .post("/api/internal/jobs/cleanup-idempotency-keys")
+      .set("Authorization", "Bearer nope");
+    expect(res.status).toBe(401);
+  });
+
+  it("runs the cleanup with a valid token", async () => {
+    process.env.INTERNAL_JOB_TOKEN = "secret";
+    whereMock.mockResolvedValue({ rowCount: 3 });
+    const res = await request(makeApp())
+      .post("/api/internal/jobs/cleanup-idempotency-keys")
+      .set("Authorization", "Bearer secret");
+    expect(res.status).toBe(200);
+    expect(res.body.data.deleted).toBe(3);
+  });
+});


### PR DESCRIPTION
Closes #212.

Adds `src/workers/cleanupIdempotency.ts` which purges expired `idempotency_records` rows (their stored responses can no longer be replayed and the table otherwise grows unbounded). Provides a one-shot `cleanupIdempotencyKeys()`, a recurring `startIdempotencyCleanup()`, and a `POST /api/internal/jobs/cleanup-idempotency-keys` trigger gated by an `INTERNAL_JOB_TOKEN` shared secret (fails closed with 404 when unset). Documents the new env var; includes worker and route tests.