### PR TITLE
Add /api/auth/wallet/logout endpoint

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -59,6 +59,32 @@ authRouter.post("/logout", async (req, res, next) => {
   }
 });
 
+/**
+ * POST /api/auth/wallet/logout
+ *
+ * Explicit wallet logout. Revokes the entire refresh-token family associated
+ * with the supplied refresh token so that every session derived from the same
+ * login is invalidated server-side. Idempotent: revoking an already-revoked or
+ * unknown token still returns 204 so clients can safely retry.
+ */
+authRouter.post("/wallet/logout", async (req, res, next) => {
+  try {
+    const refreshToken = parseRefreshToken(req.body);
+
+    if (!refreshToken) {
+      res.status(400).json({
+        error: { code: "invalid_request", message: "refreshToken is required and must be a string" },
+      });
+      return;
+    }
+
+    await revokeFamily(refreshToken);
+    res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+});
+
 const challengeBodySchema = z.object({
   stellarAddress: z.string().min(1),
 });

--- a/tests/walletLogout.test.ts
+++ b/tests/walletLogout.test.ts
@@ -1,0 +1,39 @@
+import request from "supertest";
+import { createApp } from "../src/index";
+import * as refreshTokenService from "../src/services/refreshTokenService";
+
+jest.mock("../src/services/refreshTokenService", () => ({
+  ...jest.requireActual("../src/services/refreshTokenService"),
+  revokeFamily: jest.fn(),
+}));
+
+const mockRevokeFamily = refreshTokenService.revokeFamily as jest.Mock;
+
+describe("POST /api/auth/wallet/logout", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeAll(() => {
+    app = createApp();
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it("revokes the token family and returns 204", async () => {
+    mockRevokeFamily.mockResolvedValue(undefined);
+
+    const res = await request(app)
+      .post("/api/auth/wallet/logout")
+      .send({ refreshToken: "some-refresh-token" });
+
+    expect(res.status).toBe(204);
+    expect(mockRevokeFamily).toHaveBeenCalledWith("some-refresh-token");
+  });
+
+  it("rejects requests without a refresh token", async () => {
+    const res = await request(app).post("/api/auth/wallet/logout").send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("invalid_request");
+    expect(mockRevokeFamily).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds POST /api/auth/wallet/logout to explicitly revoke a wallet session by invalidating the entire refresh-token family. Validates input at the boundary, returns 204 on success (idempotent), and 400 for missing tokens. Includes tests.

Closes #208