### PR TITLE
Add /api/markets/:id/share endpoint with OG metadata

### DIFF
--- a/src/routes/markets.ts
+++ b/src/routes/markets.ts
@@ -87,6 +87,51 @@ marketsRouter.get("/:id", async (req, res, next) => {
   } catch (e) { return next(e); }
 });
 
+marketsRouter.get("/:id/share", async (req, res, next) => {
+  const reqId = String((req as any).id ?? "anon");
+  try {
+    const id = req.params.id as string;
+    const market = await getMarketById(id);
+    if (!market) {
+      logger.info({ reqId, correlationId: reqId, marketId: id }, "market_share_not_found");
+      return res.status(404).json({
+        error: { code: "not_found", message: "market not found", requestId: reqId },
+      });
+    }
+
+    const baseUrl = (process.env.PUBLIC_APP_URL ?? "https://app.predictify.xyz").replace(/\/+$/, "");
+    const marketUrl = `${baseUrl}/markets/${encodeURIComponent(id)}`;
+    const title = market.question;
+    const description = `Predict the outcome on Predictify — status: ${market.status}.`;
+    const imageUrl = `${baseUrl}/api/markets/${encodeURIComponent(id)}/og-image.png`;
+
+    logger.info({ reqId, correlationId: reqId, marketId: id }, "market_share_generated");
+
+    return res.json({
+      data: {
+        url: marketUrl,
+        og: {
+          "og:type": "website",
+          "og:url": marketUrl,
+          "og:title": title,
+          "og:description": description,
+          "og:image": imageUrl,
+          "og:site_name": "Predictify",
+        },
+        twitter: {
+          "twitter:card": "summary_large_image",
+          "twitter:title": title,
+          "twitter:description": description,
+          "twitter:image": imageUrl,
+        },
+      },
+    });
+  } catch (err) {
+    logger.error({ reqId, correlationId: reqId, err }, "market_share_failed");
+    return next(err);
+  }
+});
+
 marketsRouter.patch("/:id", requireAdmin, async (req: AuthenticatedRequest, res, next) => {
   try {
     const parsed = patchMarketSchema.safeParse(req.body);

--- a/tests/marketShare.test.ts
+++ b/tests/marketShare.test.ts
@@ -1,0 +1,50 @@
+// Set up environment variables before importing anything that parses them
+process.env.JWT_SECRET = "super-secret-key-that-is-at-least-32-bytes-long";
+process.env.DATABASE_URL = "postgres://postgres:postgres@localhost:5432/predictify";
+process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "CABCDEF";
+process.env.ADMIN_ALLOWLIST = "G-ADMIN-ADDRESS-1,G-ADMIN-ADDRESS-2";
+process.env.PUBLIC_APP_URL = "https://app.predictify.test";
+
+import request from "supertest";
+import { createApp } from "../src/index";
+import * as marketService from "../src/services/marketService";
+
+jest.mock("../src/services/marketService", () => ({
+  ...jest.requireActual("../src/services/marketService"),
+  getMarketById: jest.fn(),
+}));
+
+const mockGetMarketById = marketService.getMarketById as jest.Mock;
+
+describe("GET /api/markets/:id/share", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("returns OG and Twitter card metadata for an existing market", async () => {
+    mockGetMarketById.mockResolvedValue({
+      id: "market-1",
+      question: "Will it rain tomorrow?",
+      status: "active",
+      resolutionTime: "2026-07-01T00:00:00.000Z",
+    });
+
+    const res = await request(createApp()).get("/api/markets/market-1/share");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.url).toBe("https://app.predictify.test/markets/market-1");
+    expect(res.body.data.og["og:title"]).toBe("Will it rain tomorrow?");
+    expect(res.body.data.og["og:type"]).toBe("website");
+    expect(res.body.data.twitter["twitter:card"]).toBe("summary_large_image");
+    expect(res.body.data.twitter["twitter:image"]).toContain("/api/markets/market-1/og-image.png");
+  });
+
+  it("returns 404 with an error envelope for an unknown market", async () => {
+    mockGetMarketById.mockResolvedValue(null);
+
+    const res = await request(createApp()).get("/api/markets/does-not-exist/share");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("not_found");
+  });
+});


### PR DESCRIPTION
Adds a public GET /api/markets/:id/share endpoint returning OG and Twitter card metadata for share previews. Returns 404 with the standard error envelope for unknown markets. Includes focused tests.

Closes #210