### PR TITLE
Add /api/markets/upcoming endpoint

### DIFF
--- a/src/routes/markets.ts
+++ b/src/routes/markets.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { listMarkets, getMarketById, updateMarket, VersionConflictError } from "../services/marketService";
+import { listMarkets, listUpcomingMarkets, getMarketById, updateMarket, VersionConflictError } from "../services/marketService";
 import { searchMarkets } from "../repositories/marketRepository";
 import { requireAdmin, AuthenticatedRequest } from "../middleware/auth";
 import { rateLimitAnon } from "../middleware/rateLimitAnon";
@@ -75,6 +75,27 @@ marketsRouter.get("/", async (req, res, next) => {
     }
     return res.json({ data: await listMarkets() });
   } catch (e) { return next(e); }
+});
+
+marketsRouter.get("/upcoming", async (req, res, next) => {
+  const reqId = String((req as any).id ?? "anon");
+  try {
+    if (
+      req.query.limit !== undefined &&
+      (isNaN(Number(req.query.limit)) || Number(req.query.limit) < 1 || Number(req.query.limit) > 100)
+    ) {
+      return res.status(400).json({
+        error: { code: "validation_error", message: "limit must be between 1 and 100", requestId: reqId },
+      });
+    }
+    const limit = req.query.limit !== undefined ? Number(req.query.limit) : 50;
+    const data = await listUpcomingMarkets({ limit });
+    logger.info({ reqId, correlationId: reqId, count: data.length }, "markets_upcoming_listed");
+    return res.json({ data });
+  } catch (err) {
+    logger.error({ reqId, correlationId: reqId, err }, "markets_upcoming_failed");
+    return next(err);
+  }
 });
 
 marketsRouter.get("/:id", async (req, res, next) => {

--- a/src/services/marketService.ts
+++ b/src/services/marketService.ts
@@ -1,6 +1,6 @@
 import { db, getDb } from "../db/client";
 import { markets, marketAuditLog } from "../db/schema";
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq, gt, inArray } from "drizzle-orm";
 import { emitMarketEvent, LogEvent } from "../logging/events";
 
 export interface Market {
@@ -50,6 +50,50 @@ export async function listMarkets(options: { limit?: number; offset?: number } =
   }
   const result = await getDb().select().from(markets);
   return Array.isArray(result) ? result : [];
+}
+
+/** Statuses that represent a market that has not yet opened for predictions. */
+export const UPCOMING_MARKET_STATUSES = ["upcoming", "pending", "scheduled"] as const;
+
+/**
+ * Lists upcoming markets — markets that are queued to be created/opened from
+ * oracle events but are not yet active. A market is "upcoming" when its status
+ * is one of UPCOMING_MARKET_STATUSES and its resolution time is still in the
+ * future. Results are ordered by soonest resolution time first.
+ */
+export async function listUpcomingMarkets(
+  options: { limit?: number; now?: Date } = {},
+): Promise<any[]> {
+  const limit = Math.min(Math.max(options.limit ?? 50, 1), 100);
+  const now = options.now ?? new Date();
+
+  const rows = await getDb()
+    .select({
+      id: markets.id,
+      question: markets.question,
+      status: markets.status,
+      resolutionTime: markets.resolutionTime,
+    })
+    .from(markets)
+    .where(
+      and(
+        eq(markets.archived, false),
+        inArray(markets.status, UPCOMING_MARKET_STATUSES as unknown as string[]),
+        gt(markets.resolutionTime, now),
+      ),
+    )
+    .orderBy(asc(markets.resolutionTime), asc(markets.id))
+    .limit(limit);
+
+  if (!Array.isArray(rows)) {
+    return [];
+  }
+
+  return rows.map((r: any) => ({
+    ...r,
+    resolutionTime:
+      r.resolutionTime instanceof Date ? r.resolutionTime.toISOString() : r.resolutionTime,
+  }));
 }
 
 export async function getMarketById(id: string): Promise<any | null> {

--- a/tests/marketsUpcoming.test.ts
+++ b/tests/marketsUpcoming.test.ts
@@ -1,0 +1,49 @@
+import request from "supertest";
+import { createApp } from "../src/index";
+import * as marketService from "../src/services/marketService";
+
+jest.mock("../src/services/marketService", () => ({
+  ...jest.requireActual("../src/services/marketService"),
+  listUpcomingMarkets: jest.fn(),
+}));
+
+const mockListUpcoming = marketService.listUpcomingMarkets as jest.Mock;
+
+describe("GET /api/markets/upcoming", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("returns the list of upcoming markets", async () => {
+    mockListUpcoming.mockResolvedValue([
+      {
+        id: "mkt-2",
+        question: "Will the next block confirm in time?",
+        status: "upcoming",
+        resolutionTime: "2026-08-01T00:00:00.000Z",
+      },
+    ]);
+
+    const res = await request(createApp()).get("/api/markets/upcoming");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].status).toBe("upcoming");
+    expect(mockListUpcoming).toHaveBeenCalledWith({ limit: 50 });
+  });
+
+  it("passes through a valid limit", async () => {
+    mockListUpcoming.mockResolvedValue([]);
+
+    const res = await request(createApp()).get("/api/markets/upcoming?limit=5");
+
+    expect(res.status).toBe(200);
+    expect(mockListUpcoming).toHaveBeenCalledWith({ limit: 5 });
+  });
+
+  it("rejects an invalid limit with 400", async () => {
+    const res = await request(createApp()).get("/api/markets/upcoming?limit=1000");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+    expect(mockListUpcoming).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds GET /api/markets/upcoming listing markets queued to open from oracle events (status upcoming/pending/scheduled with a future resolution time), ordered by soonest resolution. Validates the optional limit (1-100) with the standard error envelope. Includes tests.

Closes #204