### PR TITLE
Add structured webhook

### DIFF
--- a/docs/WEBHOOK_EVENTS.md
+++ b/docs/WEBHOOK_EVENTS.md
@@ -1,0 +1,45 @@
+# Webhook events
+
+Predictify sends webhook deliveries as JSON `POST` requests. Each delivery uses
+`X-Predictify-Event` for the event name, `X-Predictify-Delivery` for the unique
+delivery id, and `X-Predictify-Signature` for the HMAC signature.
+
+## `predictions.created`
+
+Emitted after a prediction is accepted and persisted for a market. Consumers
+should treat deliveries as at-least-once and deduplicate with
+`X-Predictify-Delivery` or `prediction.id`.
+
+### Payload
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `event` | string | Always `predictions.created`. |
+| `prediction.id` | UUID string | Prediction identifier. |
+| `prediction.marketId` | string | Market receiving the prediction. |
+| `prediction.userId` | UUID string | Internal Predictify user identifier. |
+| `prediction.outcome` | string | Selected market outcome. |
+| `prediction.amount` | numeric string | Prediction amount in the smallest supported unit. |
+| `prediction.txHash` | string | Client/on-chain transaction hash associated with the prediction. |
+| `prediction.status` | string | Initial prediction status, usually `pending`. |
+| `prediction.createdAt` | ISO-8601 string | Time the prediction row was created. |
+| `timestamp` | ISO-8601 string | Event timestamp; matches `prediction.createdAt`. |
+
+### Example
+
+```json
+{
+  "event": "predictions.created",
+  "prediction": {
+    "id": "11111111-1111-4111-8111-111111111111",
+    "marketId": "mkt-2026-election",
+    "userId": "22222222-2222-4222-8222-222222222222",
+    "outcome": "YES",
+    "amount": "10000000",
+    "txHash": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+    "status": "pending",
+    "createdAt": "2026-06-29T12:00:00.000Z"
+  },
+  "timestamp": "2026-06-29T12:00:00.000Z"
+}
+```

--- a/src/services/webhookCatalog.ts
+++ b/src/services/webhookCatalog.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+
+const isoDateTime = z.string().datetime({ offset: true });
+
+export const predictionCreatedPayloadSchema = z.object({
+  event: z.literal("predictions.created"),
+  prediction: z.object({
+    id: z.string().uuid(),
+    marketId: z.string().min(1),
+    userId: z.string().uuid(),
+    outcome: z.string().min(1),
+    amount: z.string().regex(/^\d+(?:\.\d+)?$/, "amount must be a numeric string"),
+    txHash: z.string().min(1),
+    status: z.string().min(1),
+    createdAt: isoDateTime,
+  }),
+  timestamp: isoDateTime,
+});
+
+export type PredictionCreatedPayload = z.infer<typeof predictionCreatedPayloadSchema>;
+
+export interface PredictionCreatedInput {
+  id: string;
+  marketId: string;
+  userId: string;
+  outcome: string;
+  amount: string;
+  txHash: string;
+  status: string;
+  createdAt: Date | string;
+}
+
+function toIsoTimestamp(value: Date | string): string {
+  if (value instanceof Date) return value.toISOString();
+  return new Date(value).toISOString();
+}
+
+export function buildPredictionCreatedPayload(prediction: PredictionCreatedInput): PredictionCreatedPayload {
+  const createdAt = toIsoTimestamp(prediction.createdAt);
+
+  return predictionCreatedPayloadSchema.parse({
+    event: "predictions.created",
+    prediction: {
+      id: prediction.id,
+      marketId: prediction.marketId,
+      userId: prediction.userId,
+      outcome: prediction.outcome,
+      amount: prediction.amount,
+      txHash: prediction.txHash,
+      status: prediction.status,
+      createdAt,
+    },
+    timestamp: createdAt,
+  });
+}
+
+export const webhookEventCatalog = {
+  "predictions.created": {
+    event: "predictions.created",
+    description: "Emitted after a new prediction record is accepted for a market.",
+    schema: predictionCreatedPayloadSchema,
+    example: buildPredictionCreatedPayload({
+      id: "11111111-1111-4111-8111-111111111111",
+      marketId: "mkt-2026-election",
+      userId: "22222222-2222-4222-8222-222222222222",
+      outcome: "YES",
+      amount: "10000000",
+      txHash: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+      status: "pending",
+      createdAt: "2026-06-29T12:00:00.000Z",
+    }),
+  },
+} as const;
+
+export type WebhookEventType = keyof typeof webhookEventCatalog;

--- a/tests/webhookCatalog.test.ts
+++ b/tests/webhookCatalog.test.ts
@@ -1,0 +1,62 @@
+import {
+  buildPredictionCreatedPayload,
+  predictionCreatedPayloadSchema,
+  webhookEventCatalog,
+} from "../src/services/webhookCatalog";
+
+describe("webhook event catalog", () => {
+  it("documents predictions.created with a valid structured example", () => {
+    const event = webhookEventCatalog["predictions.created"];
+
+    expect(event.event).toBe("predictions.created");
+    expect(() => event.schema.parse(event.example)).not.toThrow();
+    expect(event.example.prediction.status).toBe("pending");
+  });
+
+  it("builds a predictions.created payload from a prediction row", () => {
+    const payload = buildPredictionCreatedPayload({
+      id: "11111111-1111-4111-8111-111111111111",
+      marketId: "mkt-1",
+      userId: "22222222-2222-4222-8222-222222222222",
+      outcome: "NO",
+      amount: "2500000",
+      txHash: "0xabc123",
+      status: "pending",
+      createdAt: new Date("2026-06-29T13:14:15.000Z"),
+    });
+
+    expect(payload).toEqual({
+      event: "predictions.created",
+      prediction: {
+        id: "11111111-1111-4111-8111-111111111111",
+        marketId: "mkt-1",
+        userId: "22222222-2222-4222-8222-222222222222",
+        outcome: "NO",
+        amount: "2500000",
+        txHash: "0xabc123",
+        status: "pending",
+        createdAt: "2026-06-29T13:14:15.000Z",
+      },
+      timestamp: "2026-06-29T13:14:15.000Z",
+    });
+  });
+
+  it("rejects malformed predictions.created payloads", () => {
+    const result = predictionCreatedPayloadSchema.safeParse({
+      event: "predictions.created",
+      prediction: {
+        id: "not-a-uuid",
+        marketId: "mkt-1",
+        userId: "22222222-2222-4222-8222-222222222222",
+        outcome: "YES",
+        amount: "ten lumens",
+        txHash: "0xabc123",
+        status: "pending",
+        createdAt: "2026-06-29T13:14:15.000Z",
+      },
+      timestamp: "2026-06-29T13:14:15.000Z",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
Motivation
Provide a documented, typed, and validated webhook payload for the predictions.created event so downstream consumers can rely on a stable, machine-checked contract.
Description
Add a typed catalog entry and builder in src/services/webhookCatalog.ts including a Zod predictionCreatedPayloadSchema, buildPredictionCreatedPayload() helper, and webhookEventCatalog export.
Add human-facing documentation docs/WEBHOOK_EVENTS.md describing headers, payload fields, deduplication guidance, and an example JSON delivery for predictions.created.
Add focused unit tests in tests/webhookCatalog.test.ts that validate the example, the builder output, and schema rejection for malformed payloads.
Keep the change minimal and self-contained so the event contract is discoverable, typed, and test-covered.
Testing
Ran lint just for the new file with npx eslint src/services/webhookCatalog.ts, which succeeded.
Ran the focused unit tests with npm test -- --runTestsByPath tests/webhookCatalog.test.ts, and all tests passed (3 tests).
Running the repo-wide checks surfaced unrelated, pre-existing issues: npm run lint fails with existing lint errors outside this change; npm run build fails due to unrelated TypeScript errors in other modules; and npm test -- --runInBand fails across multiple suites primarily due to environment/dependency issues (eg. Redis ECONNREFUSED) and other pre-existing type/test failures.
Closes https://github.com/Predictify-org/predictify-backend/issues/202