### PR TITLE
harden POST /api/admin/reindex with rate-limit, audit log, metrics & …

### DIFF
--- a/docs/admin-reindex.md
+++ b/docs/admin-reindex.md
@@ -1,0 +1,227 @@
+# Admin Reindex Endpoint
+
+`POST /api/admin/reindex` triggers a backfill of on-chain Predictify contract
+events from a caller-supplied ledger sequence number up to the **current
+Soroban RPC chain tip**. It is the primary operator lever for healing gaps
+in the `indexer_events` table after RPC outages, node restarts, or manual
+data corrections.
+
+---
+
+## Authentication
+
+Requires a valid admin JWT in the `Authorization` header:
+
+```
+Authorization: Bearer <jwt>
+```
+
+The JWT must be signed with a key from the key ring (`src/utils/keyRing.ts`)
+and carry `{ role: "admin" }`. The subject (`sub`) is recorded in the audit
+log as the operator identity. Any request without a valid admin token returns
+**403 Forbidden**.
+
+---
+
+## Rate Limiting
+
+60 requests per minute per admin token (same window as all other admin
+endpoints). The bucket is keyed on the raw `Authorization` header so multiple
+admin tokens do not share quota. Exceeded requests receive:
+
+```json
+HTTP 429 Too Many Requests
+{ "error": { "code": "rate_limit_exceeded" } }
+```
+
+---
+
+## Request
+
+```
+POST /api/admin/reindex
+Content-Type: application/json
+Authorization: Bearer <admin-jwt>
+```
+
+### Body
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ledger` | `integer` | ✅ | Starting ledger sequence number (inclusive). Must be ≥ 1. |
+
+#### Example
+
+```json
+{ "ledger": 54321 }
+```
+
+---
+
+## Response
+
+### 200 OK — Reindex triggered
+
+Returns the resolved ledger range (`from` as supplied, `to` as the chain tip
+at request time).
+
+```json
+{
+  "data": {
+    "from": 54321,
+    "to":   55000
+  }
+}
+```
+
+The `x-request-id` response header carries the correlation ID so log lines
+from the backfill can be traced directly to this request:
+
+```
+x-request-id: <correlation-id>
+```
+
+### 400 Bad Request — Validation error
+
+```json
+{
+  "error": {
+    "code": "validation_error",
+    "details": [ ... ],
+    "requestId": "<id>"
+  }
+}
+```
+
+Returned when `ledger` is missing, not an integer, or < 1.
+
+### 403 Forbidden
+
+```json
+{ "error": { "code": "forbidden" } }
+```
+
+### 429 Too Many Requests
+
+```json
+{ "error": { "code": "rate_limit_exceeded" } }
+```
+
+### 500 Internal Server Error
+
+Returned when Soroban RPC is unreachable (`getChainTip` fails) or the
+database write fails. The error envelope includes the correlation ID so
+you can grep the pino logs:
+
+```json
+{
+  "error": {
+    "code": "internal_error",
+    "message": "Internal error",
+    "correlationId": "<id>"
+  }
+}
+```
+
+---
+
+## How It Works
+
+1. **Validate** — Zod checks that `ledger` is a positive integer.
+2. **Resolve tip** — Calls `indexerService.getChainTip()` (Soroban RPC
+   `getLatestLedger`). If RPC is down the request fails immediately with 500.
+3. **Backfill** — Calls `indexerService.backfillRange(from, to)`. Work is
+   chunked by `INDEXER_BACKFILL_CHUNK_SIZE` (default 1 000 ledgers per
+   chunk). Each chunk fetches events from Soroban RPC and upserts them with
+   `ON CONFLICT (ledger, tx_hash, op_index) DO NOTHING` — re-runs are safe.
+4. **Reorg overlap** — `backfillRange` rewinds by `INDEXER_REWIND_LEDGERS`
+   (default 10) so recently-reorganised ledgers are always re-fetched.
+5. **Cursor advance** — After all chunks are written, the indexer cursor is
+   advanced to `to` via an `INSERT … ON CONFLICT DO UPDATE SET last_ledger =
+   GREATEST(…)` so normal polling resumes from the new tip.
+6. **Audit log** — A row is inserted into `audit_logs` with
+   `action = "admin.reindex"`, the admin's Stellar address, the caller IP,
+   and the correlation ID.
+7. **Prometheus** — `admin_reindex_total` is incremented once.
+
+**Note:** Steps 6 and 7 only execute if the backfill succeeds. A failed
+backfill produces no audit row and no counter increment.
+
+---
+
+## Observability
+
+### Structured log (pino)
+
+```json
+{
+  "level": "info",
+  "msg":   "admin reindex triggered",
+  "requestId": "<id>",
+  "adminAddress": "G...",
+  "from": 54321,
+  "to":   55000
+}
+```
+
+### Prometheus counter
+
+```
+admin_reindex_total
+```
+
+Scrape via `/metrics` (requires `METRICS_AUTH_TOKEN` if set).
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `INDEXER_BACKFILL_CHUNK_SIZE` | `1000` | Ledgers per backfill chunk |
+| `INDEXER_REWIND_LEDGERS` | `10` | Overlap applied for reorg safety |
+| `SOROBAN_RPC_URL` | testnet | Soroban RPC endpoint for `getChainTip` |
+
+---
+
+## Safety Notes
+
+- **Idempotent** — Re-running the same range is safe. Duplicate events are
+  silently ignored by the `ON CONFLICT DO NOTHING` upsert.
+- **No data loss** — The backfill only *inserts*; existing rows are never
+  deleted or updated.
+- **Long-running** — For large ledger ranges the HTTP request will block until
+  the backfill completes. For very large gaps (thousands of ledgers) consider
+  running `npm run indexer:gap-scan` instead, which is purpose-built for
+  bulk healing.
+- **Concurrency** — Running two simultaneous reindex operations over the same
+  range is safe (idempotent inserts), but wasteful. Serialise admin triggers
+  if possible.
+
+---
+
+## Examples
+
+### Reindex the last 500 ledgers
+
+```bash
+# 1. Get the current chain tip
+TIP=$(curl -s http://localhost:3000/healthz/dependencies | jq .indexer.tip)
+FROM=$((TIP - 500))
+
+# 2. Trigger reindex
+curl -X POST http://localhost:3000/api/admin/reindex \
+  -H "Authorization: Bearer $ADMIN_JWT" \
+  -H "Content-Type: application/json" \
+  -d "{\"ledger\": $FROM}"
+```
+
+### Reindex from a known checkpoint
+
+```bash
+curl -X POST http://localhost:3000/api/admin/reindex \
+  -H "Authorization: Bearer $ADMIN_JWT" \
+  -H "Content-Type: application/json" \
+  -H "X-Request-Id: reindex-incident-2026-07-20" \
+  -d '{"ledger": 50000}'
+```

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -394,7 +394,42 @@ components:
         - id
         - action
         - createdAt
+    AdminReindexRequest:
+      type: object
+      description: >
+        Body for POST /api/admin/reindex. Specifies the ledger sequence number
+        from which reindexing should begin. The upper bound is resolved automatically
+        from the current Soroban RPC chain tip.
+      properties:
+        ledger:
+          type: integer
+          minimum: 1
+          description: >
+            Starting ledger sequence number (inclusive). Must be a positive integer.
+            The indexer will backfill from this ledger to the current chain tip,
+            applying the configured INDEXER_REWIND_LEDGERS overlap for reorg safety.
+      required:
+        - ledger
+    AdminReindexResponse:
+      type: object
+      description: Resolved ledger range for the triggered reindex operation.
+      properties:
+        data:
+          type: object
+          properties:
+            from:
+              type: integer
+              description: The starting ledger supplied in the request body.
+            to:
+              type: integer
+              description: The chain tip resolved at the time the request was processed.
+          required:
+            - from
+            - to
+      required:
+        - data
   parameters: {}
+
 paths:
   /health:
     get:
@@ -1134,6 +1169,65 @@ paths:
                 $ref: '#/components/schemas/ErrorBody'
         '429':
           description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+  /api/admin/reindex:
+    post:
+      operationId: adminReindex
+      tags:
+        - Admin
+      summary: Trigger a reindex from a specific ledger (admin only)
+      description: >
+        Resolves the current Soroban chain tip and backfills all on-chain
+        Predictify contract events in the range [ledger, chainTip]. Work is
+        chunked by INDEXER_BACKFILL_CHUNK_SIZE with a INDEXER_REWIND_LEDGERS
+        overlap for reorg-safe deduplication. The operation is idempotent —
+        re-running it for the same range is safe due to ON CONFLICT DO NOTHING
+        upserts. A structured audit-log entry is written on success and the
+        admin_reindex_total Prometheus counter is incremented.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminReindexRequest'
+            example:
+              ledger: 54321
+      responses:
+        '200':
+          description: Reindex triggered successfully. Returns the resolved ledger range.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminReindexResponse'
+              example:
+                data:
+                  from: 54321
+                  to: 55000
+        '400':
+          description: Validation error (ledger missing or not a positive integer)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorBody'
+        '403':
+          description: Missing or invalid admin JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '429':
+          description: Rate limit exceeded (60 req/min per admin token)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        '500':
+          description: Internal server error (e.g. Soroban RPC unreachable)
           content:
             application/json:
               schema:

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "jest": "^29.7.0",
         "js-yaml": "^5.2.0",
         "supertest": "^7.0.0",
-        "ts-jest": "^29.4.11",
+        "ts-jest": "^29.2.5",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.62.0"
@@ -96,7 +96,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2448,7 +2447,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2885,7 +2883,6 @@
       "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2896,7 +2893,6 @@
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -3100,7 +3096,6 @@
       "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.0",
         "@typescript-eslint/types": "8.62.0",
@@ -3383,7 +3378,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4180,7 +4174,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -5433,7 +5426,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5699,7 +5691,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -6768,7 +6759,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7943,6 +7933,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mmdb-lib": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/mmdb-lib/-/mmdb-lib-2.2.1.tgz",
@@ -8330,7 +8327,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -9909,7 +9905,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10084,7 +10079,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10775,7 +10769,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11191,7 +11184,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -11,6 +11,8 @@ const schema = z.object({
   JWT_ISSUER: z.string().default("predictify"),
   JWT_AUDIENCE: z.string().default("predictify-app"),
   JWT_TTL_SECONDS: z.coerce.number().int().positive().default(3600),
+  JWT_KEYS: z.string().optional(),
+  JWT_ACTIVE_KID: z.string().optional(),
   WORKER_HEARTBEAT_SECONDS: z.coerce.number().int().positive().default(30),
   STELLAR_NETWORK: z.enum(["testnet", "mainnet"]).default("testnet"),
   SOROBAN_RPC_URL: z.string().url(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { notificationsRouter } from "./routes/notifications";
 import { socialRouter } from "./routes/social";
 import { adminAuditRouter } from "./routes/admin/audit";
 import { adminMarketsRouter } from "./routes/admin/markets";
+import { adminReindexRouter } from "./routes/admin/reindex";
 import { errorHandler } from "./middleware/errorHandler";
 import { requestContextStorage } from "./lib/requestContext";
 import { REQUEST_ID_HEADER } from "./lib/http";
@@ -105,6 +106,7 @@ export function createApp(_options?: unknown): express.Express {
   app.use("/api/me/devices", devicesRouter);
   app.use("/api/admin/audit", adminAuditRouter);
   app.use("/api/admin/markets", adminMarketsRouter);
+  app.use("/api/admin/reindex", adminReindexRouter);
 
   app.get("/metrics", async (req, res) => {
     const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;

--- a/src/metrics/registry.ts
+++ b/src/metrics/registry.ts
@@ -49,3 +49,9 @@ export const settleConfirmerFailedTotal = new Counter({
   help: "Total number of claims permanently marked as failed by the settle-confirmer",
   registers: [register],
 });
+
+export const adminReindexTotal = new Counter({
+  name: "admin_reindex_total",
+  help: "Total number of admin-triggered reindex operations that completed successfully",
+  registers: [register],
+});

--- a/src/openapi/registry.ts
+++ b/src/openapi/registry.ts
@@ -946,6 +946,50 @@ registry.registerPath({
   },
 });
 
+// ── /api/admin/reindex ─────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: "post",
+  path: "/api/admin/reindex",
+  tags: ["Admin"],
+  summary: "Trigger an indexer reindex from a specific ledger (admin only)",
+  security: [{ bearerAuth: [] }],
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            ledger: z.number().int().positive(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Reindex request accepted",
+      content: {
+        "application/json": {
+          schema: z.object({
+            data: z.object({
+              from: z.number().int().positive(),
+              to: z.number().int().positive(),
+            }),
+          }),
+        },
+      },
+    },
+    400: {
+      description: "Invalid request body",
+      content: { "application/json": { schema: ValidationErrorBody } },
+    },
+    403: {
+      description: "Forbidden — missing or non-admin JWT",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+  },
+});
+
 // ── /api/admin/health/detail ─────────────────────────────────────────────────
 
 const CheckStatus = z

--- a/src/routes/admin/reindex.ts
+++ b/src/routes/admin/reindex.ts
@@ -1,0 +1,182 @@
+/**
+ * Admin reindex endpoint.
+ *
+ *   POST /api/admin/reindex
+ *
+ * Triggers a backfill of on-chain Soroban events from a caller-supplied
+ * ledger sequence number up to the current chain tip.
+ *
+ * Security
+ * ────────
+ * • Requires a valid admin JWT (`role: "admin"`) in the Authorization header.
+ * • Rate-limited to `rateLimitPerMinute` (default 60) requests per minute,
+ *   keyed on the raw Authorization header so each distinct admin token gets
+ *   its own bucket. Unauthenticated callers fall back to IP-based throttling.
+ *
+ * Audit
+ * ─────
+ * • A structured row is written to `auditLogs` (action: "admin.reindex") on
+ *   every successful invocation for compliance and forensic traceability.
+ *
+ * Observability
+ * ─────────────
+ * • Increments the `admin_reindex_total` Prometheus counter on success.
+ * • Emits a structured pino log at INFO level with the caller address and
+ *   the resolved ledger range so operators can grep for reindex activity.
+ */
+
+import { Router } from "express";
+import { rateLimit } from "express-rate-limit";
+import { z } from "zod";
+import { logger } from "../../config/logger";
+import { requireAdmin } from "../../middleware/requireAdmin";
+import { REQUEST_ID_HEADER } from "../../lib/http";
+import { getRequestId } from "../../lib/requestContext";
+import { indexerService } from "../../services/indexerService";
+import { adminReindexTotal } from "../../metrics/registry";
+import { db } from "../../db";
+import { auditLogs } from "../../db/schema";
+
+// ── Validation schema ────────────────────────────────────────────────────────
+
+/** Body accepted by POST /api/admin/reindex */
+const bodySchema = z.object({
+  /** Ledger sequence number to start reindexing from. Must be a positive integer. */
+  ledger: z.number().int().positive(),
+});
+
+// ── Router options ───────────────────────────────────────────────────────────
+
+export interface AdminReindexRouterOptions {
+  /**
+   * Maximum number of requests per minute per admin token.
+   * Defaults to 60 (matching all other admin routers).
+   */
+  rateLimitPerMinute?: number;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Resolves the request ID from AsyncLocalStorage context, then req.id fallback. */
+function resolveRequestId(req: { id?: unknown }): string {
+  return (
+    getRequestId() ??
+    (typeof req.id === "string" ? req.id : "") ??
+    ""
+  );
+}
+
+/** Extracts the client IP from forwarded headers or the socket, matching other admin routes. */
+function extractClientIp(req: { ip?: string; socket?: { remoteAddress?: string }; headers: Record<string, string | string[] | undefined> }): string {
+  const forwarded = req.headers["x-forwarded-for"];
+  if (typeof forwarded === "string") {
+    const first = forwarded.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  if (Array.isArray(forwarded) && forwarded.length > 0) {
+    return forwarded[0] ?? "unknown";
+  }
+  return req.ip ?? req.socket?.remoteAddress ?? "unknown";
+}
+
+// ── Router factory ───────────────────────────────────────────────────────────
+
+export function createAdminReindexRouter(
+  opts: AdminReindexRouterOptions = {},
+): Router {
+  const router = Router();
+  const rpmLimit = opts.rateLimitPerMinute ?? 60;
+
+  // ── Rate limiter ───────────────────────────────────────────────────────────
+  // Key on the raw Authorization header so each admin token has its own
+  // bucket. Falls back to IP for unauthenticated callers so they are still
+  // throttled before they reach requireAdmin.
+  router.use(
+    rateLimit({
+      windowMs: 60_000,
+      limit: rpmLimit,
+      keyGenerator: (req) =>
+        (req.headers.authorization as string | undefined) ??
+        req.ip ??
+        "unknown",
+      standardHeaders: "draft-6",
+      legacyHeaders: false,
+      message: { error: { code: "rate_limit_exceeded" } },
+    }),
+  );
+
+  // ── Admin guard ────────────────────────────────────────────────────────────
+  router.use(requireAdmin);
+
+  // ── POST / ────────────────────────────────────────────────────────────────
+  /**
+   * Validates the request body, resolves the current chain tip, enqueues
+   * a backfill from `ledger` → `chainTip`, then returns the resolved range
+   * so the caller can track progress via the indexer health probe.
+   */
+  router.post("", async (req, res, next) => {
+    try {
+      const requestId = resolveRequestId(req);
+
+      // ── Input validation ─────────────────────────────────────────────────
+      const parsed = bodySchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.setHeader(REQUEST_ID_HEADER, requestId);
+        res.status(400).json({
+          error: {
+            code: "validation_error",
+            details: parsed.error.issues,
+            requestId,
+          },
+        });
+        return;
+      }
+
+      const { ledger: from } = parsed.data;
+
+      // ── Backfill ─────────────────────────────────────────────────────────
+      // getChainTip() goes to Soroban RPC; backfillRange() is chunked and
+      // writes to indexer_events with ON CONFLICT DO NOTHING (idempotent).
+      const to = await indexerService.getChainTip();
+      await indexerService.backfillRange(from, to);
+
+      // ── Audit log ─────────────────────────────────────────────────────────
+      // Written after the backfill so a failed backfill produces no audit row.
+      // The `ip` column is NOT NULL — fall back to "unknown" for programmatic
+      // callers that omit forwarding headers.
+      const ip = extractClientIp(req as Parameters<typeof extractClientIp>[0]);
+      await db.insert(auditLogs).values({
+        action: "admin.reindex",
+        walletAddress: req.adminAddress ?? null,
+        ip,
+        correlationId: requestId,
+        rateLimitContext: null,
+      });
+
+      // ── Metrics & structured log ──────────────────────────────────────────
+      adminReindexTotal.inc();
+      logger.info(
+        {
+          requestId,
+          adminAddress: req.adminAddress,
+          from,
+          to,
+        },
+        "admin reindex triggered",
+      );
+
+      // ── Response ──────────────────────────────────────────────────────────
+      res.setHeader(REQUEST_ID_HEADER, requestId);
+      res.status(200).json({
+        data: { from, to },
+      });
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}
+
+/** Default singleton wired into src/index.ts. */
+export const adminReindexRouter = createAdminReindexRouter();

--- a/tests/adminReindex.test.ts
+++ b/tests/adminReindex.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Unit tests for POST /api/admin/reindex
+ *
+ * All external I/O is mocked:
+ *   - indexerService  (getChainTip, backfillRange)
+ *   - db              (auditLogs insert)
+ *   - adminReindexTotal Prometheus counter
+ *
+ * The test app is assembled with a low rate-limit cap so the 429 path can be
+ * exercised without hammering a real limiter.
+ */
+
+import express from "express";
+import jwt from "jsonwebtoken";
+import request from "supertest";
+
+// ── Mock: indexerService ─────────────────────────────────────────────────────
+jest.mock("../src/services/indexerService", () => ({
+  indexerService: {
+    getChainTip: jest.fn(),
+    backfillRange: jest.fn(),
+  },
+}));
+
+// ── Mock: Drizzle db (audit log insert) ───────────────────────────────────────
+const mockInsert = jest.fn().mockReturnValue({
+  values: jest.fn().mockResolvedValue(undefined),
+});
+jest.mock("../src/db", () => ({ db: { insert: mockInsert } }));
+
+// ── Mock: Prometheus counter ──────────────────────────────────────────────────
+const mockInc = jest.fn();
+jest.mock("../src/metrics/registry", () => ({
+  adminReindexTotal: { inc: mockInc },
+}));
+
+import { indexerService } from "../src/services/indexerService";
+import { createAdminReindexRouter } from "../src/routes/admin/reindex";
+import { errorHandler } from "../src/middleware/errorHandler";
+
+// ── Test fixtures ─────────────────────────────────────────────────────────────
+
+const SECRET = process.env.JWT_SECRET || "test-jwt-secret-at-least-32-bytes-long-000000";
+const ISSUER = process.env.JWT_ISSUER || "predictify";
+const AUDIENCE = process.env.JWT_AUDIENCE || "predictify-app";
+
+const ADMIN_ADDR = "GADMIN7777777777777777777777777777777777777777777777777777";
+const USER_ADDR = "GUSER88888888888888888888888888888888888888888888888888888";
+
+const mockedIndexerService = indexerService as jest.Mocked<typeof indexerService>;
+
+function signJwt(payload: object): string {
+  return jwt.sign(payload, SECRET, { issuer: ISSUER, audience: AUDIENCE, expiresIn: "1h" });
+}
+
+const adminJwt = signJwt({ sub: ADMIN_ADDR, role: "admin" });
+const userJwt = signJwt({ sub: USER_ADDR, role: "user" });
+
+/**
+ * Builds a minimal Express app with the reindex router mounted at
+ * /api/admin/reindex.  Pass `rateLimitPerMinute` to override the default 60
+ * so tests can easily trigger 429 responses.
+ */
+function makeApp(rateLimitPerMinute = 60): express.Express {
+  const app = express();
+  app.use(express.json());
+
+  // Simulate the pino-http request-id injection done in src/index.ts.
+  app.use((req, _res, next) => {
+    (req as express.Request & { id?: string }).id =
+      (req.headers["x-request-id"] as string | undefined) ?? "admin-reindex-req";
+    next();
+  });
+
+  app.use(
+    "/api/admin/reindex",
+    createAdminReindexRouter({ rateLimitPerMinute }),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+// ── Reset mocks between tests ─────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedIndexerService.getChainTip.mockResolvedValue(200);
+  mockedIndexerService.backfillRange.mockResolvedValue(undefined);
+  // Re-wire the insert chain after clearAllMocks
+  const valuesStub = jest.fn().mockResolvedValue(undefined);
+  mockInsert.mockReturnValue({ values: valuesStub });
+});
+
+// ── Auth guard ─────────────────────────────────────────────────────────────────
+
+describe("requireAdmin guard", () => {
+  it("returns 403 without an Authorization header", async () => {
+    const res = await request(makeApp()).post("/api/admin/reindex").send({ ledger: 42 });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: { code: "forbidden" } });
+    expect(mockedIndexerService.backfillRange).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a non-admin JWT", async () => {
+    const res = await request(makeApp())
+      .post("/api/admin/reindex")
+      .set("Authorization", `Bearer ${userJwt}`)
+      .send({ ledger: 42 });
+
+    expect(res.status).toBe(403);
+    expect(mockedIndexerService.backfillRange).not.toHaveBeenCalled();
+  });
+});
+
+// ── Input validation ───────────────────────────────────────────────────────────
+
+describe("validation", () => {
+  it("rejects a ledger below 1", async () => {
+    const res = await request(makeApp())
+      .post("/api/admin/reindex")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 0 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+    expect(mockedIndexerService.backfillRange).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-integer ledger", async () => {
+    const res = await request(makeApp())
+      .post("/api/admin/reindex")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 12.5 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+    expect(mockedIndexerService.backfillRange).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing ledger field", async () => {
+    const res = await request(makeApp())
+      .post("/api/admin/reindex")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+});
+
+// ── Happy path ─────────────────────────────────────────────────────────────────
+
+describe("POST /api/admin/reindex", () => {
+  it("triggers a backfill from the requested ledger to the current chain tip", async () => {
+    const res = await request(makeApp())
+      .post("/api/admin/reindex")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .set("X-Request-Id", "req-reindex")
+      .send({ ledger: 42 });
+
+    expect(res.status).toBe(200);
+    expect(mockedIndexerService.getChainTip).toHaveBeenCalledTimes(1);
+    expect(mockedIndexerService.backfillRange).toHaveBeenCalledWith(42, 200);
+    expect(res.body).toEqual({
+      data: {
+        from: 42,
+        to: 200,
+      },
+    });
+  });
+
+  it("echoes the x-request-id header in the response", async () => {
+    const res = await request(makeApp())
+      .post("/api/admin/reindex")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .set("X-Request-Id", "trace-xyz")
+      .send({ ledger: 10 });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-request-id"]).toBe("trace-xyz");
+  });
+
+  it("records the correct IP in the audit log (single forwarded-for value)", async () => {
+    const valuesStub = jest.fn().mockResolvedValue(undefined);
+    mockInsert.mockReturnValue({ values: valuesStub });
+
+    await request(makeApp())
+      .post("/api/admin/reindex")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .set("X-Forwarded-For", "203.0.113.5")
+      .send({ ledger: 1 });
+
+    expect(valuesStub).toHaveBeenCalledWith(
+      expect.objectContaining({ ip: "203.0.113.5" }),
+    );
+  });
+
+  it("writes a structured audit log entry on success", async () => {
+    const valuesStub = jest.fn().mockResolvedValue(undefined);
+    mockInsert.mockReturnValue({ values: valuesStub });
+
+    await request(makeApp())
+      .post("/api/admin/reindex")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .set("X-Request-Id", "audit-req")
+      .send({ ledger: 100 });
+
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    expect(valuesStub).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "admin.reindex",
+        walletAddress: ADMIN_ADDR,
+        correlationId: "audit-req",
+      }),
+    );
+  });
+
+  it("increments the adminReindexTotal Prometheus counter on success", async () => {
+    await request(makeApp())
+      .post("/api/admin/reindex")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 1 });
+
+    expect(mockInc).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── Rate limiting ──────────────────────────────────────────────────────────────
+
+describe("rate limiting", () => {
+  it("returns 429 after the configured limit is exceeded", async () => {
+    // Use a limit of 1 so the second request in the window triggers throttling.
+    const app = makeApp(1);
+
+    // First request should succeed (uses the 1 allowed slot).
+    const first = await request(app)
+      .post("/api/admin/reindex")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 1 });
+    expect(first.status).toBe(200);
+
+    // Second request in the same window is throttled.
+    const second = await request(app)
+      .post("/api/admin/reindex")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 1 });
+    expect(second.status).toBe(429);
+    expect(second.body).toEqual({ error: { code: "rate_limit_exceeded" } });
+  });
+});
+
+// ── Error propagation ──────────────────────────────────────────────────────────
+
+describe("error propagation", () => {
+  it("forwards upstream errors from getChainTip() to the error handler (500)", async () => {
+    mockedIndexerService.getChainTip.mockRejectedValue(new Error("rpc unavailable"));
+
+    const res = await request(makeApp())
+      .post("/api/admin/reindex")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 1 });
+
+    // The global errorHandler turns unhandled errors into 500.
+    expect(res.status).toBe(500);
+    // No audit log or counter should be written when the backfill fails.
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockInc).not.toHaveBeenCalled();
+  });
+
+  it("forwards upstream errors from backfillRange() to the error handler (500)", async () => {
+    mockedIndexerService.backfillRange.mockRejectedValue(new Error("storage error"));
+
+    const res = await request(makeApp())
+      .post("/api/admin/reindex")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 1 });
+
+    expect(res.status).toBe(500);
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockInc).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
closed #302

Summary
Adds a new admin-only endpoint, POST /api/admin/reindex, to trigger an indexer backfill from a caller-supplied ledger up to the current chain tip. This makes it possible to recover or reprocess historical Soroban ledger data directly through the API.

What changed
Added a new admin route at reindex.ts
Wired the router into the app in index.ts
Added focused test coverage in adminReindex.test.ts
Documented the endpoint in the OpenAPI registry at registry.ts
