### PR TITLE
feat: token-protected /api/metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,47 @@
+# Metrics
+
+Predictify exposes Prometheus metrics at `GET /api/metrics`.
+
+## Auth
+
+If `METRICS_AUTH_TOKEN` is set, the endpoint requires a `Bearer` token:
+
+```
+Authorization: Bearer <token>
+```
+
+When the token is missing or invalid, the endpoint returns `401 Unauthorized` with a JSON error body.
+
+If `METRICS_AUTH_TOKEN` is empty (default), the endpoint is unprotected.
+
+## Metrics collected
+
+### Default Node.js metrics
+
+Collected by `prom-client`'s `collectDefaultMetrics`:
+
+- `process_cpu_user_seconds_total`
+- `process_cpu_system_seconds_total`
+- `process_resident_memory_bytes`
+- `node_heap_size_bytes`
+- `node_event_loop_lag_seconds`
+- and more
+
+### Custom metrics
+
+| Metric name | Type | Labels | Description |
+|---|---|---|---|
+| `http_request_duration_seconds` | Histogram | `route`, `status` | HTTP request duration in seconds, bucketed |
+| `indexer_polls_total` | Counter | — | Total indexer poll cycles completed |
+| `webhook_deliveries_total` | Counter | `status` | Webhook deliveries by outcome |
+| `auth_verifications_total` | Counter | `outcome` | Auth verification attempts by result |
+
+## Content type
+
+The response uses `Content-Type: text/plain; charset=utf-8; version=0.0.4` (Prometheus exposition format).
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `METRICS_AUTH_TOKEN` | `""` | Bearer token required to access `/api/metrics`. Empty means no auth |

--- a/src/config/env-schema.ts
+++ b/src/config/env-schema.ts
@@ -36,6 +36,10 @@ export const envSchema = z.object({
   CAPTCHA_THRESHOLD: z.coerce.number().int().nonnegative().default(10),
   /** Sliding window length for captcha threshold tracking (ms) */
   CAPTCHA_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
+
+  // ── Metrics ──────────────────────────────────────────────
+  /** Bearer token required to access /api/metrics. Empty string (default) means no auth. */
+  METRICS_AUTH_TOKEN: z.string().default(""),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -30,6 +30,8 @@ const schema = z.object({
   // ── Captcha gate ──────────────────────────────────────────
   CAPTCHA_THRESHOLD: z.coerce.number().int().nonnegative().default(10),
   CAPTCHA_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
+  // ── Metrics ──────────────────────────────────────────────
+  METRICS_AUTH_TOKEN: z.string().default(""),
 });
 
 export const env = schema.parse(process.env);

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,10 @@ import { createDocsRouter } from "./routes/docs";
 import { notificationsRouter } from "./routes/notifications";
 import { socialRouter } from "./routes/social";
 import { adminAuditRouter } from "./routes/admin/audit";
+import { metricsRouter } from "./routes/metrics";
 import { errorHandler } from "./middleware/errorHandler";
 import { requestContextStorage } from "./lib/requestContext";
 import { REQUEST_ID_HEADER } from "./lib/http";
-import { register } from "./metrics/registry";
 import { connectWithRetry, closeDb } from "./db/client";
 import { stopScheduler } from "./services/scheduler";
 
@@ -92,20 +92,7 @@ export function createApp(): express.Express {
   app.use("/api/users", socialRouter);
   app.use("/api/users", usersRouter);
   app.use("/api/admin/audit", adminAuditRouter);
-
-  app.get("/metrics", async (req, res) => {
-    const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;
-    if (
-      metricsAuthToken &&
-      req.headers.authorization !== `Bearer ${metricsAuthToken}`
-    ) {
-      res.status(401).send("Unauthorized");
-      return;
-    }
-
-    res.set("Content-Type", register.contentType);
-    res.send(await register.metrics());
-  });
+  app.use("/api/metrics", metricsRouter);
 
   app.use(errorHandler);
   return app;

--- a/src/routes/metrics.ts
+++ b/src/routes/metrics.ts
@@ -1,0 +1,19 @@
+import { Router } from "express";
+import { register } from "../metrics/registry";
+
+export const metricsRouter = Router();
+
+metricsRouter.get("/", async (_req, res) => {
+  const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;
+
+  if (metricsAuthToken) {
+    const header = _req.headers.authorization;
+    if (!header || header !== `Bearer ${metricsAuthToken}`) {
+      res.status(401).json({ error: { code: "unauthorized", message: "Invalid or missing metrics token" } });
+      return;
+    }
+  }
+
+  res.set("Content-Type", register.contentType);
+  res.send(await register.metrics());
+});

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -7,27 +7,29 @@ process.env.PREDICTIFY_CONTRACT_ID = "test-contract-id";
 import request from "supertest";
 import { createApp } from "../src/index";
 
-describe("GET /metrics", () => {
+const METRICS_PATH = "/api/metrics";
+
+describe("GET /api/metrics", () => {
   afterEach(() => {
     delete process.env.METRICS_AUTH_TOKEN;
   });
 
   it("returns 200 when METRICS_AUTH_TOKEN is not set", async () => {
     delete process.env.METRICS_AUTH_TOKEN;
-    const res = await request(createApp()).get("/metrics");
+    const res = await request(createApp()).get(METRICS_PATH);
     expect(res.status).toBe(200);
   });
 
   it("returns 401 when METRICS_AUTH_TOKEN is set but not provided", async () => {
     process.env.METRICS_AUTH_TOKEN = "secret123";
-    const res = await request(createApp()).get("/metrics");
+    const res = await request(createApp()).get(METRICS_PATH);
     expect(res.status).toBe(401);
   });
 
   it("returns 200 when correct Bearer token is provided", async () => {
     process.env.METRICS_AUTH_TOKEN = "secret123";
     const res = await request(createApp())
-      .get("/metrics")
+      .get(METRICS_PATH)
       .set("Authorization", "Bearer secret123");
     expect(res.status).toBe(200);
   });
@@ -35,20 +37,20 @@ describe("GET /metrics", () => {
   it("returns 401 when wrong token is provided", async () => {
     process.env.METRICS_AUTH_TOKEN = "secret123";
     const res = await request(createApp())
-      .get("/metrics")
+      .get(METRICS_PATH)
       .set("Authorization", "Bearer wrongtoken");
     expect(res.status).toBe(401);
   });
 
   it("returns the Prometheus text content type", async () => {
     delete process.env.METRICS_AUTH_TOKEN;
-    const res = await request(createApp()).get("/metrics");
+    const res = await request(createApp()).get(METRICS_PATH);
     expect(res.headers["content-type"]).toContain("text/plain");
   });
 
   it("contains all custom metric names in the body", async () => {
     delete process.env.METRICS_AUTH_TOKEN;
-    const res = await request(createApp()).get("/metrics");
+    const res = await request(createApp()).get(METRICS_PATH);
     expect(res.text).toContain("http_request_duration_seconds");
     expect(res.text).toContain("indexer_polls_total");
     expect(res.text).toContain("webhook_deliveries_total");
@@ -57,7 +59,7 @@ describe("GET /metrics", () => {
 
   it("contains default Node.js metrics", async () => {
     delete process.env.METRICS_AUTH_TOKEN;
-    const res = await request(createApp()).get("/metrics");
+    const res = await request(createApp()).get(METRICS_PATH);
     expect(res.text).toContain("process_cpu_user_seconds_total");
   });
 
@@ -65,7 +67,7 @@ describe("GET /metrics", () => {
     delete process.env.METRICS_AUTH_TOKEN;
     const app = createApp();
     await request(app).get("/health");
-    const res = await request(app).get("/metrics");
+    const res = await request(app).get(METRICS_PATH);
     expect(res.text).toContain("http_request_duration_seconds_count");
   });
 
@@ -73,7 +75,7 @@ describe("GET /metrics", () => {
     delete process.env.METRICS_AUTH_TOKEN;
     const { indexerPollsTotal } = await import("../src/metrics/registry");
     indexerPollsTotal.inc();
-    const res = await request(createApp()).get("/metrics");
+    const res = await request(createApp()).get(METRICS_PATH);
     const match = res.text.match(/^indexer_polls_total\s+(\d+)/m);
     expect(match).toBeTruthy();
     expect(Number(match![1])).toBeGreaterThanOrEqual(1);
@@ -84,7 +86,7 @@ describe("GET /metrics", () => {
     const { webhookDeliveriesTotal } = await import("../src/metrics/registry");
     webhookDeliveriesTotal.inc({ status: "success" });
     webhookDeliveriesTotal.inc({ status: "failed" });
-    const res = await request(createApp()).get("/metrics");
+    const res = await request(createApp()).get(METRICS_PATH);
     expect(res.text).toContain('webhook_deliveries_total{status="success"}');
     expect(res.text).toContain('webhook_deliveries_total{status="failed"}');
   });
@@ -94,8 +96,33 @@ describe("GET /metrics", () => {
     const { authVerificationsTotal } = await import("../src/metrics/registry");
     authVerificationsTotal.inc({ outcome: "success" });
     authVerificationsTotal.inc({ outcome: "failure" });
-    const res = await request(createApp()).get("/metrics");
+    const res = await request(createApp()).get(METRICS_PATH);
     expect(res.text).toContain('auth_verifications_total{outcome="success"}');
     expect(res.text).toContain('auth_verifications_total{outcome="failure"}');
+  });
+
+  it("returns 401 with wrong Bearer scheme", async () => {
+    process.env.METRICS_AUTH_TOKEN = "secret123";
+    const res = await request(createApp())
+      .get(METRICS_PATH)
+      .set("Authorization", "Basic secret123");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for /metrics (without /api prefix)", async () => {
+    delete process.env.METRICS_AUTH_TOKEN;
+    const res = await request(createApp()).get("/metrics");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns JSON error body on 401", async () => {
+    process.env.METRICS_AUTH_TOKEN = "secret123";
+    const res = await request(createApp()).get(METRICS_PATH);
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({
+      error: {
+        code: "unauthorized",
+      },
+    });
   });
 });


### PR DESCRIPTION
Closes #159

# Metrics API Update Summary

### Overview of Changes
The metrics endpoint has been moved and secured with Bearer token authentication[cite: 1].

| File | Action | Description |
| :--- | :--- | :--- |
| `src/routes/metrics.ts` | New | Dedicated route for `GET /api/metrics` with Bearer token auth via `METRICS_AUTH_TOKEN`[cite: 1]. |
| `docs/metrics.md` | New | Documentation of the metrics endpoint, auth, collected metrics, and config[cite: 1]. |
| `src/config/env-schema.ts` | Modified | Added `METRICS_AUTH_TOKEN` (string, default "")[cite: 1]. |
| `src/config/env.ts` | Modified | Added `METRICS_AUTH_TOKEN` to runtime schema[cite: 1]. |
| `src/index.ts` | Modified | Replaced inline `/metrics` route with `app.use("/api/metrics", metricsRouter)`; removed unused `register` import[cite: 1]. |
| `tests/metrics.test.ts` | Modified | Changed all paths from `/metrics` to `/api/metrics`; added 3 new tests: wrong Bearer scheme, 404 on old path, JSON error body on 401[cite: 1]. |

---

### Test Results
* **14/14 passed** (3 new tests added).
* **Lint passes clean** (0 errors).
* *Note: The 6 pre-existing failures in `env.test.ts` and `healthz-dependencies.test.ts` are unrelated to these changes.*

---

### Key Design Decisions
* **Dynamic Token Loading**: The route reads `process.env.METRICS_AUTH_TOKEN` at request time (not via pre-parsed env), so token changes take effect without restart.
* **Validation**: The env schema validates the variable's shape at startup.
* **Standardized Errors**: Auth failure returns `401` with a JSON error envelope (`{ error: { code: "unauthorized", message } }`) matching the project's standardized error format.
* **Backward Compatibility**: Empty `METRICS_AUTH_TOKEN` (default) means no auth is required, matching the existing `env.example` convention.