### PR TITLE
Add /api/admin/users/:addr/freeze endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { createDocsRouter } from "./routes/docs";
 import { notificationsRouter } from "./routes/notifications";
 import { socialRouter } from "./routes/social";
 import { adminAuditRouter } from "./routes/admin/audit";
+import { adminFreezeRouter } from "./routes/admin/users/freeze";
 import { errorHandler } from "./middleware/errorHandler";
 import { requestContextStorage } from "./lib/requestContext";
 import { REQUEST_ID_HEADER } from "./lib/http";
@@ -92,6 +93,7 @@ export function createApp(): express.Express {
   app.use("/api/users", socialRouter);
   app.use("/api/users", usersRouter);
   app.use("/api/admin/audit", adminAuditRouter);
+  app.use("/api/admin/users", adminFreezeRouter);
 
   app.get("/metrics", async (req, res) => {
     const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;

--- a/src/routes/admin/users/freeze.ts
+++ b/src/routes/admin/users/freeze.ts
@@ -1,0 +1,109 @@
+/**
+ * Admin user-freeze router.
+ *
+ *   GET    /api/admin/users/:address/freeze  — read current freeze status
+ *   POST   /api/admin/users/:address/freeze  — freeze a user (block further bets)
+ *   DELETE /api/admin/users/:address/freeze  — lift the freeze
+ *
+ * Every route requires a valid admin JWT (role: "admin") and is rate-limited
+ * per admin token. The Stellar address is validated at the boundary and all
+ * failures use the standard error envelope.
+ */
+
+import { Router } from "express";
+import { rateLimit } from "express-rate-limit";
+import { z } from "zod";
+import { requireAdmin } from "../../../middleware/requireAdmin";
+import { getRequestId } from "../../../lib/requestContext";
+import { logger } from "../../../config/logger";
+import {
+  getFreezeStatus,
+  freezeUser,
+  unfreezeUser,
+} from "../../../services/userFreezeService";
+
+export interface AdminFreezeRouterOptions {
+  /** Requests per minute per admin token. Default: 60 */
+  rateLimitPerMinute?: number;
+}
+
+const stellarAddressSchema = z
+  .string()
+  .regex(/^G[A-Z2-7]{55}$/, "Invalid Stellar address");
+
+const freezeBodySchema = z
+  .object({
+    reason: z.string().max(280).nullish(),
+  })
+  .strict()
+  .optional();
+
+function validationError(res: import("express").Response, message: string): void {
+  res.status(400).json({
+    error: { code: "validation_error", message, requestId: getRequestId() },
+  });
+}
+
+export function createAdminFreezeRouter(opts: AdminFreezeRouterOptions = {}): Router {
+  // mergeParams so the :address segment from the parent mount is visible here.
+  const router = Router({ mergeParams: true });
+  const limit = opts.rateLimitPerMinute ?? 60;
+
+  router.use(
+    rateLimit({
+      windowMs: 60_000,
+      limit,
+      keyGenerator: (req) =>
+        (req.headers.authorization as string | undefined) ?? req.ip ?? "unknown",
+      standardHeaders: "draft-6",
+      legacyHeaders: false,
+      message: { error: { code: "rate_limit_exceeded" } },
+    }),
+  );
+
+  router.use(requireAdmin);
+
+  router.get("/:address/freeze", (req, res) => {
+    const parsed = stellarAddressSchema.safeParse(req.params.address);
+    if (!parsed.success) {
+      return validationError(res, "invalid stellar address");
+    }
+    return res.json({ data: getFreezeStatus(parsed.data) });
+  });
+
+  router.post("/:address/freeze", (req, res) => {
+    const parsed = stellarAddressSchema.safeParse(req.params.address);
+    if (!parsed.success) {
+      return validationError(res, "invalid stellar address");
+    }
+    const body = freezeBodySchema.safeParse(req.body);
+    if (!body.success) {
+      return validationError(res, body.error.issues[0]?.message ?? "invalid body");
+    }
+
+    const record = freezeUser(parsed.data, req.adminAddress!, body.data?.reason ?? null);
+    logger.info(
+      { reqId: getRequestId(), address: parsed.data, actor: req.adminAddress },
+      "user_frozen",
+    );
+    return res.json({ data: record });
+  });
+
+  router.delete("/:address/freeze", (req, res) => {
+    const parsed = stellarAddressSchema.safeParse(req.params.address);
+    if (!parsed.success) {
+      return validationError(res, "invalid stellar address");
+    }
+
+    const record = unfreezeUser(parsed.data, req.adminAddress!);
+    logger.info(
+      { reqId: getRequestId(), address: parsed.data, actor: req.adminAddress },
+      "user_unfrozen",
+    );
+    return res.json({ data: record });
+  });
+
+  return router;
+}
+
+export const adminFreezeRouter = createAdminFreezeRouter();

--- a/src/services/userFreezeService.ts
+++ b/src/services/userFreezeService.ts
@@ -1,0 +1,72 @@
+/**
+ * User-freeze registry.
+ *
+ * Tracks which Stellar addresses an admin has "frozen". A frozen user is
+ * prevented from placing further bets/predictions (enforcement is expected at
+ * the prediction-creation boundary via `isUserFrozen`). The store is a simple
+ * in-process Map keyed by Stellar address so the admin surface works without a
+ * schema migration; it can later be swapped for a persisted table behind the
+ * same interface.
+ */
+
+export interface FreezeRecord {
+  address: string;
+  frozen: boolean;
+  reason: string | null;
+  /** Stellar address of the admin who last changed the freeze state. */
+  updatedBy: string;
+  updatedAt: string;
+}
+
+const store = new Map<string, FreezeRecord>();
+
+/** Test-only helper: clear all freeze records. */
+export function resetUserFreezeForTests(): void {
+  store.clear();
+}
+
+/** Returns the freeze record for an address, or a default "not frozen" view. */
+export function getFreezeStatus(address: string): FreezeRecord {
+  return (
+    store.get(address) ?? {
+      address,
+      frozen: false,
+      reason: null,
+      updatedBy: "",
+      updatedAt: new Date(0).toISOString(),
+    }
+  );
+}
+
+/** True when the address is currently frozen and must not place bets. */
+export function isUserFrozen(address: string): boolean {
+  return store.get(address)?.frozen === true;
+}
+
+export function freezeUser(
+  address: string,
+  adminAddress: string,
+  reason?: string | null,
+): FreezeRecord {
+  const record: FreezeRecord = {
+    address,
+    frozen: true,
+    reason: reason ?? null,
+    updatedBy: adminAddress,
+    updatedAt: new Date().toISOString(),
+  };
+  store.set(address, record);
+  return record;
+}
+
+export function unfreezeUser(address: string, adminAddress: string): FreezeRecord {
+  const record: FreezeRecord = {
+    address,
+    frozen: false,
+    reason: null,
+    updatedBy: adminAddress,
+    updatedAt: new Date().toISOString(),
+  };
+  store.set(address, record);
+  return record;
+}

--- a/tests/adminUserFreeze.test.ts
+++ b/tests/adminUserFreeze.test.ts
@@ -1,0 +1,78 @@
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { createAdminFreezeRouter } from "../src/routes/admin/users/freeze";
+import { resetUserFreezeForTests, isUserFrozen } from "../src/services/userFreezeService";
+import { errorHandler } from "../src/middleware/errorHandler";
+
+// Prevent a real DB connection at import time.
+jest.mock("../src/db/client", () => ({ db: {} }));
+
+const SECRET = process.env.JWT_SECRET || "test-jwt-secret-that-is-at-least-32-chars!!";
+const ISSUER = process.env.JWT_ISSUER || "predictify";
+const AUDIENCE = process.env.JWT_AUDIENCE || "predictify-app";
+
+const ADMIN_ADDRESS = "GADMIN7777777777777777777777777777777777777777777777777777";
+// A syntactically valid Stellar public key (G + 55 base32 chars).
+const TARGET = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+function signJwt(payload: object): string {
+  return jwt.sign(payload, SECRET, { issuer: ISSUER, audience: AUDIENCE, expiresIn: "1h" });
+}
+
+const adminJwt = signJwt({ sub: ADMIN_ADDRESS, role: "admin" });
+const userJwt = signJwt({ sub: ADMIN_ADDRESS, role: "user" });
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/admin/users", createAdminFreezeRouter());
+  app.use(errorHandler);
+  return app;
+}
+
+beforeEach(() => resetUserFreezeForTests());
+
+describe("admin user freeze", () => {
+  it("rejects non-admin callers with 403", async () => {
+    const res = await request(makeApp())
+      .post(`/api/admin/users/${TARGET}/freeze`)
+      .set("Authorization", `Bearer ${userJwt}`)
+      .send({});
+    expect(res.status).toBe(403);
+  });
+
+  it("freezes, reports status, and unfreezes a user", async () => {
+    const app = makeApp();
+
+    const frozen = await request(app)
+      .post(`/api/admin/users/${TARGET}/freeze`)
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ reason: "suspicious activity" });
+    expect(frozen.status).toBe(200);
+    expect(frozen.body.data).toMatchObject({ frozen: true, reason: "suspicious activity" });
+    expect(isUserFrozen(TARGET)).toBe(true);
+
+    const status = await request(app)
+      .get(`/api/admin/users/${TARGET}/freeze`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+    expect(status.status).toBe(200);
+    expect(status.body.data.frozen).toBe(true);
+
+    const unfrozen = await request(app)
+      .delete(`/api/admin/users/${TARGET}/freeze`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+    expect(unfrozen.status).toBe(200);
+    expect(unfrozen.body.data.frozen).toBe(false);
+    expect(isUserFrozen(TARGET)).toBe(false);
+  });
+
+  it("rejects an invalid stellar address with 400", async () => {
+    const res = await request(makeApp())
+      .post("/api/admin/users/not-an-address/freeze")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+});


### PR DESCRIPTION
Adds admin-only freeze controls under /api/admin/users/:address/freeze (GET status, POST freeze, DELETE unfreeze). A frozen user is flagged to block further bets (enforceable via isUserFrozen). Admin JWT required, per-token rate limiting, Stellar address validation, and the standard error envelope. Includes tests.

Closes #203