### PR TITLE
Add /api/indexer/health endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { createDocsRouter } from "./routes/docs";
 import { notificationsRouter } from "./routes/notifications";
 import { socialRouter } from "./routes/social";
 import { adminAuditRouter } from "./routes/admin/audit";
+import { indexerHealthRouter } from "./routes/indexer/health";
 import { errorHandler } from "./middleware/errorHandler";
 import { requestContextStorage } from "./lib/requestContext";
 import { REQUEST_ID_HEADER } from "./lib/http";
@@ -92,6 +93,7 @@ export function createApp(): express.Express {
   app.use("/api/users", socialRouter);
   app.use("/api/users", usersRouter);
   app.use("/api/admin/audit", adminAuditRouter);
+  app.use("/api/indexer", indexerHealthRouter);
 
   app.get("/metrics", async (req, res) => {
     const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;

--- a/src/routes/indexer/health.ts
+++ b/src/routes/indexer/health.ts
@@ -1,0 +1,81 @@
+/**
+ * Indexer health router.
+ *
+ * GET /api/indexer/health
+ *   Reports the indexer's liveness by comparing the persisted cursor (the last
+ *   ledger the indexer has processed) against the current chain tip. The
+ *   difference ("lag") is the primary signal that the indexer has fallen behind.
+ *
+ *   Response status:
+ *     - "ok"       — lag is within INDEXER_HEALTH_MAX_LAG ledgers
+ *     - "degraded" — lag exceeds the threshold (indexer is behind)
+ *     - "down"     — the chain tip could not be reached (RPC error)
+ *
+ *   The endpoint always returns HTTP 200 with a status field so that uptime
+ *   probes can scrape it without tripping on non-2xx responses; orchestrators
+ *   should alert on the `status` field instead.
+ */
+
+import { Router } from "express";
+import { indexerService } from "../../services/indexerService";
+import { logger } from "../../config/logger";
+import { getRequestId } from "../../lib/requestContext";
+
+/** Maximum acceptable cursor lag (in ledgers) before the indexer is "degraded". */
+const DEFAULT_MAX_LAG = 50;
+
+function resolveMaxLag(): number {
+  const raw = process.env.INDEXER_HEALTH_MAX_LAG;
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_MAX_LAG;
+}
+
+export function createIndexerHealthRouter(): Router {
+  const router = Router();
+
+  router.get("/health", async (_req, res, next) => {
+    const reqId = getRequestId();
+    const maxLag = resolveMaxLag();
+
+    try {
+      const cursor = await indexerService.getCursor();
+
+      let chainTip: number | null = null;
+      try {
+        chainTip = await indexerService.getChainTip();
+      } catch (err) {
+        // Cursor is readable but the chain tip is not — report "down" without
+        // failing the whole probe so monitoring still gets the cursor value.
+        logger.warn({ reqId, err }, "indexer_health_chain_tip_unavailable");
+      }
+
+      if (chainTip === null) {
+        return res.status(200).json({
+          data: {
+            status: "down",
+            cursor,
+            chainTip: null,
+            lag: null,
+            maxLag,
+          },
+        });
+      }
+
+      const lag = Math.max(0, chainTip - cursor);
+      const status = lag > maxLag ? "degraded" : "ok";
+
+      logger.info({ reqId, cursor, chainTip, lag, status }, "indexer_health_checked");
+
+      return res.status(200).json({
+        data: { status, cursor, chainTip, lag, maxLag },
+      });
+    } catch (err) {
+      logger.error({ reqId, err }, "indexer_health_failed");
+      return next(err);
+    }
+  });
+
+  return router;
+}
+
+export const indexerHealthRouter = createIndexerHealthRouter();

--- a/tests/indexerHealth.test.ts
+++ b/tests/indexerHealth.test.ts
@@ -1,0 +1,62 @@
+// Set up environment variables before importing anything that parses them
+process.env.JWT_SECRET = "super-secret-key-that-is-at-least-32-bytes-long";
+process.env.DATABASE_URL = "postgres://postgres:postgres@localhost:5432/predictify";
+process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "CABCDEF";
+process.env.ADMIN_ALLOWLIST = "G-ADMIN-ADDRESS-1,G-ADMIN-ADDRESS-2";
+process.env.INDEXER_HEALTH_MAX_LAG = "50";
+
+import request from "supertest";
+import { createApp } from "../src/index";
+import { indexerService } from "../src/services/indexerService";
+
+describe("GET /api/indexer/health", () => {
+  let getCursor: jest.SpyInstance;
+  let getChainTip: jest.SpyInstance;
+
+  beforeEach(() => {
+    getCursor = jest.spyOn(indexerService, "getCursor");
+    getChainTip = jest.spyOn(indexerService, "getChainTip");
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it("reports ok when cursor lag is within the threshold", async () => {
+    getCursor.mockResolvedValue(1000);
+    getChainTip.mockResolvedValue(1010);
+
+    const res = await request(createApp()).get("/api/indexer/health");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      status: "ok",
+      cursor: 1000,
+      chainTip: 1010,
+      lag: 10,
+    });
+  });
+
+  it("reports degraded when cursor lag exceeds the threshold", async () => {
+    getCursor.mockResolvedValue(1000);
+    getChainTip.mockResolvedValue(2000);
+
+    const res = await request(createApp()).get("/api/indexer/health");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("degraded");
+    expect(res.body.data.lag).toBe(1000);
+  });
+
+  it("reports down when the chain tip is unreachable", async () => {
+    getCursor.mockResolvedValue(1000);
+    getChainTip.mockRejectedValue(new Error("rpc unavailable"));
+
+    const res = await request(createApp()).get("/api/indexer/health");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("down");
+    expect(res.body.data.chainTip).toBeNull();
+    expect(res.body.data.lag).toBeNull();
+  });
+});


### PR DESCRIPTION
Adds GET /api/indexer/health reporting indexer cursor, chain tip, and the resulting ledger lag. Returns status ok/degraded/down based on a configurable lag threshold (INDEXER_HEALTH_MAX_LAG, default 50). Always returns HTTP 200 so uptime probes scrape the status field. Includes tests.

Closes #207