### PR TITLE
Add /api/predictions/:id/stats endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { createDocsRouter } from "./routes/docs";
 import { notificationsRouter } from "./routes/notifications";
 import { socialRouter } from "./routes/social";
 import { adminAuditRouter } from "./routes/admin/audit";
+import { predictionsRouter } from "./routes/predictions";
 import { errorHandler } from "./middleware/errorHandler";
 import { requestContextStorage } from "./lib/requestContext";
 import { REQUEST_ID_HEADER } from "./lib/http";
@@ -92,6 +93,7 @@ export function createApp(): express.Express {
   app.use("/api/users", socialRouter);
   app.use("/api/users", usersRouter);
   app.use("/api/admin/audit", adminAuditRouter);
+  app.use("/api/predictions", predictionsRouter);
 
   app.get("/metrics", async (req, res) => {
     const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;

--- a/src/routes/predictions.ts
+++ b/src/routes/predictions.ts
@@ -1,10 +1,31 @@
 import { Router } from "express";
 import { requireAuth } from "../middleware/requireAuth";
 import { getPredictionExplanation } from "../services/predictionExplainService";
+import { getPredictionStats } from "../services/predictionStatsService";
+import { getRequestId } from "../lib/requestContext";
+import { logger } from "../config/logger";
 
 export const predictionsRouter = Router();
 
-// Apply requireAuth to every route on this router.
+/**
+ * GET /api/predictions/:id/stats
+ * Public per-prediction statistics: pool totals, stake ranking among
+ * same-outcome predictions, outcome share, and a parimutuel expected payout.
+ * Registered before requireAuth so the aggregate (non-sensitive) view is
+ * readable without authentication.
+ */
+predictionsRouter.get("/:id/stats", async (req, res, next) => {
+  const reqId = getRequestId();
+  try {
+    const stats = await getPredictionStats(req.params.id);
+    logger.info({ reqId, predictionId: req.params.id }, "prediction_stats_served");
+    res.json({ data: stats });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Apply requireAuth to every route declared below this point.
 predictionsRouter.use(requireAuth);
 
 /**

--- a/src/services/predictionStatsService.ts
+++ b/src/services/predictionStatsService.ts
@@ -1,0 +1,132 @@
+/**
+ * Per-prediction statistics.
+ *
+ * Aggregates the predictions on the same market to derive how a single
+ * prediction is positioned relative to its peers:
+ *   - pool totals (overall and per outcome)
+ *   - the share of the winning-side pool this prediction represents
+ *   - its stake-rank among predictions that backed the same outcome
+ *   - an expected payout under a parimutuel (pool-share) model: if the
+ *     prediction's outcome wins, the whole market pool is split pro-rata
+ *     across the stakes on that outcome.
+ *
+ * The parimutuel model is intentionally simple — it gives the caller a useful
+ * "what would I win" estimate without depending on on-chain settlement rules.
+ */
+
+import { eq } from "drizzle-orm";
+import { db } from "../db";
+import { predictions, markets } from "../db/schema";
+import { NotFoundError } from "../errors";
+
+export interface PredictionStats {
+  prediction: {
+    id: string;
+    marketId: string;
+    outcome: string;
+    amount: string;
+    status: string;
+  };
+  market: {
+    id: string;
+    question: string;
+    status: string;
+  };
+  totals: {
+    predictions: number;
+    pool: string;
+    outcomePool: string;
+  };
+  ranking: {
+    /** 1-based rank of this prediction's stake among same-outcome predictions. */
+    rank: number;
+    outOf: number;
+  };
+  /** Fraction (0..1) of the winning-outcome pool this prediction represents. */
+  outcomeShare: number;
+  /** Estimated payout if this prediction's outcome wins (parimutuel). */
+  expectedPayout: string;
+}
+
+/** Parse a stake string into a finite number, defaulting to 0 on garbage. */
+function toAmount(raw: string): number {
+  const n = Number.parseFloat(raw);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export async function getPredictionStats(predictionId: string): Promise<PredictionStats> {
+  const [prediction] = await db
+    .select()
+    .from(predictions)
+    .where(eq(predictions.id, predictionId))
+    .limit(1);
+
+  if (!prediction) {
+    throw new NotFoundError(`Prediction ${predictionId} not found`);
+  }
+
+  const [market] = await db
+    .select()
+    .from(markets)
+    .where(eq(markets.id, prediction.marketId))
+    .limit(1);
+
+  if (!market) {
+    throw new NotFoundError(`Market ${prediction.marketId} not found`);
+  }
+
+  // All predictions on the same market drive the pool maths.
+  const siblings = await db
+    .select({
+      id: predictions.id,
+      outcome: predictions.outcome,
+      amount: predictions.amount,
+    })
+    .from(predictions)
+    .where(eq(predictions.marketId, prediction.marketId));
+
+  const myAmount = toAmount(prediction.amount);
+  let pool = 0;
+  let outcomePool = 0;
+  const sameOutcome: number[] = [];
+
+  for (const s of siblings) {
+    const amt = toAmount(s.amount);
+    pool += amt;
+    if (s.outcome === prediction.outcome) {
+      outcomePool += amt;
+      sameOutcome.push(amt);
+    }
+  }
+
+  // Rank: number of same-outcome stakes strictly greater than mine, plus one.
+  const rank = sameOutcome.filter((a) => a > myAmount).length + 1;
+  const outcomeShare = outcomePool > 0 ? myAmount / outcomePool : 0;
+  const expectedPayout = outcomePool > 0 ? pool * outcomeShare : myAmount;
+
+  return {
+    prediction: {
+      id: prediction.id,
+      marketId: prediction.marketId,
+      outcome: prediction.outcome,
+      amount: prediction.amount,
+      status: prediction.status,
+    },
+    market: {
+      id: market.id,
+      question: market.question,
+      status: market.status,
+    },
+    totals: {
+      predictions: siblings.length,
+      pool: pool.toString(),
+      outcomePool: outcomePool.toString(),
+    },
+    ranking: {
+      rank,
+      outOf: sameOutcome.length,
+    },
+    outcomeShare,
+    expectedPayout: expectedPayout.toString(),
+  };
+}

--- a/tests/predictionStats.test.ts
+++ b/tests/predictionStats.test.ts
@@ -1,0 +1,50 @@
+import request from "supertest";
+import { createApp } from "../src/index";
+import * as predictionStatsService from "../src/services/predictionStatsService";
+import { NotFoundError } from "../src/errors";
+
+jest.mock("../src/services/predictionStatsService");
+
+const mockGetPredictionStats =
+  predictionStatsService.getPredictionStats as jest.MockedFunction<
+    typeof predictionStatsService.getPredictionStats
+  >;
+
+const app = createApp();
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("GET /api/predictions/:id/stats", () => {
+  it("returns per-prediction statistics", async () => {
+    mockGetPredictionStats.mockResolvedValue({
+      prediction: {
+        id: "pred-1",
+        marketId: "mkt-1",
+        outcome: "yes",
+        amount: "100",
+        status: "confirmed",
+      },
+      market: { id: "mkt-1", question: "Will it rain?", status: "active" },
+      totals: { predictions: 3, pool: "300", outcomePool: "150" },
+      ranking: { rank: 1, outOf: 2 },
+      outcomeShare: 0.6667,
+      expectedPayout: "200",
+    });
+
+    const res = await request(app).get("/api/predictions/pred-1/stats");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.ranking).toEqual({ rank: 1, outOf: 2 });
+    expect(res.body.data.expectedPayout).toBe("200");
+    expect(mockGetPredictionStats).toHaveBeenCalledWith("pred-1");
+  });
+
+  it("returns 404 when the prediction does not exist", async () => {
+    mockGetPredictionStats.mockRejectedValue(new NotFoundError("Prediction missing not found"));
+
+    const res = await request(app).get("/api/predictions/missing/stats");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBeDefined();
+  });
+});


### PR DESCRIPTION
Adds GET /api/predictions/:id/stats returning per-prediction statistics: market pool totals, stake ranking among same-outcome predictions, outcome share, and a parimutuel expected payout estimate. Wires the predictions router into the app. Returns 404 for unknown predictions. Includes tests.

Closes #206