### PR TITLE
Add /api/admin/feature-flags CRUD

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { createDocsRouter } from "./routes/docs";
 import { notificationsRouter } from "./routes/notifications";
 import { socialRouter } from "./routes/social";
 import { adminAuditRouter } from "./routes/admin/audit";
+import { adminFeatureFlagsRouter } from "./routes/admin/feature-flags";
 import { errorHandler } from "./middleware/errorHandler";
 import { requestContextStorage } from "./lib/requestContext";
 import { REQUEST_ID_HEADER } from "./lib/http";
@@ -92,6 +93,7 @@ export function createApp(): express.Express {
   app.use("/api/users", socialRouter);
   app.use("/api/users", usersRouter);
   app.use("/api/admin/audit", adminAuditRouter);
+  app.use("/api/admin/feature-flags", adminFeatureFlagsRouter);
 
   app.get("/metrics", async (req, res) => {
     const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;

--- a/src/routes/admin/feature-flags.ts
+++ b/src/routes/admin/feature-flags.ts
@@ -1,0 +1,169 @@
+/**
+ * Admin feature-flag CRUD router.
+ *
+ *   GET    /api/admin/feature-flags        — list all flags
+ *   POST   /api/admin/feature-flags        — create a flag
+ *   GET    /api/admin/feature-flags/:key   — read one flag
+ *   PATCH  /api/admin/feature-flags/:key   — update enabled/description
+ *   DELETE /api/admin/feature-flags/:key   — remove a flag
+ *
+ * Every route requires a valid admin JWT (role: "admin"). Requests are
+ * rate-limited per admin token. Input is validated at the boundary with zod and
+ * all failures return the standard error envelope.
+ */
+
+import { Router } from "express";
+import { rateLimit } from "express-rate-limit";
+import { z } from "zod";
+import { requireAdmin } from "../../middleware/requireAdmin";
+import { getRequestId } from "../../lib/requestContext";
+import { logger } from "../../config/logger";
+import {
+  listFeatureFlags,
+  getFeatureFlag,
+  createFeatureFlag,
+  updateFeatureFlag,
+  deleteFeatureFlag,
+  FeatureFlagConflictError,
+  FeatureFlagNotFoundError,
+} from "../../services/featureFlagService";
+
+export interface AdminFeatureFlagsRouterOptions {
+  /** Requests per minute per admin token. Default: 60 */
+  rateLimitPerMinute?: number;
+}
+
+const flagKeySchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9][a-z0-9_-]*$/i, "key must be alphanumeric with - or _ separators");
+
+const createSchema = z
+  .object({
+    key: flagKeySchema,
+    enabled: z.boolean(),
+    description: z.string().max(280).nullish(),
+  })
+  .strict();
+
+const updateSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    description: z.string().max(280).nullish(),
+  })
+  .strict()
+  .refine((v) => v.enabled !== undefined || v.description !== undefined, {
+    message: "at least one of enabled or description is required",
+  });
+
+function validationError(res: import("express").Response, message: string): void {
+  res.status(400).json({
+    error: { code: "validation_error", message, requestId: getRequestId() },
+  });
+}
+
+/**
+ * Maps the service's typed domain errors to the standard error envelope.
+ * Returns true when the error was handled so callers can short-circuit.
+ */
+function handleFlagError(res: import("express").Response, e: unknown): boolean {
+  if (e instanceof FeatureFlagConflictError || e instanceof FeatureFlagNotFoundError) {
+    res.status(e.status).json({
+      error: { code: e.code, message: e.message, requestId: getRequestId() },
+    });
+    return true;
+  }
+  return false;
+}
+
+export function createAdminFeatureFlagsRouter(
+  opts: AdminFeatureFlagsRouterOptions = {},
+): Router {
+  const router = Router();
+  const limit = opts.rateLimitPerMinute ?? 60;
+
+  router.use(
+    rateLimit({
+      windowMs: 60_000,
+      limit,
+      keyGenerator: (req) =>
+        (req.headers.authorization as string | undefined) ?? req.ip ?? "unknown",
+      standardHeaders: "draft-6",
+      legacyHeaders: false,
+      message: { error: { code: "rate_limit_exceeded" } },
+    }),
+  );
+
+  router.use(requireAdmin);
+
+  router.get("/", (_req, res) => {
+    res.json({ data: listFeatureFlags() });
+  });
+
+  router.post("/", (req, res, next) => {
+    const parsed = createSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return validationError(res, parsed.error.issues[0]?.message ?? "invalid body");
+    }
+    try {
+      const flag = createFeatureFlag(parsed.data);
+      logger.info({ reqId: getRequestId(), key: flag.key, actor: req.adminAddress }, "feature_flag_created");
+      return res.status(201).json({ data: flag });
+    } catch (e) {
+      if (handleFlagError(res, e)) return;
+      return next(e);
+    }
+  });
+
+  router.get("/:key", (req, res, next) => {
+    const key = flagKeySchema.safeParse(req.params.key);
+    if (!key.success) {
+      return validationError(res, "invalid feature flag key");
+    }
+    try {
+      return res.json({ data: getFeatureFlag(key.data) });
+    } catch (e) {
+      if (handleFlagError(res, e)) return;
+      return next(e);
+    }
+  });
+
+  router.patch("/:key", (req, res, next) => {
+    const key = flagKeySchema.safeParse(req.params.key);
+    if (!key.success) {
+      return validationError(res, "invalid feature flag key");
+    }
+    const parsed = updateSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return validationError(res, parsed.error.issues[0]?.message ?? "invalid body");
+    }
+    try {
+      const flag = updateFeatureFlag(key.data, parsed.data);
+      logger.info({ reqId: getRequestId(), key: flag.key, actor: req.adminAddress }, "feature_flag_updated");
+      return res.json({ data: flag });
+    } catch (e) {
+      if (handleFlagError(res, e)) return;
+      return next(e);
+    }
+  });
+
+  router.delete("/:key", (req, res, next) => {
+    const key = flagKeySchema.safeParse(req.params.key);
+    if (!key.success) {
+      return validationError(res, "invalid feature flag key");
+    }
+    try {
+      deleteFeatureFlag(key.data);
+      logger.info({ reqId: getRequestId(), key: key.data, actor: req.adminAddress }, "feature_flag_deleted");
+      return res.status(204).send();
+    } catch (e) {
+      if (handleFlagError(res, e)) return;
+      return next(e);
+    }
+  });
+
+  return router;
+}
+
+export const adminFeatureFlagsRouter = createAdminFeatureFlagsRouter();

--- a/src/services/featureFlagService.ts
+++ b/src/services/featureFlagService.ts
@@ -1,0 +1,95 @@
+/**
+ * Feature-flag store.
+ *
+ * A lightweight in-process registry of feature flags used by the admin CRUD
+ * endpoints. Flags are keyed by a stable, URL-safe `key`. The store is
+ * deliberately simple (a Map) so the admin surface can be exercised without a
+ * migration; it can later be swapped for a persisted table behind the same
+ * interface without touching the route layer.
+ */
+
+export interface FeatureFlag {
+  key: string;
+  enabled: boolean;
+  description: string | null;
+  updatedAt: string;
+}
+
+export class FeatureFlagConflictError extends Error {
+  status = 409;
+  code = "feature_flag_exists";
+  constructor(key: string) {
+    super(`Feature flag '${key}' already exists`);
+    Object.setPrototypeOf(this, FeatureFlagConflictError.prototype);
+  }
+}
+
+export class FeatureFlagNotFoundError extends Error {
+  status = 404;
+  code = "not_found";
+  constructor(key: string) {
+    super(`Feature flag '${key}' not found`);
+    Object.setPrototypeOf(this, FeatureFlagNotFoundError.prototype);
+  }
+}
+
+const store = new Map<string, FeatureFlag>();
+
+/** Test-only helper: wipe all flags so suites start from a clean slate. */
+export function resetFeatureFlagsForTests(): void {
+  store.clear();
+}
+
+export function listFeatureFlags(): FeatureFlag[] {
+  return Array.from(store.values()).sort((a, b) => a.key.localeCompare(b.key));
+}
+
+export function getFeatureFlag(key: string): FeatureFlag {
+  const flag = store.get(key);
+  if (!flag) {
+    throw new FeatureFlagNotFoundError(key);
+  }
+  return flag;
+}
+
+export function createFeatureFlag(input: {
+  key: string;
+  enabled: boolean;
+  description?: string | null;
+}): FeatureFlag {
+  if (store.has(input.key)) {
+    throw new FeatureFlagConflictError(input.key);
+  }
+  const flag: FeatureFlag = {
+    key: input.key,
+    enabled: input.enabled,
+    description: input.description ?? null,
+    updatedAt: new Date().toISOString(),
+  };
+  store.set(flag.key, flag);
+  return flag;
+}
+
+export function updateFeatureFlag(
+  key: string,
+  patch: { enabled?: boolean; description?: string | null },
+): FeatureFlag {
+  const existing = store.get(key);
+  if (!existing) {
+    throw new FeatureFlagNotFoundError(key);
+  }
+  const updated: FeatureFlag = {
+    ...existing,
+    enabled: patch.enabled ?? existing.enabled,
+    description: patch.description !== undefined ? patch.description : existing.description,
+    updatedAt: new Date().toISOString(),
+  };
+  store.set(key, updated);
+  return updated;
+}
+
+export function deleteFeatureFlag(key: string): void {
+  if (!store.delete(key)) {
+    throw new FeatureFlagNotFoundError(key);
+  }
+}

--- a/tests/adminFeatureFlags.test.ts
+++ b/tests/adminFeatureFlags.test.ts
@@ -1,0 +1,94 @@
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { createAdminFeatureFlagsRouter } from "../src/routes/admin/feature-flags";
+import { resetFeatureFlagsForTests } from "../src/services/featureFlagService";
+import { errorHandler } from "../src/middleware/errorHandler";
+
+// Prevent a real DB connection at import time.
+jest.mock("../src/db/client", () => ({ db: {} }));
+
+const SECRET = process.env.JWT_SECRET || "test-jwt-secret-that-is-at-least-32-chars!!";
+const ISSUER = process.env.JWT_ISSUER || "predictify";
+const AUDIENCE = process.env.JWT_AUDIENCE || "predictify-app";
+
+const ADMIN_ADDRESS = "GADMIN7777777777777777777777777777777777777777777777777777";
+
+function signJwt(payload: object): string {
+  return jwt.sign(payload, SECRET, { issuer: ISSUER, audience: AUDIENCE, expiresIn: "1h" });
+}
+
+const adminJwt = signJwt({ sub: ADMIN_ADDRESS, role: "admin" });
+const userJwt = signJwt({ sub: ADMIN_ADDRESS, role: "user" });
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/admin/feature-flags", createAdminFeatureFlagsRouter());
+  app.use(errorHandler);
+  return app;
+}
+
+function auth(req: request.Test): request.Test {
+  return req.set("Authorization", `Bearer ${adminJwt}`);
+}
+
+beforeEach(() => resetFeatureFlagsForTests());
+
+describe("admin feature-flags CRUD", () => {
+  it("rejects non-admin callers with 403", async () => {
+    const res = await request(makeApp())
+      .get("/api/admin/feature-flags")
+      .set("Authorization", `Bearer ${userJwt}`);
+    expect(res.status).toBe(403);
+  });
+
+  it("creates, reads, lists, updates and deletes a flag", async () => {
+    const app = makeApp();
+
+    const created = await auth(
+      request(app).post("/api/admin/feature-flags").send({
+        key: "new-dashboard",
+        enabled: true,
+        description: "Beta dashboard",
+      }),
+    );
+    expect(created.status).toBe(201);
+    expect(created.body.data).toMatchObject({ key: "new-dashboard", enabled: true });
+
+    const got = await auth(request(app).get("/api/admin/feature-flags/new-dashboard"));
+    expect(got.status).toBe(200);
+    expect(got.body.data.description).toBe("Beta dashboard");
+
+    const list = await auth(request(app).get("/api/admin/feature-flags"));
+    expect(list.body.data).toHaveLength(1);
+
+    const patched = await auth(
+      request(app).patch("/api/admin/feature-flags/new-dashboard").send({ enabled: false }),
+    );
+    expect(patched.status).toBe(200);
+    expect(patched.body.data.enabled).toBe(false);
+
+    const removed = await auth(request(app).delete("/api/admin/feature-flags/new-dashboard"));
+    expect(removed.status).toBe(204);
+
+    const missing = await auth(request(app).get("/api/admin/feature-flags/new-dashboard"));
+    expect(missing.status).toBe(404);
+  });
+
+  it("returns 409 on duplicate key and 400 on invalid body", async () => {
+    const app = makeApp();
+    await auth(request(app).post("/api/admin/feature-flags").send({ key: "dup", enabled: true }));
+
+    const dup = await auth(
+      request(app).post("/api/admin/feature-flags").send({ key: "dup", enabled: false }),
+    );
+    expect(dup.status).toBe(409);
+
+    const bad = await auth(
+      request(app).post("/api/admin/feature-flags").send({ key: "bad key!", enabled: true }),
+    );
+    expect(bad.status).toBe(400);
+    expect(bad.body.error.code).toBe("validation_error");
+  });
+});


### PR DESCRIPTION
Adds admin-only CRUD for feature flags under /api/admin/feature-flags (list, create, read, update, delete). Admin JWT required, per-token rate limiting, zod boundary validation with the standard error envelope, and 404/409 handling. Backed by a swappable in-process store. Includes tests.

Closes #205