### PR TITLE
Closes #140 Add JWT key rotation with kid header support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,14 @@ JWT_TTL_SECONDS=3600
 # Minimum internal interval between worker heartbeats; JWT_TTL_SECONDS must be >= this * 2
 WORKER_HEARTBEAT_SECONDS=30
 
+# Additional signing/verification keys for rotation (optional).
+# Comma-separated "kid:secret" pairs; each secret >= 32 chars. JWT_SECRET
+# above is always loaded too, under the reserved kid "default".
+# See docs/jwt-rotation.md and the rotation script: npm run jwt:rotate
+# JWT_KEYS=2026-07-01:7f3c9c2c4f0c4d5a8e9b1a2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f6
+# kid used to sign *new* tokens (default: "default", i.e. JWT_SECRET)
+# JWT_ACTIVE_KID=2026-07-01
+
 # Webhooks
 WEBHOOK_SIGNING_SECRET=replace-with-16+byte-random-string
 

--- a/docs/jwt-rotation.md
+++ b/docs/jwt-rotation.md
@@ -1,0 +1,144 @@
+# JWT key rotation
+
+Predictify issues access tokens (`POST /api/auth/verify`, `POST /api/auth/refresh`)
+as HS256 JWTs. This document explains how multiple signing keys are loaded,
+how the verifier picks the right one, and the runbook for rotating a key
+without invalidating tokens that are already out in the wild.
+
+## Why rotate
+
+A signing key may need to change because: it leaked, a scheduled rotation
+policy requires it, or an employee/system that had access to it is being
+decommissioned. Rotating naively (just swapping `JWT_SECRET`) immediately
+invalidates every outstanding access token, forcing every signed-in user to
+re-authenticate. Key-ID (`kid`) based rotation avoids that.
+
+## How it works
+
+### Key ring (`src/utils/keyRing.ts`)
+
+The app loads a *ring* of keys, each identified by a `kid`:
+
+- `JWT_SECRET` (required, existing variable) is always loaded under the
+  reserved kid `"default"`. Deployments that never touch the variables below
+  keep working exactly as before — this is a fully backward-compatible
+  addition.
+- `JWT_KEYS` (optional) adds more keys, as comma-separated `kid:secret`
+  pairs:
+
+  ```
+  JWT_KEYS=2026-07-01:7f3c9c2c4f0c4d5a8e9b1a2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f6,2026-06-01:a91e7b54...
+  ```
+
+  Each secret must be at least 32 characters. Kids may only contain letters,
+  digits, `.`, `_`, `-`, and must be unique (`"default"` is reserved).
+- `JWT_ACTIVE_KID` (optional) selects which loaded kid signs *new* tokens.
+  Defaults to `"default"`.
+
+The ring is parsed once per process at startup (same fail-fast pattern as
+`src/config/env.ts`) — a malformed `JWT_KEYS` or an `JWT_ACTIVE_KID` that
+doesn't match any loaded key crashes on boot rather than failing silently at
+request time.
+
+### Signing and verification (`src/services/jwtService.ts`)
+
+- `signAccessToken(payload)` signs with the active key and stamps its `kid`
+  into the JWT header (via the standard `keyid` option — no custom claims).
+- `verifyAccessToken(token)` reads the **unsigned** header to find the `kid`,
+  looks up the matching key in the ring (active *or* retired), and verifies
+  the signature against it. Tokens without a `kid` header — i.e. every token
+  issued before this feature shipped — fall back to `"default"`
+  (`JWT_SECRET`), so existing sessions are unaffected by the upgrade.
+
+Every call site that previously called `jwt.sign` / `jwt.verify` directly
+(`refreshTokenService`, `authVerifyService`, `requireAuth`, `requireAdmin`,
+`middleware/auth`) now goes through this single module, so a rotation is
+effective everywhere at once.
+
+Because verification accepts any loaded key, a token signed before a
+rotation stays valid until it naturally expires (`JWT_TTL_SECONDS`) — keys
+are never removed from the ring while a token signed with them could still
+be outstanding.
+
+## Rotation runbook
+
+Use `npm run jwt:rotate -- <command>` (wraps `scripts/rotate-jwt-key.ts`).
+By default the script only **prints** the resulting `JWT_KEYS` /
+`JWT_ACTIVE_KID` values — paste them into your secrets manager / deployment
+config. Pass `--write` to also update a local `.env` file (handy in dev);
+`--file <path>` overrides which file is read/written.
+
+Rotation is a deliberate three-step, three-deploy process. Each step is
+single-purpose so a partial rollout (some instances updated, some not) is
+always safe:
+
+### 1. Add the new key
+
+```bash
+npm run jwt:rotate -- add
+# or pin a specific kid: npm run jwt:rotate -- add 2026-07-01
+```
+
+This generates a new random secret and adds it to `JWT_KEYS`.
+**`JWT_ACTIVE_KID` is left unchanged** — nothing signs with the new key yet.
+
+Deploy this change everywhere. Once every instance has it, every verifier in
+the fleet recognizes the new `kid`, even though nothing has used it yet.
+
+### 2. Activate the new key
+
+```bash
+npm run jwt:rotate -- activate 2026-07-01
+```
+
+This flips `JWT_ACTIVE_KID`. Deploy again — from this point on, new tokens
+are signed with the new key. Tokens signed with the old key are still
+accepted (it's still in `JWT_KEYS`), so users mid-session are unaffected.
+
+### 3. Remove the retired key
+
+Wait at least `JWT_TTL_SECONDS` after step 2 deployed everywhere — long
+enough that no token signed with the old key can still be outstanding —
+then:
+
+```bash
+npm run jwt:rotate -- remove 2026-06-01
+```
+
+The script refuses to remove `"default"` (it's tied to `JWT_SECRET`, not
+`JWT_KEYS`) and refuses to remove whichever kid is currently active, to
+prevent locking out new sign-ins. Deploy once more to complete the rotation.
+
+### Inspecting current state
+
+```bash
+npm run jwt:rotate -- list
+```
+
+Prints every loaded kid and marks which one is active. Secrets are never
+printed by `list`.
+
+## Security notes
+
+- Secrets are validated at load time (`>= 32` chars) — the same bar as
+  `JWT_SECRET` today.
+- `pino`'s redaction config (`src/config/logger.ts`) already strips
+  `Authorization` headers and `token` fields from logs; the key ring itself
+  never logs secret material.
+- An unrecognized `kid` (e.g. a forged header naming a key that was already
+  removed) is treated as an invalid token — verification fails closed, the
+  same as a bad signature.
+- Rotation never widens the trust boundary: every key in the ring is one
+  that an operator explicitly added via `JWT_SECRET` or `JWT_KEYS`.
+
+## Testing
+
+```bash
+npm test -- tests/keyRing.test.ts tests/jwtService.test.ts
+```
+
+Covers: multi-key loading, duplicate/invalid kid rejection, secret-length
+validation, `JWT_ACTIVE_KID` resolution and mismatch errors, signing embeds
+the active kid, verification routes by kid (active and retired keys),
+fallback for tokens with no `kid`, rejection of unknown kids, and the usual
+expired/wrong-issuer/wrong-audience/tampered-signature cases.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "indexer:gap-scan": "ts-node-dev --transpile-only src/workers/indexerGapScan.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
-    "db:check-drift": "ts-node scripts/check-drizzle-drift.ts"
+    "db:check-drift": "ts-node scripts/check-drizzle-drift.ts",
+    "jwt:rotate": "ts-node --transpile-only scripts/rotate-jwt-key.ts"
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "7.3.4",

--- a/scripts/rotate-jwt-key.ts
+++ b/scripts/rotate-jwt-key.ts
@@ -1,0 +1,219 @@
+/**
+ * JWT key rotation CLI.
+ *
+ * Manages the JWT_KEYS / JWT_ACTIVE_KID env vars consumed by
+ * src/utils/keyRing.ts. Safe, zero-downtime rotation is a three-step
+ * process — see docs/jwt-rotation.md for the full runbook:
+ *
+ *   1. add               — generate a new key, add it to JWT_KEYS (NOT yet
+ *                           used for signing). Deploy so every verifier
+ *                           knows the new key.
+ *   2. activate <kid>     — flip JWT_ACTIVE_KID to the new key. Deploy so
+ *                           new tokens are signed with it.
+ *   3. remove <kid>       — once JWT_TTL_SECONDS has fully elapsed (so no
+ *                           outstanding token still uses the old key),
+ *                           delete the retired key. Deploy.
+ *
+ * Usage:
+ *   npx ts-node --transpile-only scripts/rotate-jwt-key.ts list
+ *   npx ts-node --transpile-only scripts/rotate-jwt-key.ts add [kid]
+ *   npx ts-node --transpile-only scripts/rotate-jwt-key.ts activate <kid>
+ *   npx ts-node --transpile-only scripts/rotate-jwt-key.ts remove <kid>
+ *
+ * By default the new state is only printed (paste it into your secrets
+ * manager / deployment config). Pass --write to also update a local .env
+ * file (handy in development); --file <path> overrides the .env location.
+ */
+import fs from "fs";
+import path from "path";
+import { randomBytes } from "crypto";
+import { DEFAULT_KID, parseJwtKeysEnv, formatJwtKeysEnv, type JwtKey } from "../src/utils/jwtKeyFormat";
+
+const SECRET_BYTES = 32; // 32 bytes -> 64 hex chars, well above the 32-char minimum.
+
+interface ParsedArgs {
+  command: string;
+  positional: string[];
+  write: boolean;
+  file: string;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const [command, ...rest] = argv;
+  const positional: string[] = [];
+  let write = false;
+  let file = path.resolve(process.cwd(), ".env");
+
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i];
+    if (arg === "--write") {
+      write = true;
+    } else if (arg === "--file") {
+      file = path.resolve(process.cwd(), rest[++i] ?? "");
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  return { command: command ?? "", positional, write, file };
+}
+
+/** Minimal .env loader — same contract as scripts/check-env.ts. */
+function loadDotEnv(envPath: string): void {
+  if (!fs.existsSync(envPath)) return;
+  const lines = fs.readFileSync(envPath, "utf8").split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    const raw = trimmed.slice(eqIdx + 1).trim();
+    const value = raw.replace(/^["']|["']$/g, "");
+    if (key && !(key in process.env)) {
+      process.env[key] = value;
+    }
+  }
+}
+
+/** Replaces (or appends) a `KEY=value` line in an .env file's contents. */
+function setEnvLine(content: string, key: string, value: string): string {
+  const linePattern = new RegExp(`^${key}=.*$`, "m");
+  const line = `${key}=${value}`;
+  if (linePattern.test(content)) {
+    return content.replace(linePattern, line);
+  }
+  const withTrailingNewline = content.endsWith("\n") || content.length === 0 ? content : `${content}\n`;
+  return `${withTrailingNewline}${line}\n`;
+}
+
+function formatJwtKeys(keys: JwtKey[]): string {
+  return keys.map((k) => `${k.kid}:${k.secret}`).join(",");
+}
+
+function loadCurrentKeys(): JwtKey[] {
+  const raw = process.env.JWT_KEYS;
+  return raw && raw.trim().length > 0 ? parseJwtKeysEnv(raw) : [];
+}
+
+function printResult(jwtKeys: JwtKey[], activeKid: string, args: ParsedArgs): void {
+  console.log(`JWT_KEYS=${formatJwtKeys(jwtKeys)}`);
+  console.log(`JWT_ACTIVE_KID=${activeKid}`);
+
+  if (args.write) {
+    if (!fs.existsSync(args.file)) {
+      console.error(`\n--write was passed but ${args.file} does not exist.`);
+      process.exit(1);
+    }
+    let content = fs.readFileSync(args.file, "utf8");
+    content = setEnvLine(content, "JWT_KEYS", formatJwtKeys(jwtKeys));
+    content = setEnvLine(content, "JWT_ACTIVE_KID", activeKid);
+    fs.writeFileSync(args.file, content);
+    console.log(`\nWrote updated JWT_KEYS / JWT_ACTIVE_KID to ${args.file}`);
+  } else {
+    console.log("\n(--write not passed: paste the lines above into your env config and deploy.)");
+  }
+}
+
+function cmdList(): void {
+  const keys = loadCurrentKeys();
+  const activeKid = process.env.JWT_ACTIVE_KID?.trim() || DEFAULT_KID;
+
+  console.log(`${DEFAULT_KID}\t(JWT_SECRET)${activeKid === DEFAULT_KID ? "  <- active" : ""}`);
+  for (const key of keys) {
+    console.log(`${key.kid}\t(JWT_KEYS)${activeKid === key.kid ? "  <- active" : ""}`);
+  }
+}
+
+function cmdAdd(args: ParsedArgs): void {
+  const keys = loadCurrentKeys();
+  const taken = new Set([DEFAULT_KID, ...keys.map((k) => k.kid)]);
+
+  let kid = args.positional[0];
+  if (kid) {
+    if (taken.has(kid)) {
+      console.error(`kid "${kid}" already exists`);
+      process.exit(1);
+    }
+  } else {
+    const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+    kid = today;
+    let suffix = 2;
+    while (taken.has(kid)) {
+      kid = `${today}-${suffix++}`;
+    }
+  }
+
+  const secret = randomBytes(SECRET_BYTES).toString("hex");
+  const updatedKeys = [...keys, { kid, secret }];
+  const activeKid = process.env.JWT_ACTIVE_KID?.trim() || DEFAULT_KID;
+
+  console.log(`Added kid "${kid}". JWT_ACTIVE_KID is unchanged (${activeKid}) — deploy this first,`);
+  console.log(`then run "activate ${kid}" once every instance has picked up the new key.\n`);
+  printResult(updatedKeys, activeKid, args);
+}
+
+function cmdActivate(args: ParsedArgs): void {
+  const kid = args.positional[0];
+  if (!kid) {
+    console.error("Usage: rotate-jwt-key activate <kid>");
+    process.exit(1);
+  }
+
+  const keys = loadCurrentKeys();
+  if (kid !== DEFAULT_KID && !keys.some((k) => k.kid === kid)) {
+    console.error(`Unknown kid "${kid}". Loaded kids: ${[DEFAULT_KID, ...keys.map((k) => k.kid)].join(", ")}`);
+    process.exit(1);
+  }
+
+  printResult(keys, kid, args);
+}
+
+function cmdRemove(args: ParsedArgs): void {
+  const kid = args.positional[0];
+  if (!kid) {
+    console.error("Usage: rotate-jwt-key remove <kid>");
+    process.exit(1);
+  }
+  if (kid === DEFAULT_KID) {
+    console.error(`Cannot remove "${DEFAULT_KID}" — it is tied to JWT_SECRET, not JWT_KEYS.`);
+    process.exit(1);
+  }
+
+  const activeKid = process.env.JWT_ACTIVE_KID?.trim() || DEFAULT_KID;
+  if (kid === activeKid) {
+    console.error(`kid "${kid}" is the active signing key — activate a different kid before removing it.`);
+    process.exit(1);
+  }
+
+  const keys = loadCurrentKeys();
+  if (!keys.some((k) => k.kid === kid)) {
+    console.error(`Unknown kid "${kid}". Loaded kids: ${[DEFAULT_KID, ...keys.map((k) => k.kid)].join(", ")}`);
+    process.exit(1);
+  }
+
+  console.log(`Removing kid "${kid}". Only do this once JWT_TTL_SECONDS has fully elapsed since it was`);
+  console.log(`deactivated — any token still signed with it will fail verification after this deploys.\n`);
+  printResult(keys.filter((k) => k.kid !== kid), activeKid, args);
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  loadDotEnv(args.file);
+
+  switch (args.command) {
+    case "list":
+      return cmdList();
+    case "add":
+      return cmdAdd(args);
+    case "activate":
+      return cmdActivate(args);
+    case "remove":
+      return cmdRemove(args);
+    default:
+      console.error("Usage: rotate-jwt-key <list|add|activate|remove> [kid] [--write] [--file <path>]");
+      process.exit(1);
+  }
+}
+
+main();

--- a/src/config/env-schema.ts
+++ b/src/config/env-schema.ts
@@ -14,6 +14,9 @@ export const envSchema = z.object({
   JWT_ISSUER: z.string().default("predictify"),
   JWT_AUDIENCE: z.string().default("predictify-app"),
   JWT_TTL_SECONDS: z.coerce.number().int().positive().default(3600),
+  // See src/utils/keyRing.ts for the "kid:secret,..." format and rotation flow.
+  JWT_KEYS: z.string().optional(),
+  JWT_ACTIVE_KID: z.string().optional(),
 
   // ── Stellar / Soroban ─────────────────────────────────────
   STELLAR_NETWORK: z.enum(["testnet", "mainnet"]).default("testnet"),

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -10,6 +10,12 @@ const schema = z.object({
   JWT_ISSUER: z.string().default("predictify"),
   JWT_AUDIENCE: z.string().default("predictify-app"),
   JWT_TTL_SECONDS: z.coerce.number().int().positive().default(3600),
+  // Additional signing/verification keys for rotation, as comma-separated
+  // "kid:secret" pairs (each secret >= 32 chars). Parsed by src/utils/keyRing.ts.
+  // JWT_SECRET above is always loaded too, under the reserved kid "default".
+  JWT_KEYS: z.string().optional(),
+  // kid used to sign *new* tokens. Defaults to "default" (i.e. JWT_SECRET).
+  JWT_ACTIVE_KID: z.string().optional(),
   STELLAR_NETWORK: z.enum(["testnet", "mainnet"]).default("testnet"),
   SOROBAN_RPC_URL: z.string().url(),
   HORIZON_URL: z.string().url(),

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
-import jwt from "jsonwebtoken";
 import { env } from "../config/env";
+import { verifyAccessToken } from "../services/jwtService";
 
 export interface AuthenticatedRequest extends Request {
   user?: {
@@ -18,10 +18,7 @@ export function requireAdmin(req: AuthenticatedRequest, res: Response, next: Nex
     }
 
     const token = authHeader.split(" ")[1];
-    const payload = jwt.verify(token, env.JWT_SECRET, {
-      audience: env.JWT_AUDIENCE,
-      issuer: env.JWT_ISSUER,
-    }) as { sub: string };
+    const payload = verifyAccessToken(token) as { sub: string };
 
     const stellarAddress = payload.sub;
     if (!stellarAddress) {

--- a/src/middleware/requireAdmin.ts
+++ b/src/middleware/requireAdmin.ts
@@ -2,17 +2,17 @@
  * requireAdmin — Express middleware that enforces admin-only access.
  *
  * Expects:  Authorization: Bearer <jwt>
- * The JWT must be signed with JWT_SECRET and carry { role: "admin" }.
- * The verified subject (Stellar address) is attached as req.adminAddress
- * for downstream use in audit logging and rate-limit keying.
+ * The JWT must be signed with a key from the key ring (src/utils/keyRing.ts)
+ * and carry { role: "admin" }. The verified subject (Stellar address) is
+ * attached as req.adminAddress for downstream use in audit logging and
+ * rate-limit keying.
  *
  * Returns 403 for any of: missing header, invalid signature, wrong role.
  * Never reveals why verification failed (prevents enumeration).
  */
 
 import type { NextFunction, Request, Response } from "express";
-import jwt from "jsonwebtoken";
-import { env } from "../config/env";
+import { verifyAccessToken } from "../services/jwtService";
 
 // Augment Express Request so downstream handlers can read the admin identity
 // without casting.
@@ -39,10 +39,7 @@ export function requireAdmin(req: Request, res: Response, next: NextFunction): v
   const token = auth.slice(7);
 
   try {
-    const payload = jwt.verify(token, env.JWT_SECRET, {
-      issuer: env.JWT_ISSUER,
-      audience: env.JWT_AUDIENCE,
-    }) as AdminTokenPayload;
+    const payload = verifyAccessToken(token) as AdminTokenPayload;
 
     if (payload.role !== "admin" || !payload.sub) {
       res.status(403).json({ error: { code: "forbidden" } });

--- a/src/middleware/requireAuth.ts
+++ b/src/middleware/requireAuth.ts
@@ -15,7 +15,10 @@
  *
  * JWT contract
  * ------------
- *   Tokens must be signed with HS256 (HMAC-SHA256) using `env.JWT_SECRET`.
+ *   Tokens must be signed with HS256 (HMAC-SHA256) using a key from the
+ *   key ring (src/utils/keyRing.ts), selected by the `kid` header claim.
+ *   This allows signing keys to rotate without invalidating outstanding
+ *   tokens — see docs/jwt-rotation.md.
  *   Required claims:
  *     - iss  === env.JWT_ISSUER    (e.g. "predictify")
  *     - aud  === env.JWT_AUDIENCE  (e.g. "predictify-app")
@@ -30,13 +33,14 @@
  */
 
 import type { NextFunction, Request, RequestHandler, Response } from "express";
-import jwt, { type JwtPayload } from "jsonwebtoken";
+import type { JwtPayload } from "jsonwebtoken";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import { eq } from "drizzle-orm";
 import { env } from "../config/env";
 import { logger } from "../config/logger";
 import { users } from "../db/schema";
+import { verifyAccessToken } from "../services/jwtService";
 
 // ---------------------------------------------------------------------------
 // Shared DB pool (module-level singleton — one pool for the whole process).
@@ -88,11 +92,7 @@ function extractBearerToken(req: Request): string {
 function verifyToken(token: string): AuthPayload {
   let payload: JwtPayload | string;
   try {
-    payload = jwt.verify(token, env.JWT_SECRET, {
-      algorithms: ["HS256"],
-      issuer: env.JWT_ISSUER,
-      audience: env.JWT_AUDIENCE,
-    });
+    payload = verifyAccessToken(token);
   } catch (err) {
     // Map jsonwebtoken error names to a single stable code so callers don't
     // need to inspect the message string.

--- a/src/services/authVerifyService.ts
+++ b/src/services/authVerifyService.ts
@@ -1,9 +1,9 @@
-import jwt from "jsonwebtoken";
 import { Keypair } from "@stellar/stellar-sdk";
 import { env } from "../config/env";
 import { verifyAndConsume } from "./authChallengeService";
 import { upsertUserByStellarAddress } from "../db/userRepo";
 import { Result, ok, err } from "../errors/RouteError";
+import { signAccessToken } from "./jwtService";
 
 export interface AuthVerifyResult {
   accessToken: string;
@@ -46,15 +46,7 @@ export async function verifyChallengeAndIssueJwt(
 
   const user = await upsertUserByStellarAddress(stellarAddress);
 
-  const accessToken = jwt.sign(
-    { sub: user.stellarAddress },
-    env.JWT_SECRET,
-    {
-      expiresIn: env.JWT_TTL_SECONDS,
-      issuer: env.JWT_ISSUER,
-      audience: env.JWT_AUDIENCE,
-    },
-  );
+  const accessToken = signAccessToken({ sub: user.stellarAddress });
 
   return ok({
     accessToken,

--- a/src/services/jwtService.ts
+++ b/src/services/jwtService.ts
@@ -1,0 +1,69 @@
+/**
+ * jwtService.ts
+ * -------------
+ * Single source of truth for signing and verifying Predictify access tokens.
+ * Backed by the key ring (src/utils/keyRing.ts) so several signing keys can
+ * be active at once, each identified by a `kid` header claim — enabling
+ * key rotation without invalidating outstanding tokens.
+ *
+ *   - signAccessToken always signs with the *active* key and stamps its kid
+ *     onto the token header.
+ *   - verifyAccessToken reads the unsigned header to find the kid, looks up
+ *     the matching key (active or retired), and verifies against it. Tokens
+ *     issued before this feature shipped carry no `kid` header; those are
+ *     verified against the reserved "default" key (JWT_SECRET) so existing
+ *     sessions are unaffected.
+ *
+ * Throws the same jsonwebtoken error types (`TokenExpiredError`,
+ * `JsonWebTokenError`) that `jwt.verify` itself throws, so existing
+ * call-site error handling keeps working unchanged.
+ */
+import jwt, { type JwtPayload, type SignOptions } from "jsonwebtoken";
+import { env } from "../config/env";
+import { getSigningKey, getVerificationKey } from "../utils/keyRing";
+
+export type JwtSignPayload = Record<string, unknown> & { sub: string };
+
+/** Signs a new access token with the currently active signing key. */
+export function signAccessToken(payload: JwtSignPayload, options: SignOptions = {}): string {
+  const { kid, secret } = getSigningKey();
+  return jwt.sign(payload, secret, {
+    algorithm: "HS256",
+    expiresIn: env.JWT_TTL_SECONDS,
+    issuer: env.JWT_ISSUER,
+    audience: env.JWT_AUDIENCE,
+    keyid: kid,
+    ...options,
+  });
+}
+
+/**
+ * Verifies an access token against the key its `kid` header names (falling
+ * back to the "default" key for tokens with no `kid`). Returns the decoded
+ * payload on success.
+ *
+ * @throws {jwt.TokenExpiredError} when the token has expired.
+ * @throws {jwt.JsonWebTokenError} for any other invalid token: bad
+ *   signature, wrong issuer/audience, malformed token, or an unrecognized kid.
+ */
+export function verifyAccessToken(token: string): JwtPayload {
+  const decoded = jwt.decode(token, { complete: true });
+  const kid = decoded && typeof decoded !== "string" ? decoded.header.kid : undefined;
+
+  const key = getVerificationKey(kid);
+  if (!key) {
+    throw new jwt.JsonWebTokenError(`Unrecognized JWT kid: "${kid}"`);
+  }
+
+  const payload = jwt.verify(token, key.secret, {
+    algorithms: ["HS256"],
+    issuer: env.JWT_ISSUER,
+    audience: env.JWT_AUDIENCE,
+  });
+
+  if (typeof payload === "string") {
+    throw new jwt.JsonWebTokenError("Unexpected string JWT payload");
+  }
+
+  return payload;
+}

--- a/src/services/refreshTokenService.ts
+++ b/src/services/refreshTokenService.ts
@@ -2,10 +2,9 @@ import { db } from "../db/index";
 import { refreshTokens, users } from "../db/schema";
 import { eq, and, isNull } from "drizzle-orm";
 import crypto from "crypto";
-import jwt from "jsonwebtoken";
-import { env } from "../config/env";
 import { logger } from "../config/logger";
 import { Result, ok, err } from "../errors/RouteError";
+import { signAccessToken } from "./jwtService";
 
 const REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 const REFRESH_TOKEN_ERROR_MESSAGES = {
@@ -35,15 +34,7 @@ export function hashToken(token: string): string {
 }
 
 export function generateAccessToken(userId: string, stellarAddress: string): string {
-  return jwt.sign(
-    { sub: userId, stellarAddress },
-    env.JWT_SECRET,
-    {
-      expiresIn: env.JWT_TTL_SECONDS,
-      issuer: env.JWT_ISSUER,
-      audience: env.JWT_AUDIENCE,
-    }
-  );
+  return signAccessToken({ sub: userId, stellarAddress });
 }
 
 async function findRefreshTokenByRawToken(rawToken: string): Promise<RefreshTokenRecord | null> {

--- a/src/utils/jwtKeyFormat.ts
+++ b/src/utils/jwtKeyFormat.ts
@@ -1,0 +1,56 @@
+/**
+ * jwtKeyFormat.ts
+ * ---------------
+ * Pure parsing/formatting helpers for the JWT_KEYS env var format
+ * ("kid1:secret1,kid2:secret2"). Deliberately has no dependency on app
+ * config so it can be reused by the rotation CLI
+ * (scripts/rotate-jwt-key.ts) without requiring the full env schema to be
+ * valid (DATABASE_URL, SOROBAN_RPC_URL, ...) — only src/utils/keyRing.ts
+ * needs that, since it also wires in JWT_SECRET as the reserved "default" key.
+ */
+
+/** Reserved kid for the always-present JWT_SECRET key. */
+export const DEFAULT_KID = "default";
+
+const MIN_SECRET_LENGTH = 32;
+const KID_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+export interface JwtKey {
+  kid: string;
+  secret: string;
+}
+
+/** Parses the "kid1:secret1,kid2:secret2" format used by JWT_KEYS. */
+export function parseJwtKeysEnv(raw: string): JwtKey[] {
+  return raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .map((entry) => {
+      const sep = entry.indexOf(":");
+      if (sep === -1) {
+        throw new Error(`JWT_KEYS entry "${entry}" must be in "kid:secret" format`);
+      }
+
+      const kid = entry.slice(0, sep).trim();
+      const secret = entry.slice(sep + 1).trim();
+
+      if (!kid || !KID_PATTERN.test(kid)) {
+        throw new Error(
+          `JWT_KEYS kid "${kid}" is invalid — kids may only contain letters, digits, ".", "_", "-"`,
+        );
+      }
+      if (secret.length < MIN_SECRET_LENGTH) {
+        throw new Error(
+          `JWT_KEYS secret for kid "${kid}" must be at least ${MIN_SECRET_LENGTH} characters`,
+        );
+      }
+
+      return { kid, secret };
+    });
+}
+
+/** Serializes keys back to the "kid1:secret1,kid2:secret2" format. */
+export function formatJwtKeysEnv(keys: JwtKey[]): string {
+  return keys.map((k) => `${k.kid}:${k.secret}`).join(",");
+}

--- a/src/utils/keyRing.ts
+++ b/src/utils/keyRing.ts
@@ -1,0 +1,100 @@
+/**
+ * keyRing.ts
+ * ----------
+ * Loads the set of JWT signing/verification keys from environment
+ * configuration and exposes lookup by `kid` (key ID), enabling zero-downtime
+ * JWT key rotation.
+ *
+ * Env contract
+ * ------------
+ *   JWT_SECRET     (required, existing) — always loaded as the key with the
+ *                  reserved kid "default". Deployments that never set the
+ *                  variables below keep working exactly as before.
+ *   JWT_KEYS       (optional) — extra keys for rotation, formatted as
+ *                  comma-separated "kid:secret" pairs (see jwtKeyFormat.ts),
+ *                  e.g. "2026-07-01:7f3c9c2c...,2026-06-01:a91e7b54...".
+ *                  Each secret must be >= 32 characters; kids must be unique
+ *                  (the kid "default" is reserved for JWT_SECRET).
+ *   JWT_ACTIVE_KID (optional) — kid used to sign *new* tokens. Defaults to
+ *                  "default". Must reference a key loaded above.
+ *
+ * Verification accepts a token signed by ANY loaded key (active or
+ * retired), so tokens issued before a rotation remain valid until they
+ * expire naturally — rotating keys never invalidates outstanding tokens.
+ *
+ * The ring is built once per process (mirrors the eager, fail-fast parsing
+ * `env.ts` already does) and memoized; tests that need a different
+ * configuration follow the repo convention of `jest.resetModules()` after
+ * changing `process.env`.
+ */
+import { env } from "../config/env";
+import { DEFAULT_KID, parseJwtKeysEnv, type JwtKey } from "./jwtKeyFormat";
+
+export { DEFAULT_KID };
+export type { JwtKey };
+
+export interface KeyRing {
+  activeKid: string;
+  keys: ReadonlyMap<string, JwtKey>;
+}
+
+function buildKeyRing(): KeyRing {
+  const keys = new Map<string, JwtKey>();
+  keys.set(DEFAULT_KID, { kid: DEFAULT_KID, secret: env.JWT_SECRET });
+
+  if (env.JWT_KEYS && env.JWT_KEYS.trim().length > 0) {
+    for (const key of parseJwtKeysEnv(env.JWT_KEYS)) {
+      if (keys.has(key.kid)) {
+        throw new Error(
+          `Duplicate kid "${key.kid}" in JWT_KEYS (kid "${DEFAULT_KID}" is reserved for JWT_SECRET)`,
+        );
+      }
+      keys.set(key.kid, key);
+    }
+  }
+
+  const activeKid = env.JWT_ACTIVE_KID?.trim() || DEFAULT_KID;
+  if (!keys.has(activeKid)) {
+    throw new Error(
+      `JWT_ACTIVE_KID "${activeKid}" does not match any loaded JWT key. Loaded kids: ${[...keys.keys()].join(", ")}`,
+    );
+  }
+
+  return { activeKid, keys };
+}
+
+// Built eagerly, once per module instance — mirrors env.ts's own eager,
+// fail-fast `schema.parse(process.env)`. A malformed JWT_KEYS or a
+// JWT_ACTIVE_KID that names no loaded key crashes on boot, not mid-request.
+const ring: KeyRing = buildKeyRing();
+
+/** Returns the process-wide key ring. */
+export function getKeyRing(): KeyRing {
+  return ring;
+}
+
+/** Returns the key currently used to sign new tokens. */
+export function getSigningKey(): JwtKey {
+  const ring = getKeyRing();
+  return ring.keys.get(ring.activeKid)!;
+}
+
+/**
+ * Looks up a key by kid for verification. Tokens without a `kid` header
+ * (issued before key rotation existed) are verified against "default".
+ * Returns undefined when the kid is unrecognized (e.g. a retired/unknown key).
+ */
+export function getVerificationKey(kid: string | undefined): JwtKey | undefined {
+  const ring = getKeyRing();
+  return ring.keys.get(kid || DEFAULT_KID);
+}
+
+/** All currently loaded kids, in load order. Used by diagnostics and the rotation script. */
+export function listKids(): string[] {
+  return [...getKeyRing().keys.keys()];
+}
+
+/** The kid currently used to sign new tokens. */
+export function getActiveKid(): string {
+  return getKeyRing().activeKid;
+}

--- a/tests/authVerify.test.ts
+++ b/tests/authVerify.test.ts
@@ -5,7 +5,7 @@ import { createApp } from "../src/index";
 
 process.env.NODE_ENV = "test";
 process.env.PORT = "3001";
-process.env.LOG_LEVEL = "silent";
+process.env.LOG_LEVEL = "fatal";
 process.env.DATABASE_URL = "postgres://localhost/test";
 process.env.JWT_SECRET = "a-very-long-test-secret-at-least-32-bytes!!";
 process.env.JWT_ISSUER = "predictify";

--- a/tests/jwtKeyFormat.test.ts
+++ b/tests/jwtKeyFormat.test.ts
@@ -1,0 +1,92 @@
+import { parseJwtKeysEnv, formatJwtKeysEnv, DEFAULT_KID } from "../src/utils/jwtKeyFormat";
+
+const SECRET_A = "a".repeat(32);
+const SECRET_B = "b".repeat(40);
+
+describe("parseJwtKeysEnv", () => {
+  it("parses a single kid:secret pair", () => {
+    expect(parseJwtKeysEnv(`2026-01-01:${SECRET_A}`)).toEqual([
+      { kid: "2026-01-01", secret: SECRET_A },
+    ]);
+  });
+
+  it("parses multiple comma-separated pairs in order", () => {
+    expect(parseJwtKeysEnv(`a:${SECRET_A},b:${SECRET_B}`)).toEqual([
+      { kid: "a", secret: SECRET_A },
+      { kid: "b", secret: SECRET_B },
+    ]);
+  });
+
+  it("trims whitespace around entries and fields", () => {
+    expect(parseJwtKeysEnv(`  a : ${SECRET_A} , b:${SECRET_B}  `)).toEqual([
+      { kid: "a", secret: SECRET_A },
+      { kid: "b", secret: SECRET_B },
+    ]);
+  });
+
+  it("ignores empty entries from trailing/double commas", () => {
+    expect(parseJwtKeysEnv(`a:${SECRET_A},,b:${SECRET_B},`)).toEqual([
+      { kid: "a", secret: SECRET_A },
+      { kid: "b", secret: SECRET_B },
+    ]);
+  });
+
+  it("returns an empty array for an empty string", () => {
+    expect(parseJwtKeysEnv("")).toEqual([]);
+  });
+
+  it("accepts kids containing letters, digits, dots, underscores, and hyphens", () => {
+    expect(parseJwtKeysEnv(`a.b_c-2026.01:${SECRET_A}`)).toEqual([
+      { kid: "a.b_c-2026.01", secret: SECRET_A },
+    ]);
+  });
+
+  it("throws when an entry has no colon separator", () => {
+    expect(() => parseJwtKeysEnv("no-colon-here")).toThrow(/"kid:secret" format/);
+  });
+
+  it("throws when the kid contains an invalid character", () => {
+    expect(() => parseJwtKeysEnv(`bad kid:${SECRET_A}`)).toThrow(/is invalid/);
+  });
+
+  it("throws when the kid is empty", () => {
+    expect(() => parseJwtKeysEnv(`:${SECRET_A}`)).toThrow(/is invalid/);
+  });
+
+  it("throws when a secret is shorter than 32 characters", () => {
+    expect(() => parseJwtKeysEnv("kid:too-short")).toThrow(/at least 32 characters/);
+  });
+
+  it("includes the offending kid in the secret-length error", () => {
+    expect(() => parseJwtKeysEnv("my-kid:short")).toThrow(/"my-kid"/);
+  });
+});
+
+describe("formatJwtKeysEnv", () => {
+  it("serializes keys back to the kid:secret,... format", () => {
+    expect(
+      formatJwtKeysEnv([
+        { kid: "a", secret: SECRET_A },
+        { kid: "b", secret: SECRET_B },
+      ]),
+    ).toBe(`a:${SECRET_A},b:${SECRET_B}`);
+  });
+
+  it("returns an empty string for an empty list", () => {
+    expect(formatJwtKeysEnv([])).toBe("");
+  });
+
+  it("round-trips through parseJwtKeysEnv", () => {
+    const keys = [
+      { kid: "x", secret: SECRET_A },
+      { kid: "y", secret: SECRET_B },
+    ];
+    expect(parseJwtKeysEnv(formatJwtKeysEnv(keys))).toEqual(keys);
+  });
+});
+
+describe("DEFAULT_KID", () => {
+  it("is the reserved literal 'default'", () => {
+    expect(DEFAULT_KID).toBe("default");
+  });
+});

--- a/tests/jwtService.test.ts
+++ b/tests/jwtService.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for src/services/jwtService.ts — the centralized sign/verify layer
+ * backed by the key ring (src/utils/keyRing.ts).
+ *
+ * Env vars (including JWT_KEYS / JWT_ACTIVE_KID) must be set before env.ts
+ * and keyRing.ts are imported, so this file sets them up-front and uses
+ * jest.resetModules() to get a fresh keyRing/jwtService per scenario —
+ * the same pattern used by tests/env.test.ts and tests/keyRing.test.ts.
+ */
+import jwt from "jsonwebtoken";
+
+const SECRET = "x".repeat(32);
+const NEXT_SECRET = "y".repeat(40);
+const ISSUER = "predictify";
+const AUDIENCE = "predictify-app";
+
+const BASE_ENV = {
+  NODE_ENV: "test",
+  DATABASE_URL: "postgres://localhost:5432/test",
+  JWT_SECRET: SECRET,
+  JWT_ISSUER: ISSUER,
+  JWT_AUDIENCE: AUDIENCE,
+  JWT_TTL_SECONDS: "3600",
+  SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org",
+  HORIZON_URL: "https://horizon-testnet.stellar.org",
+  PREDICTIFY_CONTRACT_ID: "C123",
+};
+
+function setEnv(overrides: Record<string, string | undefined>): void {
+  delete process.env.JWT_KEYS;
+  delete process.env.JWT_ACTIVE_KID;
+  Object.assign(process.env, BASE_ENV);
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function loadJwtService(): typeof import("../src/services/jwtService") {
+  jest.resetModules();
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require("../src/services/jwtService");
+}
+
+/**
+ * Asserts `fn` throws an error with the given jsonwebtoken `.name`.
+ *
+ * jest.resetModules() (used by loadJwtService) gives jwtService its own
+ * `jsonwebtoken` module instance, so the `JsonWebTokenError` class it throws
+ * is a different object identity than the one imported at the top of this
+ * file — `toThrow(jwt.JsonWebTokenError)` would always report a (spurious)
+ * mismatch. `.name` is a plain string set by the constructor and stays
+ * stable across module instances, so check that instead — the same
+ * discriminator src/middleware/requireAuth.ts itself relies on.
+ */
+function expectThrowsNamed(fn: () => unknown, name: string): void {
+  try {
+    fn();
+  } catch (err) {
+    expect((err as Error).name).toBe(name);
+    return;
+  }
+  throw new Error(`Expected function to throw "${name}", but it did not throw`);
+}
+
+afterAll(() => {
+  delete process.env.JWT_KEYS;
+  delete process.env.JWT_ACTIVE_KID;
+});
+
+describe("signAccessToken", () => {
+  it("signs with the default key and embeds kid='default' when no rotation is configured", () => {
+    setEnv({});
+    const { signAccessToken } = loadJwtService();
+
+    const token = signAccessToken({ sub: "GUSER" });
+    const decoded = jwt.decode(token, { complete: true });
+
+    expect(decoded?.header.kid).toBe("default");
+    expect(decoded?.header.alg).toBe("HS256");
+
+    const payload = jwt.verify(token, SECRET, { issuer: ISSUER, audience: AUDIENCE }) as jwt.JwtPayload;
+    expect(payload.sub).toBe("GUSER");
+  });
+
+  it("signs with the active rotation key and embeds its kid", () => {
+    setEnv({ JWT_KEYS: `2026-01-01:${NEXT_SECRET}`, JWT_ACTIVE_KID: "2026-01-01" });
+    const { signAccessToken } = loadJwtService();
+
+    const token = signAccessToken({ sub: "GUSER" });
+    const decoded = jwt.decode(token, { complete: true });
+    expect(decoded?.header.kid).toBe("2026-01-01");
+
+    // Verifying with the OLD secret must fail — proves it signed with the new one.
+    expectThrowsNamed(() => jwt.verify(token, SECRET), "JsonWebTokenError");
+    const payload = jwt.verify(token, NEXT_SECRET, { issuer: ISSUER, audience: AUDIENCE }) as jwt.JwtPayload;
+    expect(payload.sub).toBe("GUSER");
+  });
+
+  it("carries arbitrary extra claims through to the payload", () => {
+    setEnv({});
+    const { signAccessToken } = loadJwtService();
+    const token = signAccessToken({ sub: "GUSER", stellarAddress: "GUSER", role: "admin" });
+    const payload = jwt.verify(token, SECRET) as jwt.JwtPayload;
+    expect(payload.stellarAddress).toBe("GUSER");
+    expect(payload.role).toBe("admin");
+  });
+});
+
+describe("verifyAccessToken", () => {
+  it("verifies a token signed by signAccessToken with the default key", () => {
+    setEnv({});
+    const { signAccessToken, verifyAccessToken } = loadJwtService();
+    const token = signAccessToken({ sub: "GUSER" });
+    expect(verifyAccessToken(token).sub).toBe("GUSER");
+  });
+
+  it("verifies a token signed with the currently active rotation key", () => {
+    setEnv({ JWT_KEYS: `2026-01-01:${NEXT_SECRET}`, JWT_ACTIVE_KID: "2026-01-01" });
+    const { signAccessToken, verifyAccessToken } = loadJwtService();
+    const token = signAccessToken({ sub: "GUSER" });
+    expect(verifyAccessToken(token).sub).toBe("GUSER");
+  });
+
+  it("still verifies a token signed under a now-retired key (rotation doesn't invalidate it)", () => {
+    // "default" (JWT_SECRET) is retired in favor of the new active kid, but a
+    // token issued before the rotation must keep verifying until it expires.
+    setEnv({ JWT_KEYS: `2026-01-01:${NEXT_SECRET}`, JWT_ACTIVE_KID: "2026-01-01" });
+    const { verifyAccessToken } = loadJwtService();
+
+    const legacyToken = jwt.sign({ sub: "GUSER" }, SECRET, {
+      algorithm: "HS256",
+      issuer: ISSUER,
+      audience: AUDIENCE,
+      expiresIn: 3600,
+      keyid: "default",
+    });
+
+    expect(verifyAccessToken(legacyToken).sub).toBe("GUSER");
+  });
+
+  it("falls back to the default key for tokens with no kid header (pre-rotation tokens)", () => {
+    setEnv({ JWT_KEYS: `2026-01-01:${NEXT_SECRET}`, JWT_ACTIVE_KID: "2026-01-01" });
+    const { verifyAccessToken } = loadJwtService();
+
+    const noKidToken = jwt.sign({ sub: "GUSER" }, SECRET, {
+      algorithm: "HS256",
+      issuer: ISSUER,
+      audience: AUDIENCE,
+      expiresIn: 3600,
+    });
+    expect(jwt.decode(noKidToken, { complete: true })?.header.kid).toBeUndefined();
+
+    expect(verifyAccessToken(noKidToken).sub).toBe("GUSER");
+  });
+
+  it("throws JsonWebTokenError for a token naming an unrecognized kid", () => {
+    setEnv({});
+    const { verifyAccessToken } = loadJwtService();
+
+    const forged = jwt.sign({ sub: "GUSER" }, "some-other-32-character-secret!!", {
+      algorithm: "HS256",
+      issuer: ISSUER,
+      audience: AUDIENCE,
+      keyid: "kid-that-was-never-loaded",
+    });
+
+    expectThrowsNamed(() => verifyAccessToken(forged), "JsonWebTokenError");
+  });
+
+  it("throws TokenExpiredError for an expired token", () => {
+    setEnv({});
+    const { signAccessToken, verifyAccessToken } = loadJwtService();
+    const token = signAccessToken({ sub: "GUSER" }, { expiresIn: -1 });
+    expectThrowsNamed(() => verifyAccessToken(token), "TokenExpiredError");
+  });
+
+  it("throws JsonWebTokenError for a tampered signature", () => {
+    setEnv({});
+    const { signAccessToken, verifyAccessToken } = loadJwtService();
+    const token = signAccessToken({ sub: "GUSER" });
+    const tampered = token.slice(0, -2) + (token.slice(-2) === "AA" ? "BB" : "AA");
+    expectThrowsNamed(() => verifyAccessToken(tampered), "JsonWebTokenError");
+  });
+
+  it("throws JsonWebTokenError for the wrong issuer", () => {
+    setEnv({});
+    const { verifyAccessToken } = loadJwtService();
+    const token = jwt.sign({ sub: "GUSER" }, SECRET, {
+      algorithm: "HS256",
+      issuer: "someone-else",
+      audience: AUDIENCE,
+      keyid: "default",
+    });
+    expectThrowsNamed(() => verifyAccessToken(token), "JsonWebTokenError");
+  });
+
+  it("throws JsonWebTokenError for the wrong audience", () => {
+    setEnv({});
+    const { verifyAccessToken } = loadJwtService();
+    const token = jwt.sign({ sub: "GUSER" }, SECRET, {
+      algorithm: "HS256",
+      issuer: ISSUER,
+      audience: "someone-elses-app",
+      keyid: "default",
+    });
+    expectThrowsNamed(() => verifyAccessToken(token), "JsonWebTokenError");
+  });
+
+  it("throws JsonWebTokenError for a malformed token string", () => {
+    setEnv({});
+    const { verifyAccessToken } = loadJwtService();
+    expectThrowsNamed(() => verifyAccessToken("not.a.jwt"), "JsonWebTokenError");
+  });
+});

--- a/tests/keyRing.test.ts
+++ b/tests/keyRing.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for src/utils/keyRing.ts.
+ *
+ * keyRing builds its ring once per module instance (mirrors env.ts's eager
+ * parsing), so each scenario below uses jest.resetModules() + require() —
+ * the same pattern tests/env.test.ts uses to exercise different env configs.
+ */
+const SECRET = "x".repeat(32);
+const SECRET_2 = "y".repeat(40);
+const SECRET_3 = "z".repeat(40);
+
+const BASE_ENV = {
+  NODE_ENV: "test",
+  DATABASE_URL: "postgres://localhost:5432/test",
+  JWT_SECRET: SECRET,
+  SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org",
+  HORIZON_URL: "https://horizon-testnet.stellar.org",
+  PREDICTIFY_CONTRACT_ID: "C123",
+};
+
+function setEnv(overrides: Record<string, string | undefined>): void {
+  delete process.env.JWT_KEYS;
+  delete process.env.JWT_ACTIVE_KID;
+  Object.assign(process.env, BASE_ENV);
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function loadKeyRing(): typeof import("../src/utils/keyRing") {
+  jest.resetModules();
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require("../src/utils/keyRing");
+}
+
+afterAll(() => {
+  delete process.env.JWT_KEYS;
+  delete process.env.JWT_ACTIVE_KID;
+});
+
+describe("keyRing", () => {
+  describe("default-only (no JWT_KEYS / JWT_ACTIVE_KID)", () => {
+    it("loads JWT_SECRET as the single 'default' key", () => {
+      setEnv({});
+      const { listKids, getActiveKid, getSigningKey, getVerificationKey, DEFAULT_KID } = loadKeyRing();
+
+      expect(listKids()).toEqual([DEFAULT_KID]);
+      expect(getActiveKid()).toBe(DEFAULT_KID);
+      expect(getSigningKey()).toEqual({ kid: DEFAULT_KID, secret: SECRET });
+      expect(getVerificationKey(DEFAULT_KID)).toEqual({ kid: DEFAULT_KID, secret: SECRET });
+    });
+
+    it("falls back to the default key when kid is undefined (legacy tokens)", () => {
+      setEnv({});
+      const { getVerificationKey, DEFAULT_KID } = loadKeyRing();
+      expect(getVerificationKey(undefined)).toEqual({ kid: DEFAULT_KID, secret: SECRET });
+    });
+
+    it("returns undefined for an unknown kid", () => {
+      setEnv({});
+      const { getVerificationKey } = loadKeyRing();
+      expect(getVerificationKey("nope")).toBeUndefined();
+    });
+  });
+
+  describe("JWT_KEYS adds rotation keys", () => {
+    it("loads additional keys alongside the default", () => {
+      setEnv({ JWT_KEYS: `2026-01-01:${SECRET_2},2025-12-01:${SECRET_3}` });
+      const { listKids, DEFAULT_KID } = loadKeyRing();
+      expect(listKids()).toEqual([DEFAULT_KID, "2026-01-01", "2025-12-01"]);
+    });
+
+    it("looks up a non-default key by kid", () => {
+      setEnv({ JWT_KEYS: `2026-01-01:${SECRET_2}` });
+      const { getVerificationKey } = loadKeyRing();
+      expect(getVerificationKey("2026-01-01")).toEqual({ kid: "2026-01-01", secret: SECRET_2 });
+    });
+
+    it("throws when JWT_KEYS reuses the reserved 'default' kid", () => {
+      setEnv({ JWT_KEYS: `default:${SECRET_2}` });
+      expect(() => loadKeyRing()).toThrow(/Duplicate kid "default"/);
+    });
+
+    it("throws when JWT_KEYS has two entries with the same kid", () => {
+      setEnv({ JWT_KEYS: `dup:${SECRET_2},dup:${SECRET_3}` });
+      expect(() => loadKeyRing()).toThrow(/Duplicate kid "dup"/);
+    });
+
+    it("propagates malformed JWT_KEYS parse errors", () => {
+      setEnv({ JWT_KEYS: "not-kid-secret-format" });
+      expect(() => loadKeyRing()).toThrow(/"kid:secret" format/);
+    });
+
+    it("treats a blank JWT_KEYS the same as unset", () => {
+      setEnv({ JWT_KEYS: "   " });
+      const { listKids, DEFAULT_KID } = loadKeyRing();
+      expect(listKids()).toEqual([DEFAULT_KID]);
+    });
+  });
+
+  describe("JWT_ACTIVE_KID", () => {
+    it("signs with the key named by JWT_ACTIVE_KID", () => {
+      setEnv({ JWT_KEYS: `2026-01-01:${SECRET_2}`, JWT_ACTIVE_KID: "2026-01-01" });
+      const { getSigningKey, getActiveKid } = loadKeyRing();
+      expect(getActiveKid()).toBe("2026-01-01");
+      expect(getSigningKey()).toEqual({ kid: "2026-01-01", secret: SECRET_2 });
+    });
+
+    it("defaults to the 'default' kid when unset", () => {
+      setEnv({ JWT_KEYS: `2026-01-01:${SECRET_2}` });
+      const { getActiveKid, DEFAULT_KID } = loadKeyRing();
+      expect(getActiveKid()).toBe(DEFAULT_KID);
+    });
+
+    it("throws at load time when JWT_ACTIVE_KID names an unknown kid", () => {
+      setEnv({ JWT_KEYS: `2026-01-01:${SECRET_2}`, JWT_ACTIVE_KID: "does-not-exist" });
+      expect(() => loadKeyRing()).toThrow(/JWT_ACTIVE_KID "does-not-exist" does not match/);
+    });
+
+    it("verification still accepts a retired (non-active) key", () => {
+      setEnv({ JWT_KEYS: `2026-01-01:${SECRET_2}`, JWT_ACTIVE_KID: "2026-01-01" });
+      const { getVerificationKey, DEFAULT_KID } = loadKeyRing();
+      // "default" (JWT_SECRET) is retired once a newer kid is activated,
+      // but must still verify tokens issued before the rotation.
+      expect(getVerificationKey(DEFAULT_KID)).toEqual({ kid: DEFAULT_KID, secret: SECRET });
+    });
+  });
+
+  describe("memoization", () => {
+    it("builds the ring once per module instance", () => {
+      setEnv({});
+      const { getKeyRing } = loadKeyRing();
+      expect(getKeyRing()).toBe(getKeyRing());
+    });
+  });
+});

--- a/tests/requireAuth.test.ts
+++ b/tests/requireAuth.test.ts
@@ -28,7 +28,7 @@ const TEST_STELLAR = "GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF12";
 
 process.env.NODE_ENV = "test";
 process.env.PORT = "3001";
-process.env.LOG_LEVEL = "silent";
+process.env.LOG_LEVEL = "fatal";
 process.env.DATABASE_URL = "postgres://localhost/test";
 process.env.JWT_SECRET = TEST_SECRET;
 process.env.JWT_ISSUER = TEST_ISSUER;


### PR DESCRIPTION
Fixes #140 Add JWT key rotation with kid header support


Add multi-key JWT signing/verification so signing keys can rotate without invalidating outstanding access tokens.

- src/utils/jwtKeyFormat.ts: pure parsing/formatting for the JWT_KEYS "kid:secret,..." env format (no app-config dependency, so the rotation CLI doesn't need DATABASE_URL etc. to run).
- src/utils/keyRing.ts: loads JWT_SECRET (always, as the reserved "default" key) plus optional JWT_KEYS/JWT_ACTIVE_KID, validating eagerly at boot (mirrors env.ts).
- src/services/jwtService.ts: single sign/verify entry point. Signs with the active key, stamping its kid into the JWT header; verifies by reading the kid header and checking the matching key (active or retired), falling back to "default" for tokens with no kid header so existing sessions survive the upgrade.
- Updated every prior jwt.sign/jwt.verify call site (refreshTokenService, authVerifyService, requireAuth, requireAdmin, middleware/auth) to go through jwtService.
- scripts/rotate-jwt-key.ts (npm run jwt:rotate): add/activate/remove CLI for the 3-step zero-downtime rotation runbook.
- docs/jwt-rotation.md: format, runbook, and security notes.
- Fixed a pre-existing invalid LOG_LEVEL="silent" in tests/requireAuth.test.ts and tests/authVerify.test.ts that crashed env parsing before these suites could even run.