### PR TITLE
feat: schema versioning table

### DIFF
--- a/drizzle/migrations/0022_schema_versions.sql
+++ b/drizzle/migrations/0022_schema_versions.sql
@@ -1,0 +1,32 @@
+-- Migration: schema_versions table + checksums
+--
+-- Tracks every applied migration by recording the migration name, the
+-- SHA-256 checksum of its SQL content, and the timestamp at which it was
+-- applied. This allows drift detection: if a previously-applied migration
+-- file is modified on disk, the stored checksum will no longer match.
+--
+-- Design decisions:
+--   • `version`      — the file-system migration tag (e.g. "0001_add_users").
+--                      TEXT PRIMARY KEY so it is both unique and self-documenting.
+--   • `checksum`     — hex-encoded SHA-256 of the raw migration SQL content.
+--                      64 characters, always stored lower-case.
+--   • `applied_at`   — timestamptz; when the migration runner first recorded this row.
+--   • `applied_by`   — optional; identity of the agent/process that applied it
+--                      (useful for multi-tenant or CI audit trails).
+--
+-- All statements use IF NOT EXISTS so re-running the migration is idempotent.
+
+CREATE TABLE IF NOT EXISTS schema_versions (
+  version     text        PRIMARY KEY,
+  checksum    text        NOT NULL,
+  applied_at  timestamptz NOT NULL DEFAULT now(),
+  applied_by  text,
+
+  -- checksum must be a 64-char lowercase hex string (SHA-256)
+  CONSTRAINT schema_versions_checksum_format
+    CHECK (checksum ~ '^[0-9a-f]{64}$')
+);
+
+-- Fast lookup by apply-time for chronological audits.
+CREATE INDEX IF NOT EXISTS schema_versions_applied_at_idx
+  ON schema_versions (applied_at DESC);

--- a/drizzle/schema-versions.sql
+++ b/drizzle/schema-versions.sql
@@ -1,0 +1,29 @@
+-- schema_versions.sql
+--
+-- Standalone DDL reference for the `schema_versions` table.
+-- The canonical migration is drizzle/migrations/0022_schema_versions.sql.
+-- This file documents the table design for reviewers and tooling.
+--
+-- Purpose:
+--   Record every applied Drizzle migration together with its SHA-256
+--   checksum, enabling drift detection when migration files change after
+--   they have been applied to a database.
+--
+-- Columns:
+--   version    — migration tag (e.g. "0001_add_users"), primary key.
+--   checksum   — hex SHA-256 of the migration SQL file at apply time.
+--   applied_at — when the row was written (defaults to now()).
+--   applied_by — optional; CI job name, user, or process identity.
+
+CREATE TABLE IF NOT EXISTS schema_versions (
+  version     text        PRIMARY KEY,
+  checksum    text        NOT NULL,
+  applied_at  timestamptz NOT NULL DEFAULT now(),
+  applied_by  text,
+
+  CONSTRAINT schema_versions_checksum_format
+    CHECK (checksum ~ '^[0-9a-f]{64}$')
+);
+
+CREATE INDEX IF NOT EXISTS schema_versions_applied_at_idx
+  ON schema_versions (applied_at DESC);

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -11,6 +11,10 @@ const schema = z.object({
   JWT_ISSUER: z.string().default("predictify"),
   JWT_AUDIENCE: z.string().default("predictify-app"),
   JWT_TTL_SECONDS: z.coerce.number().int().positive().default(3600),
+  // Optional multi-key ring for zero-downtime JWT rotation.
+  // Format: "kid1:secret1,kid2:secret2" — see src/utils/keyRing.ts.
+  JWT_KEYS: z.string().optional(),
+  JWT_ACTIVE_KID: z.string().optional(),
   WORKER_HEARTBEAT_SECONDS: z.coerce.number().int().positive().default(30),
   STELLAR_NETWORK: z.enum(["testnet", "mainnet"]).default("testnet"),
   SOROBAN_RPC_URL: z.string().url(),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -356,3 +356,40 @@ export const featureFlags = pgTable("feature_flags", {
     .notNull()
     .defaultNow(),
 });
+
+// ---------------------------------------------------------------------------
+// Schema Versions
+// ---------------------------------------------------------------------------
+/**
+ * schema_versions — per-migration checksum registry.
+ *
+ * Each row tracks a single applied Drizzle migration by recording:
+ *   - `version`    — the migration tag (file name without extension), PRIMARY KEY.
+ *   - `checksum`   — hex-encoded SHA-256 of the migration SQL at apply time.
+ *                    64 lower-case hex characters.
+ *   - `appliedAt`  — timestamp at which the row was first written.
+ *   - `appliedBy`  — optional identifier for the process/agent that ran the migration
+ *                    (CI job name, DB user, etc.).
+ *
+ * Drift detection: compare stored checksums against the current file contents.
+ * A mismatch means the migration was modified after it was applied.
+ */
+export const schemaVersions = pgTable(
+  "schema_versions",
+  {
+    version: text("version").primaryKey(),
+    checksum: text("checksum").notNull(),
+    appliedAt: timestamp("applied_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    appliedBy: text("applied_by"),
+  },
+  (t) => ({
+    schemaVersionsAppliedAtIdx: index("schema_versions_applied_at_idx").on(
+      t.appliedAt,
+    ),
+  }),
+);
+
+export type SchemaVersion = typeof schemaVersions.$inferSelect;
+export type NewSchemaVersion = typeof schemaVersions.$inferInsert;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { notificationsRouter } from "./routes/notifications";
 import { socialRouter } from "./routes/social";
 import { adminAuditRouter } from "./routes/admin/audit";
 import { adminMarketsRouter } from "./routes/admin/markets";
+import { adminSchemaVersionsRouter } from "./routes/admin/schema-versions";
 import { errorHandler } from "./middleware/errorHandler";
 import { requestContextStorage } from "./lib/requestContext";
 import { REQUEST_ID_HEADER } from "./lib/http";
@@ -105,6 +106,7 @@ export function createApp(_options?: unknown): express.Express {
   app.use("/api/me/devices", devicesRouter);
   app.use("/api/admin/audit", adminAuditRouter);
   app.use("/api/admin/markets", adminMarketsRouter);
+  app.use("/api/admin/schema-versions", adminSchemaVersionsRouter);
 
   app.get("/metrics", async (req, res) => {
     const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;

--- a/src/repositories/schemaVersionRepo.ts
+++ b/src/repositories/schemaVersionRepo.ts
@@ -1,0 +1,183 @@
+/**
+ * schemaVersionRepo — CRUD + drift-detection for the schema_versions table.
+ *
+ * Responsibilities:
+ *   - Record a migration as applied (with its SHA-256 checksum).
+ *   - Look up a single version row.
+ *   - List all recorded versions in chronological order.
+ *   - Verify the on-disk checksum of a migration SQL file against the stored
+ *     value and report any drift.
+ *
+ * Checksum algorithm: SHA-256 of the raw file/string content, hex-encoded,
+ * lower-case.  This is the same algorithm used in most migration tooling and
+ * produces a stable 64-character string.
+ */
+
+import { createHash } from "crypto";
+import { asc, desc, eq } from "drizzle-orm";
+import { db } from "../db/client";
+import { schemaVersions, type SchemaVersion, type NewSchemaVersion } from "../db/schema";
+
+// ---------------------------------------------------------------------------
+// Checksum helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the hex-encoded SHA-256 of arbitrary string content.
+ * The result is always 64 lower-case hexadecimal characters.
+ */
+export function computeChecksum(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+/**
+ * Validate that a string looks like a SHA-256 hex digest.
+ * Accepts exactly 64 lower-case hex characters.
+ */
+export function isValidChecksum(value: string): boolean {
+  return /^[0-9a-f]{64}$/.test(value);
+}
+
+// ---------------------------------------------------------------------------
+// Repository operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Record a migration as applied.
+ *
+ * Computes the SHA-256 checksum of `sqlContent` (the raw SQL string) and
+ * inserts a row into `schema_versions`.  If a row with the same `version`
+ * already exists the call is a no-op (ON CONFLICT DO NOTHING), making
+ * repeated calls idempotent.
+ *
+ * @param version   Migration tag, e.g. "0001_add_users".
+ * @param sqlContent Raw SQL content of the migration file.
+ * @param appliedBy Optional identity of the agent running the migration.
+ * @returns The newly inserted (or existing) schema_version row.
+ */
+export async function recordMigration(
+  version: string,
+  sqlContent: string,
+  appliedBy?: string,
+): Promise<SchemaVersion> {
+  if (!version || version.trim() === "") {
+    throw new Error("version must be a non-empty string");
+  }
+
+  const checksum = computeChecksum(sqlContent);
+
+  const [inserted] = await db
+    .insert(schemaVersions)
+    .values({
+      version: version.trim(),
+      checksum,
+      appliedBy: appliedBy ?? null,
+    } satisfies NewSchemaVersion)
+    .onConflictDoNothing()
+    .returning();
+
+  // If the row already existed onConflictDoNothing returns nothing — fetch it.
+  if (!inserted) {
+    const existing = await getSchemaVersion(version.trim());
+    if (!existing) {
+      // Should never happen unless a concurrent DELETE raced us.
+      throw new Error(`Failed to record or retrieve schema version '${version}'`);
+    }
+    return existing;
+  }
+
+  return inserted;
+}
+
+/**
+ * Retrieve a single schema_version row by migration tag.
+ * Returns `null` when the version has not been recorded.
+ */
+export async function getSchemaVersion(version: string): Promise<SchemaVersion | null> {
+  const rows = await db
+    .select()
+    .from(schemaVersions)
+    .where(eq(schemaVersions.version, version))
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
+/**
+ * Return all recorded schema_version rows sorted oldest-first (by appliedAt).
+ * Useful for auditing the full migration history in order.
+ */
+export async function listSchemaVersions(): Promise<SchemaVersion[]> {
+  return db
+    .select()
+    .from(schemaVersions)
+    .orderBy(asc(schemaVersions.appliedAt), asc(schemaVersions.version));
+}
+
+/**
+ * Return the most recently applied schema_version row, or `null` if the table
+ * is empty.
+ */
+export async function getLatestSchemaVersion(): Promise<SchemaVersion | null> {
+  const rows = await db
+    .select()
+    .from(schemaVersions)
+    .orderBy(desc(schemaVersions.appliedAt), desc(schemaVersions.version))
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
+/**
+ * Delete a schema_version row (for rollback scenarios or test cleanup).
+ * Returns `true` if a row was deleted, `false` if the version was not found.
+ */
+export async function deleteSchemaVersion(version: string): Promise<boolean> {
+  const deleted = await db
+    .delete(schemaVersions)
+    .where(eq(schemaVersions.version, version))
+    .returning({ version: schemaVersions.version });
+
+  return deleted.length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Drift detection
+// ---------------------------------------------------------------------------
+
+export interface DriftCheckResult {
+  version: string;
+  /** Checksum stored in the database when the migration was applied. */
+  storedChecksum: string;
+  /** Checksum computed from the current file content at call time. */
+  currentChecksum: string;
+  /** `true` when stored and current checksums match — migration is clean. */
+  ok: boolean;
+}
+
+/**
+ * Compare the stored checksum for a migration against the current content of
+ * its SQL file (provided as a string).
+ *
+ * @param version      Migration tag.
+ * @param sqlContent   Current content of the migration SQL file.
+ * @returns            A `DriftCheckResult`, or `null` if the version was never recorded.
+ */
+export async function checkDrift(
+  version: string,
+  sqlContent: string,
+): Promise<DriftCheckResult | null> {
+  const row = await getSchemaVersion(version);
+  if (!row) {
+    return null;
+  }
+
+  const currentChecksum = computeChecksum(sqlContent);
+
+  return {
+    version,
+    storedChecksum: row.checksum,
+    currentChecksum,
+    ok: row.checksum === currentChecksum,
+  };
+}

--- a/src/routes/admin/schema-versions.ts
+++ b/src/routes/admin/schema-versions.ts
@@ -1,0 +1,293 @@
+/**
+ * Admin schema-versions router.
+ *
+ *   GET    /api/admin/schema-versions            — list all recorded migrations
+ *   GET    /api/admin/schema-versions/latest     — most recently applied migration
+ *   GET    /api/admin/schema-versions/:version   — single migration record
+ *   POST   /api/admin/schema-versions            — record a migration as applied
+ *   POST   /api/admin/schema-versions/:version/drift-check
+ *                                                — compare stored vs current checksum
+ *   DELETE /api/admin/schema-versions/:version   — remove a recorded migration
+ *
+ * All routes require a valid admin JWT (role: "admin").
+ * Input is validated at the boundary with zod.
+ * Failures return the standard error envelope:
+ *   { error: { code, message, requestId } }
+ */
+
+import { Router } from "express";
+import { z } from "zod";
+import { requireAdmin } from "../../middleware/requireAdmin";
+import { getRequestId } from "../../lib/requestContext";
+import { logger } from "../../config/logger";
+import {
+  recordMigration,
+  getSchemaVersion,
+  listSchemaVersions,
+  getLatestSchemaVersion,
+  deleteSchemaVersion,
+  checkDrift,
+} from "../../repositories/schemaVersionRepo";
+
+// ---------------------------------------------------------------------------
+// Validation schemas
+// ---------------------------------------------------------------------------
+
+/**
+ * Migration version tag: alphanumeric characters plus underscores and hyphens.
+ * Matches the naming convention used by Drizzle Kit (e.g. "0001_add_users").
+ */
+const versionParamSchema = z
+  .string()
+  .min(1, "version must not be empty")
+  .max(128, "version must be at most 128 characters")
+  .regex(
+    /^[A-Za-z0-9][A-Za-z0-9_-]*$/,
+    "version must be alphanumeric with underscores or hyphens",
+  );
+
+const recordBodySchema = z
+  .object({
+    /** Migration tag — the file name without the .sql extension. */
+    version: versionParamSchema,
+    /**
+     * Raw SQL content of the migration file.  The route computes the
+     * SHA-256 checksum server-side so callers never need to hash it
+     * themselves.
+     */
+    sqlContent: z.string().min(1, "sqlContent must not be empty"),
+    /** Optional identity of the agent applying the migration (CI job, user, etc.). */
+    appliedBy: z.string().max(255).optional(),
+  })
+  .strict();
+
+const driftCheckBodySchema = z
+  .object({
+    /** Current SQL content to compare against the stored checksum. */
+    sqlContent: z.string().min(1, "sqlContent must not be empty"),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Res = import("express").Response;
+
+function validationError(res: Res, message: string): void {
+  res.status(400).json({
+    error: { code: "validation_error", message, requestId: getRequestId() },
+  });
+}
+
+function notFound(res: Res, version: string): void {
+  res.status(404).json({
+    error: {
+      code: "not_found",
+      message: `Schema version '${version}' not found`,
+      requestId: getRequestId(),
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Router factory
+// ---------------------------------------------------------------------------
+
+export function createAdminSchemaVersionsRouter(): Router {
+  const router = Router();
+
+  router.use(requireAdmin);
+
+  // ── GET /api/admin/schema-versions ────────────────────────────────────────
+  /**
+   * List all recorded schema_version rows, oldest-first.
+   *
+   * Response: { data: SchemaVersion[] }
+   */
+  router.get("/", async (_req, res, next) => {
+    try {
+      const versions = await listSchemaVersions();
+      res.json({ data: versions });
+    } catch (e) {
+      next(e);
+    }
+  });
+
+  // ── GET /api/admin/schema-versions/latest ─────────────────────────────────
+  /**
+   * Return the most recently applied migration, or 404 when no migrations have
+   * been recorded yet.
+   *
+   * Response: { data: SchemaVersion }
+   */
+  router.get("/latest", async (_req, res, next) => {
+    try {
+      const latest = await getLatestSchemaVersion();
+      if (!latest) {
+        return res.status(404).json({
+          error: {
+            code: "not_found",
+            message: "No schema versions have been recorded yet",
+            requestId: getRequestId(),
+          },
+        });
+      }
+      return res.json({ data: latest });
+    } catch (e) {
+      return next(e);
+    }
+  });
+
+  // ── GET /api/admin/schema-versions/:version ───────────────────────────────
+  /**
+   * Fetch a single schema_version row by migration tag.
+   *
+   * Response: { data: SchemaVersion }
+   */
+  router.get("/:version", async (req, res, next) => {
+    const parsed = versionParamSchema.safeParse(req.params.version);
+    if (!parsed.success) {
+      return validationError(res, parsed.error.issues[0]?.message ?? "invalid version");
+    }
+    try {
+      const row = await getSchemaVersion(parsed.data);
+      if (!row) {
+        return notFound(res, parsed.data);
+      }
+      return res.json({ data: row });
+    } catch (e) {
+      return next(e);
+    }
+  });
+
+  // ── POST /api/admin/schema-versions ──────────────────────────────────────
+  /**
+   * Record a migration as applied.  The server computes the SHA-256 checksum
+   * from `sqlContent`; clients do not need to hash it themselves.
+   *
+   * If the version was already recorded the call is idempotent and returns the
+   * existing row with HTTP 200 (rather than 201).
+   *
+   * Request body: { version, sqlContent, appliedBy? }
+   * Response:     { data: SchemaVersion }
+   */
+  router.post("/", async (req, res, next) => {
+    const parsed = recordBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      return validationError(res, parsed.error.issues[0]?.message ?? "invalid body");
+    }
+
+    const { version, sqlContent, appliedBy } = parsed.data;
+
+    try {
+      const existing = await getSchemaVersion(version);
+      const row = await recordMigration(version, sqlContent, appliedBy);
+
+      logger.info(
+        {
+          reqId: getRequestId(),
+          version,
+          checksum: row.checksum,
+          actor: req.adminAddress,
+        },
+        "schema_version_recorded",
+      );
+
+      // 201 when newly created, 200 when already existed (idempotent).
+      const status = existing ? 200 : 201;
+      return res.status(status).json({ data: row });
+    } catch (e) {
+      return next(e);
+    }
+  });
+
+  // ── POST /api/admin/schema-versions/:version/drift-check ─────────────────
+  /**
+   * Compare the stored checksum for a migration against the current SQL content
+   * provided in the request body.
+   *
+   * Response:
+   *   { data: { version, storedChecksum, currentChecksum, ok } }
+   *     ok = true  → migration file is unchanged since it was applied.
+   *     ok = false → migration file has been modified (drift detected).
+   */
+  router.post("/:version/drift-check", async (req, res, next) => {
+    const parsed = versionParamSchema.safeParse(req.params.version);
+    if (!parsed.success) {
+      return validationError(res, parsed.error.issues[0]?.message ?? "invalid version");
+    }
+
+    const bodyParsed = driftCheckBodySchema.safeParse(req.body);
+    if (!bodyParsed.success) {
+      return validationError(
+        res,
+        bodyParsed.error.issues[0]?.message ?? "invalid body",
+      );
+    }
+
+    try {
+      const result = await checkDrift(parsed.data, bodyParsed.data.sqlContent);
+      if (!result) {
+        return notFound(res, parsed.data);
+      }
+
+      if (!result.ok) {
+        logger.warn(
+          {
+            reqId: getRequestId(),
+            version: parsed.data,
+            storedChecksum: result.storedChecksum,
+            currentChecksum: result.currentChecksum,
+            actor: req.adminAddress,
+          },
+          "schema_version_drift_detected",
+        );
+      }
+
+      return res.json({ data: result });
+    } catch (e) {
+      return next(e);
+    }
+  });
+
+  // ── DELETE /api/admin/schema-versions/:version ────────────────────────────
+  /**
+   * Remove a recorded schema_version row.
+   *
+   * Use with caution: this does not roll back the migration itself — it only
+   * removes the tracking record.
+   *
+   * Response: 204 No Content
+   */
+  router.delete("/:version", async (req, res, next) => {
+    const parsed = versionParamSchema.safeParse(req.params.version);
+    if (!parsed.success) {
+      return validationError(res, parsed.error.issues[0]?.message ?? "invalid version");
+    }
+
+    try {
+      const deleted = await deleteSchemaVersion(parsed.data);
+      if (!deleted) {
+        return notFound(res, parsed.data);
+      }
+
+      logger.info(
+        {
+          reqId: getRequestId(),
+          version: parsed.data,
+          actor: req.adminAddress,
+        },
+        "schema_version_deleted",
+      );
+
+      return res.status(204).send();
+    } catch (e) {
+      return next(e);
+    }
+  });
+
+  return router;
+}
+
+export const adminSchemaVersionsRouter = createAdminSchemaVersionsRouter();

--- a/tests/adminSchemaVersions.test.ts
+++ b/tests/adminSchemaVersions.test.ts
@@ -1,0 +1,541 @@
+/**
+ * Tests for src/routes/admin/schema-versions.ts
+ *
+ * The repository layer is fully mocked so no real database is required.
+ * Tests cover auth enforcement, input validation, all HTTP verbs, happy paths,
+ * edge cases, and error propagation.
+ */
+
+// ── Mocks (must come before imports) ─────────────────────────────────────────
+
+jest.mock("../src/db/client", () => ({ db: {} }));
+
+jest.mock("../src/repositories/schemaVersionRepo");
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { createAdminSchemaVersionsRouter } from "../src/routes/admin/schema-versions";
+import { errorHandler } from "../src/middleware/errorHandler";
+import {
+  recordMigration,
+  getSchemaVersion,
+  listSchemaVersions,
+  getLatestSchemaVersion,
+  deleteSchemaVersion,
+  checkDrift,
+} from "../src/repositories/schemaVersionRepo";
+
+const mockRecordMigration = recordMigration as jest.MockedFunction<typeof recordMigration>;
+const mockGetSchemaVersion = getSchemaVersion as jest.MockedFunction<typeof getSchemaVersion>;
+const mockListSchemaVersions = listSchemaVersions as jest.MockedFunction<typeof listSchemaVersions>;
+const mockGetLatestSchemaVersion = getLatestSchemaVersion as jest.MockedFunction<typeof getLatestSchemaVersion>;
+const mockDeleteSchemaVersion = deleteSchemaVersion as jest.MockedFunction<typeof deleteSchemaVersion>;
+const mockCheckDrift = checkDrift as jest.MockedFunction<typeof checkDrift>;
+
+// ── JWT helpers ───────────────────────────────────────────────────────────────
+
+const SECRET   = process.env.JWT_SECRET    || "test-jwt-secret-that-is-at-least-32-chars!";
+const ISSUER   = process.env.JWT_ISSUER    || "predictify";
+const AUDIENCE = process.env.JWT_AUDIENCE  || "predictify-app";
+
+const ADMIN_ADDR = "GADMIN7777777777777777777777777777777777777777777777777777";
+const USER_ADDR  = "GUSER88888888888888888888888888888888888888888888888888888";
+
+function signJwt(payload: object): string {
+  return jwt.sign(payload, SECRET, { issuer: ISSUER, audience: AUDIENCE, expiresIn: "1h" });
+}
+
+const adminJwt = signJwt({ sub: ADMIN_ADDR, role: "admin" });
+const userJwt  = signJwt({ sub: USER_ADDR,  role: "user"  });
+
+// ── App factory ───────────────────────────────────────────────────────────────
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/admin/schema-versions", createAdminSchemaVersionsRouter());
+  app.use(errorHandler);
+  return app;
+}
+
+function auth(req: request.Test, token = adminJwt): request.Test {
+  return req.set("Authorization", `Bearer ${token}`);
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const SAMPLE_SQL = "CREATE TABLE test (id uuid PRIMARY KEY);";
+const SAMPLE_ROW = {
+  version: "0001_add_users",
+  checksum: "a".repeat(64),
+  appliedAt: new Date("2026-01-01T00:00:00Z"),
+  appliedBy: "ci",
+};
+
+// ── Shared: auth enforcement ──────────────────────────────────────────────────
+
+describe("auth enforcement", () => {
+  const app = makeApp();
+
+  it("rejects unauthenticated requests with 403", async () => {
+    const res = await request(app).get("/api/admin/schema-versions");
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects non-admin JWT with 403", async () => {
+    const res = await auth(
+      request(app).get("/api/admin/schema-versions"),
+      userJwt,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects a JWT signed with a different secret", async () => {
+    const badToken = jwt.sign(
+      { sub: ADMIN_ADDR, role: "admin" },
+      "wrong-secret-at-least-32-characters-long",
+      { issuer: ISSUER, audience: AUDIENCE },
+    );
+    const res = await auth(request(app).get("/api/admin/schema-versions"), badToken);
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── GET /api/admin/schema-versions ───────────────────────────────────────────
+
+describe("GET /api/admin/schema-versions", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 200 with an array of versions", async () => {
+    mockListSchemaVersions.mockResolvedValue([SAMPLE_ROW]);
+
+    const res = await auth(request(makeApp()).get("/api/admin/schema-versions"));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].version).toBe(SAMPLE_ROW.version);
+  });
+
+  it("returns 200 with an empty array when no versions exist", async () => {
+    mockListSchemaVersions.mockResolvedValue([]);
+
+    const res = await auth(request(makeApp()).get("/api/admin/schema-versions"));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it("propagates repository errors through the error handler", async () => {
+    mockListSchemaVersions.mockRejectedValue(new Error("db error"));
+
+    const res = await auth(request(makeApp()).get("/api/admin/schema-versions"));
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── GET /api/admin/schema-versions/latest ────────────────────────────────────
+
+describe("GET /api/admin/schema-versions/latest", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 200 with the latest version row", async () => {
+    mockGetLatestSchemaVersion.mockResolvedValue(SAMPLE_ROW);
+
+    const res = await auth(
+      request(makeApp()).get("/api/admin/schema-versions/latest"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.version).toBe(SAMPLE_ROW.version);
+  });
+
+  it("returns 404 when no versions have been recorded", async () => {
+    mockGetLatestSchemaVersion.mockResolvedValue(null);
+
+    const res = await auth(
+      request(makeApp()).get("/api/admin/schema-versions/latest"),
+    );
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("not_found");
+  });
+
+  it("propagates errors through the error handler", async () => {
+    mockGetLatestSchemaVersion.mockRejectedValue(new Error("db error"));
+
+    const res = await auth(
+      request(makeApp()).get("/api/admin/schema-versions/latest"),
+    );
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── GET /api/admin/schema-versions/:version ──────────────────────────────────
+
+describe("GET /api/admin/schema-versions/:version", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 200 with the version row when found", async () => {
+    mockGetSchemaVersion.mockResolvedValue(SAMPLE_ROW);
+
+    const res = await auth(
+      request(makeApp()).get("/api/admin/schema-versions/0001_add_users"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.checksum).toBe(SAMPLE_ROW.checksum);
+  });
+
+  it("returns 404 when the version is not found", async () => {
+    mockGetSchemaVersion.mockResolvedValue(null);
+
+    const res = await auth(
+      request(makeApp()).get("/api/admin/schema-versions/nonexistent"),
+    );
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("not_found");
+  });
+
+  it("returns 400 for an invalid version param (special chars)", async () => {
+    const res = await auth(
+      request(makeApp()).get("/api/admin/schema-versions/bad version!"),
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("propagates errors through the error handler", async () => {
+    mockGetSchemaVersion.mockRejectedValue(new Error("db error"));
+
+    const res = await auth(
+      request(makeApp()).get("/api/admin/schema-versions/0001_add_users"),
+    );
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── POST /api/admin/schema-versions ──────────────────────────────────────────
+
+describe("POST /api/admin/schema-versions", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const validBody = {
+    version: "0001_add_users",
+    sqlContent: SAMPLE_SQL,
+    appliedBy: "ci",
+  };
+
+  it("returns 201 when a new version is recorded", async () => {
+    mockGetSchemaVersion.mockResolvedValue(null); // Not previously existing
+    mockRecordMigration.mockResolvedValue(SAMPLE_ROW);
+
+    const res = await auth(
+      request(makeApp()).post("/api/admin/schema-versions").send(validBody),
+    );
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.version).toBe(SAMPLE_ROW.version);
+    expect(mockRecordMigration).toHaveBeenCalledWith(
+      validBody.version,
+      validBody.sqlContent,
+      validBody.appliedBy,
+    );
+  });
+
+  it("returns 200 (idempotent) when the version already exists", async () => {
+    mockGetSchemaVersion.mockResolvedValue(SAMPLE_ROW); // Already exists
+    mockRecordMigration.mockResolvedValue(SAMPLE_ROW);
+
+    const res = await auth(
+      request(makeApp()).post("/api/admin/schema-versions").send(validBody),
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it("records without appliedBy when the field is omitted", async () => {
+    mockGetSchemaVersion.mockResolvedValue(null);
+    mockRecordMigration.mockResolvedValue({ ...SAMPLE_ROW, appliedBy: null });
+
+    const res = await auth(
+      request(makeApp())
+        .post("/api/admin/schema-versions")
+        .send({ version: "0001_add_users", sqlContent: SAMPLE_SQL }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockRecordMigration).toHaveBeenCalledWith(
+      "0001_add_users",
+      SAMPLE_SQL,
+      undefined,
+    );
+  });
+
+  it("returns 400 when version is missing", async () => {
+    const res = await auth(
+      request(makeApp())
+        .post("/api/admin/schema-versions")
+        .send({ sqlContent: SAMPLE_SQL }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("returns 400 when sqlContent is missing", async () => {
+    const res = await auth(
+      request(makeApp())
+        .post("/api/admin/schema-versions")
+        .send({ version: "0001_add_users" }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("returns 400 when version contains invalid characters", async () => {
+    const res = await auth(
+      request(makeApp())
+        .post("/api/admin/schema-versions")
+        .send({ version: "bad version!", sqlContent: SAMPLE_SQL }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("returns 400 when sqlContent is an empty string", async () => {
+    const res = await auth(
+      request(makeApp())
+        .post("/api/admin/schema-versions")
+        .send({ version: "0001_add_users", sqlContent: "" }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("returns 400 for extra unknown fields (strict schema)", async () => {
+    const res = await auth(
+      request(makeApp())
+        .post("/api/admin/schema-versions")
+        .send({ version: "0001_add_users", sqlContent: SAMPLE_SQL, unknownField: "x" }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("propagates errors through the error handler", async () => {
+    mockGetSchemaVersion.mockResolvedValue(null);
+    mockRecordMigration.mockRejectedValue(new Error("db error"));
+
+    const res = await auth(
+      request(makeApp()).post("/api/admin/schema-versions").send(validBody),
+    );
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── POST /api/admin/schema-versions/:version/drift-check ─────────────────────
+
+describe("POST /api/admin/schema-versions/:version/drift-check", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns ok: true when checksums match", async () => {
+    mockCheckDrift.mockResolvedValue({
+      version: "0001_add_users",
+      storedChecksum: "a".repeat(64),
+      currentChecksum: "a".repeat(64),
+      ok: true,
+    });
+
+    const res = await auth(
+      request(makeApp())
+        .post("/api/admin/schema-versions/0001_add_users/drift-check")
+        .send({ sqlContent: SAMPLE_SQL }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.ok).toBe(true);
+  });
+
+  it("returns ok: false and logs a warning when drift is detected", async () => {
+    mockCheckDrift.mockResolvedValue({
+      version: "0001_add_users",
+      storedChecksum: "a".repeat(64),
+      currentChecksum: "b".repeat(64),
+      ok: false,
+    });
+
+    const res = await auth(
+      request(makeApp())
+        .post("/api/admin/schema-versions/0001_add_users/drift-check")
+        .send({ sqlContent: SAMPLE_SQL + "\n-- modified" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.ok).toBe(false);
+    expect(res.body.data.storedChecksum).toBe("a".repeat(64));
+    expect(res.body.data.currentChecksum).toBe("b".repeat(64));
+  });
+
+  it("returns 404 when the version has not been recorded", async () => {
+    mockCheckDrift.mockResolvedValue(null);
+
+    const res = await auth(
+      request(makeApp())
+        .post("/api/admin/schema-versions/not_recorded/drift-check")
+        .send({ sqlContent: SAMPLE_SQL }),
+    );
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("not_found");
+  });
+
+  it("returns 400 for an invalid version param", async () => {
+    const res = await auth(
+      request(makeApp())
+        .post("/api/admin/schema-versions/bad version!/drift-check")
+        .send({ sqlContent: SAMPLE_SQL }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("returns 400 when sqlContent is missing", async () => {
+    const res = await auth(
+      request(makeApp())
+        .post("/api/admin/schema-versions/0001_add_users/drift-check")
+        .send({}),
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("returns 400 when sqlContent is empty", async () => {
+    const res = await auth(
+      request(makeApp())
+        .post("/api/admin/schema-versions/0001_add_users/drift-check")
+        .send({ sqlContent: "" }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("returns 400 for extra unknown body fields", async () => {
+    const res = await auth(
+      request(makeApp())
+        .post("/api/admin/schema-versions/0001_add_users/drift-check")
+        .send({ sqlContent: SAMPLE_SQL, extra: "field" }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("propagates errors through the error handler", async () => {
+    mockCheckDrift.mockRejectedValue(new Error("db error"));
+
+    const res = await auth(
+      request(makeApp())
+        .post("/api/admin/schema-versions/0001_add_users/drift-check")
+        .send({ sqlContent: SAMPLE_SQL }),
+    );
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── DELETE /api/admin/schema-versions/:version ───────────────────────────────
+
+describe("DELETE /api/admin/schema-versions/:version", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 204 when the version is deleted", async () => {
+    mockDeleteSchemaVersion.mockResolvedValue(true);
+
+    const res = await auth(
+      request(makeApp()).delete("/api/admin/schema-versions/0001_add_users"),
+    );
+
+    expect(res.status).toBe(204);
+    expect(mockDeleteSchemaVersion).toHaveBeenCalledWith("0001_add_users");
+  });
+
+  it("returns 404 when the version is not found", async () => {
+    mockDeleteSchemaVersion.mockResolvedValue(false);
+
+    const res = await auth(
+      request(makeApp()).delete("/api/admin/schema-versions/nonexistent"),
+    );
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("not_found");
+  });
+
+  it("returns 400 for an invalid version param", async () => {
+    const res = await auth(
+      request(makeApp()).delete("/api/admin/schema-versions/bad version!"),
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("propagates errors through the error handler", async () => {
+    mockDeleteSchemaVersion.mockRejectedValue(new Error("db error"));
+
+    const res = await auth(
+      request(makeApp()).delete("/api/admin/schema-versions/0001_add_users"),
+    );
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── Version param edge-cases ──────────────────────────────────────────────────
+
+describe("version param edge cases", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("accepts versions with hyphens", async () => {
+    mockGetSchemaVersion.mockResolvedValue(SAMPLE_ROW);
+
+    const res = await auth(
+      request(makeApp()).get("/api/admin/schema-versions/0001-add-users"),
+    );
+
+    // Valid format — should reach the repo (404 if not mocked to return data)
+    expect([200, 404].includes(res.status)).toBe(true);
+    expect(res.status).not.toBe(400);
+  });
+
+  it("rejects version starting with a special character", async () => {
+    const res = await auth(
+      request(makeApp()).get("/api/admin/schema-versions/_bad"),
+    );
+    // Starts with underscore → fails the regex (must start with alphanum)
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects version exceeding 128 characters", async () => {
+    const longVersion = "a".repeat(129);
+    const res = await auth(
+      request(makeApp()).get(`/api/admin/schema-versions/${longVersion}`),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/schemaVersionRepo.test.ts
+++ b/tests/schemaVersionRepo.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Tests for src/repositories/schemaVersionRepo.ts
+ *
+ * All DB interactions are mocked so no real database is needed.
+ * Coverage targets: branches 90%+, functions 100%, lines 90%+.
+ */
+
+// ── DB mock must be declared before repo import ──────────────────────────────
+
+jest.mock("../src/db/client", () => {
+  const chain: Record<string, jest.Mock> = {};
+  const methods = [
+    "select",
+    "from",
+    "where",
+    "orderBy",
+    "limit",
+    "insert",
+    "values",
+    "onConflictDoNothing",
+    "returning",
+    "delete",
+  ];
+  methods.forEach((m) => {
+    chain[m] = jest.fn().mockReturnThis();
+  });
+  return { db: chain };
+});
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import { db } from "../src/db/client";
+import {
+  computeChecksum,
+  isValidChecksum,
+  recordMigration,
+  getSchemaVersion,
+  listSchemaVersions,
+  getLatestSchemaVersion,
+  deleteSchemaVersion,
+  checkDrift,
+} from "../src/repositories/schemaVersionRepo";
+
+const mockDb = db as unknown as Record<string, jest.Mock>;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const SAMPLE_SQL = "CREATE TABLE users (id uuid PRIMARY KEY);";
+const SAMPLE_VERSION = "0001_add_users";
+const SAMPLE_CHECKSUM = computeChecksum(SAMPLE_SQL);
+
+const mockRow = {
+  version: SAMPLE_VERSION,
+  checksum: SAMPLE_CHECKSUM,
+  appliedAt: new Date("2026-01-01T00:00:00Z"),
+  appliedBy: "ci",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Reset chain so each test starts fresh
+  Object.values(mockDb).forEach((fn) => {
+    fn.mockReturnThis();
+  });
+});
+
+// ── computeChecksum ──────────────────────────────────────────────────────────
+
+describe("computeChecksum", () => {
+  it("returns a 64-character lowercase hex string", () => {
+    const result = computeChecksum("hello world");
+    expect(result).toHaveLength(64);
+    expect(result).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is deterministic — same input produces same output", () => {
+    expect(computeChecksum(SAMPLE_SQL)).toBe(computeChecksum(SAMPLE_SQL));
+  });
+
+  it("produces different checksums for different inputs", () => {
+    expect(computeChecksum("foo")).not.toBe(computeChecksum("bar"));
+  });
+
+  it("handles empty string input", () => {
+    const result = computeChecksum("");
+    expect(result).toHaveLength(64);
+  });
+
+  it("is sensitive to whitespace differences", () => {
+    expect(computeChecksum("a b")).not.toBe(computeChecksum("ab"));
+  });
+});
+
+// ── isValidChecksum ──────────────────────────────────────────────────────────
+
+describe("isValidChecksum", () => {
+  it("returns true for a valid 64-char lowercase hex string", () => {
+    expect(isValidChecksum(SAMPLE_CHECKSUM)).toBe(true);
+  });
+
+  it("returns false for a string with uppercase letters", () => {
+    expect(isValidChecksum(SAMPLE_CHECKSUM.toUpperCase())).toBe(false);
+  });
+
+  it("returns false for a string shorter than 64 chars", () => {
+    expect(isValidChecksum(SAMPLE_CHECKSUM.slice(0, 63))).toBe(false);
+  });
+
+  it("returns false for a string longer than 64 chars", () => {
+    expect(isValidChecksum(SAMPLE_CHECKSUM + "a")).toBe(false);
+  });
+
+  it("returns false for an empty string", () => {
+    expect(isValidChecksum("")).toBe(false);
+  });
+
+  it("returns false for non-hex characters", () => {
+    const notHex = "z".repeat(64);
+    expect(isValidChecksum(notHex)).toBe(false);
+  });
+});
+
+// ── recordMigration ──────────────────────────────────────────────────────────
+
+describe("recordMigration", () => {
+  it("inserts a row and returns the inserted record", async () => {
+    mockDb.returning.mockResolvedValueOnce([mockRow]);
+
+    const result = await recordMigration(SAMPLE_VERSION, SAMPLE_SQL, "ci");
+
+    expect(mockDb.insert).toHaveBeenCalled();
+    expect(mockDb.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        version: SAMPLE_VERSION,
+        checksum: SAMPLE_CHECKSUM,
+        appliedBy: "ci",
+      }),
+    );
+    expect(result).toEqual(mockRow);
+  });
+
+  it("trims whitespace from the version string", async () => {
+    mockDb.returning.mockResolvedValueOnce([mockRow]);
+
+    await recordMigration("  0001_add_users  ", SAMPLE_SQL);
+
+    expect(mockDb.values).toHaveBeenCalledWith(
+      expect.objectContaining({ version: SAMPLE_VERSION }),
+    );
+  });
+
+  it("falls back to getSchemaVersion when onConflictDoNothing returns nothing", async () => {
+    // Simulate an existing record: insert returns [], then select returns the existing row.
+    mockDb.returning.mockResolvedValueOnce([]);
+    mockDb.limit.mockResolvedValueOnce([mockRow]);
+
+    const result = await recordMigration(SAMPLE_VERSION, SAMPLE_SQL);
+
+    expect(result).toEqual(mockRow);
+  });
+
+  it("throws when the existing record cannot be found after conflict", async () => {
+    mockDb.returning.mockResolvedValueOnce([]);
+    mockDb.limit.mockResolvedValueOnce([]); // Row disappeared
+
+    await expect(recordMigration(SAMPLE_VERSION, SAMPLE_SQL)).rejects.toThrow(
+      `Failed to record or retrieve schema version '${SAMPLE_VERSION}'`,
+    );
+  });
+
+  it("stores null as appliedBy when not provided", async () => {
+    mockDb.returning.mockResolvedValueOnce([{ ...mockRow, appliedBy: null }]);
+
+    await recordMigration(SAMPLE_VERSION, SAMPLE_SQL);
+
+    expect(mockDb.values).toHaveBeenCalledWith(
+      expect.objectContaining({ appliedBy: null }),
+    );
+  });
+
+  it("throws when version is an empty string", async () => {
+    await expect(recordMigration("", SAMPLE_SQL)).rejects.toThrow(
+      "version must be a non-empty string",
+    );
+  });
+
+  it("throws when version is only whitespace", async () => {
+    await expect(recordMigration("   ", SAMPLE_SQL)).rejects.toThrow(
+      "version must be a non-empty string",
+    );
+  });
+});
+
+// ── getSchemaVersion ─────────────────────────────────────────────────────────
+
+describe("getSchemaVersion", () => {
+  it("returns the row when found", async () => {
+    mockDb.limit.mockResolvedValueOnce([mockRow]);
+
+    const result = await getSchemaVersion(SAMPLE_VERSION);
+
+    expect(result).toEqual(mockRow);
+    expect(mockDb.where).toHaveBeenCalled();
+    expect(mockDb.limit).toHaveBeenCalledWith(1);
+  });
+
+  it("returns null when not found", async () => {
+    mockDb.limit.mockResolvedValueOnce([]);
+
+    const result = await getSchemaVersion("nonexistent");
+
+    expect(result).toBeNull();
+  });
+});
+
+// ── listSchemaVersions ────────────────────────────────────────────────────────
+
+describe("listSchemaVersions", () => {
+  it("returns all rows in order", async () => {
+    const rows = [mockRow, { ...mockRow, version: "0002_add_markets" }];
+    // listSchemaVersions does not call .limit() — the chain terminates at .orderBy()
+    mockDb.orderBy.mockResolvedValueOnce(rows);
+
+    const result = await listSchemaVersions();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].version).toBe(SAMPLE_VERSION);
+  });
+
+  it("returns an empty array when no versions are recorded", async () => {
+    mockDb.orderBy.mockResolvedValueOnce([]);
+
+    const result = await listSchemaVersions();
+
+    expect(result).toEqual([]);
+  });
+});
+
+// ── getLatestSchemaVersion ───────────────────────────────────────────────────
+
+describe("getLatestSchemaVersion", () => {
+  it("returns the most recent row", async () => {
+    mockDb.limit.mockResolvedValueOnce([mockRow]);
+
+    const result = await getLatestSchemaVersion();
+
+    expect(result).toEqual(mockRow);
+    expect(mockDb.limit).toHaveBeenCalledWith(1);
+  });
+
+  it("returns null when no versions exist", async () => {
+    mockDb.limit.mockResolvedValueOnce([]);
+
+    const result = await getLatestSchemaVersion();
+
+    expect(result).toBeNull();
+  });
+});
+
+// ── deleteSchemaVersion ──────────────────────────────────────────────────────
+
+describe("deleteSchemaVersion", () => {
+  it("returns true when a row is deleted", async () => {
+    mockDb.returning.mockResolvedValueOnce([{ version: SAMPLE_VERSION }]);
+
+    const result = await deleteSchemaVersion(SAMPLE_VERSION);
+
+    expect(result).toBe(true);
+    expect(mockDb.delete).toHaveBeenCalled();
+  });
+
+  it("returns false when the row does not exist", async () => {
+    mockDb.returning.mockResolvedValueOnce([]);
+
+    const result = await deleteSchemaVersion("nonexistent");
+
+    expect(result).toBe(false);
+  });
+});
+
+// ── checkDrift ───────────────────────────────────────────────────────────────
+
+describe("checkDrift", () => {
+  it("returns ok: true when checksums match", async () => {
+    mockDb.limit.mockResolvedValueOnce([mockRow]);
+
+    const result = await checkDrift(SAMPLE_VERSION, SAMPLE_SQL);
+
+    expect(result).not.toBeNull();
+    expect(result!.ok).toBe(true);
+    expect(result!.storedChecksum).toBe(SAMPLE_CHECKSUM);
+    expect(result!.currentChecksum).toBe(SAMPLE_CHECKSUM);
+  });
+
+  it("returns ok: false when the file content has changed", async () => {
+    mockDb.limit.mockResolvedValueOnce([mockRow]);
+
+    const modifiedSql = SAMPLE_SQL + "\n-- added a comment";
+    const result = await checkDrift(SAMPLE_VERSION, modifiedSql);
+
+    expect(result).not.toBeNull();
+    expect(result!.ok).toBe(false);
+    expect(result!.storedChecksum).toBe(SAMPLE_CHECKSUM);
+    expect(result!.currentChecksum).toBe(computeChecksum(modifiedSql));
+    expect(result!.storedChecksum).not.toBe(result!.currentChecksum);
+  });
+
+  it("returns null when the version has not been recorded", async () => {
+    mockDb.limit.mockResolvedValueOnce([]);
+
+    const result = await checkDrift("not_recorded", SAMPLE_SQL);
+
+    expect(result).toBeNull();
+  });
+
+  it("includes the version tag in the result", async () => {
+    mockDb.limit.mockResolvedValueOnce([mockRow]);
+
+    const result = await checkDrift(SAMPLE_VERSION, SAMPLE_SQL);
+
+    expect(result!.version).toBe(SAMPLE_VERSION);
+  });
+});


### PR DESCRIPTION
Add schema_versions table with SHA-256 checksum tracking for applied Drizzle migrations, enabling drift detection when migration files are modified after being applied.

Changes:
- drizzle/migrations/0022_schema_versions.sql: canonical migration DDL
- drizzle/schema-versions.sql: standalone DDL reference for tooling
- src/db/schema.ts: add schemaVersions pgTable + exported types
- src/repositories/schemaVersionRepo.ts: CRUD + checksum helpers (computeChecksum, isValidChecksum, recordMigration, getSchemaVersion, listSchemaVersions, getLatestSchemaVersion, deleteSchemaVersion, checkDrift)
- src/routes/admin/schema-versions.ts: REST endpoints under /api/admin/schema-versions (list, latest, get, record, drift-check, delete); requires admin JWT; input validated with zod; structured logs
- src/index.ts: mount adminSchemaVersionsRouter
- src/config/env.ts: add optional JWT_KEYS / JWT_ACTIVE_KID fields to fix pre-existing TS compile error in src/utils/keyRing.ts
- tests/schemaVersionRepo.test.ts: 30 unit tests, 100% coverage
- tests/adminSchemaVersions.test.ts: 37 route tests, 100% stmt/fn/line

Closes #315