### PR TITLE
fix: standardize 429 responses with Retry-After header

### DIFF
--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -147,14 +147,30 @@ export function createRateLimiter(options: Partial<Options> = {}): RateLimitRequ
         rateLimitContext,
       });
 
+      // Seconds the client should wait before retrying. Derived from the
+      // window reset time and never negative; defaults to a 1s minimum so the
+      // header is always actionable.
+      const retryAfterSeconds = Math.max(
+        1,
+        Math.ceil((new Date(resetAt).getTime() - Date.now()) / 1000),
+      );
+
       logger.warn(
-        { correlationId, ip, rateLimitContext },
+        { correlationId, ip, rateLimitContext, retryAfterSeconds },
         "rate_limit_blocked",
       );
 
-      // Follow project error envelope: { error: { code } }
+      // Standardized 429: RFC 7231 `Retry-After` header (seconds) plus a
+      // structured envelope echoing the same value and the reset timestamp so
+      // clients can back off without parsing headers.
+      res.setHeader("Retry-After", String(retryAfterSeconds));
       res.status(429).json({
-        error: { code: "rate_limit_exceeded" },
+        error: {
+          code: "rate_limit_exceeded",
+          message: "Too many requests. Please retry after the indicated delay.",
+          retryAfter: retryAfterSeconds,
+          resetAt,
+        },
       });
     },
   });

--- a/tests/rateLimitRetryAfter.test.ts
+++ b/tests/rateLimitRetryAfter.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for the standardized 429 response with Retry-After (#211).
+ */
+import request from "supertest";
+import express from "express";
+
+jest.mock("../src/services/auditService", () => ({
+  createAuditLog: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../src/config/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { createRateLimiter } from "../src/middleware/rateLimit";
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(createRateLimiter({ windowMs: 60_000, limit: 1 }));
+  app.get("/", (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+describe("rate limit 429 envelope", () => {
+  it("sets Retry-After and a structured body once the limit is exceeded", async () => {
+    const app = makeApp();
+
+    const first = await request(app).get("/");
+    expect(first.status).toBe(200);
+
+    const blocked = await request(app).get("/");
+    expect(blocked.status).toBe(429);
+
+    // Retry-After header present and a positive integer number of seconds.
+    const retryAfter = blocked.headers["retry-after"];
+    expect(retryAfter).toBeDefined();
+    expect(Number(retryAfter)).toBeGreaterThanOrEqual(1);
+
+    // Structured envelope mirrors the header.
+    expect(blocked.body.error.code).toBe("rate_limit_exceeded");
+    expect(blocked.body.error.retryAfter).toBe(Number(retryAfter));
+    expect(typeof blocked.body.error.resetAt).toBe("string");
+  });
+});


### PR DESCRIPTION
Closes #211.

The rate-limit middleware's 429 handler now sets an RFC 7231 `Retry-After` header (seconds, derived from the window reset and clamped to >= 1) and returns a structured envelope echoing `retryAfter` and `resetAt` alongside the existing `code`. This gives clients a consistent, actionable back-off signal. Adds a focused test asserting the header and body shape.