### PR TITLE
Add per-endpoint body size limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Once running:
 ## Request body size limits
 
 - Default JSON request body limit: `256kb`.
-- Route-level overrides are applied in middleware using `createBodyLimitMiddleware(...)`.
+- Route-level overrides are applied in middleware using `createBodySizeLimitMiddleware(...)` from `src/middleware/bodySize.ts`.
 - Webhook routes may opt into a larger limit of `1mb`.
 - Requests exceeding the configured limit return HTTP `413` with the standard error envelope, including correlation and request IDs.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { env } from "./config/env";
 import { logger } from "./config/logger";
 import { metricsMiddleware } from "./metrics/httpMetrics";
 import { idempotency } from "./middleware/idempotency";
-import { defaultBodyLimitMiddleware, webhookBodyLimitMiddleware } from "./middleware/bodyLimit";
+import { defaultBodySizeLimitMiddleware, webhookBodySizeLimitMiddleware } from "./middleware/bodySize";
 import { healthRouter } from "./routes/health";
 import dependenciesRouter from "./routes/healthz/dependencies";
 import { authRouter } from "./routes/auth";
@@ -54,8 +54,6 @@ export function createApp(_options?: unknown): express.Express {
   }
 
   app.use(helmet());
-  app.use("/api/admin/webhooks", webhookBodyLimitMiddleware);
-  app.use(defaultBodyLimitMiddleware);
 
   app.use(
     pinoHttp({
@@ -82,6 +80,9 @@ export function createApp(_options?: unknown): express.Express {
       requestContextStorage.run({ requestId }, next);
     },
   );
+
+  app.use("/api/admin/webhooks", webhookBodySizeLimitMiddleware);
+  app.use(defaultBodySizeLimitMiddleware);
 
   app.use(metricsMiddleware);
   app.use("/health", healthRouter);

--- a/src/middleware/bodyLimit.ts
+++ b/src/middleware/bodyLimit.ts
@@ -1,64 +1,8 @@
-import express, { type ErrorRequestHandler, type NextFunction, type Request, type RequestHandler, type Response } from "express";
-import type { OptionsJson } from "body-parser";
-import { AppError, ErrorCodes } from "../errors";
-
-export const DEFAULT_BODY_LIMIT = "256kb";
-export const WEBHOOK_BODY_LIMIT = "1mb";
-
-export interface BodyLimitOptions {
-  limit?: OptionsJson["limit"];
-}
-
-function normalizeLimit(limit?: OptionsJson["limit"]): OptionsJson["limit"] {
-  return limit ?? DEFAULT_BODY_LIMIT;
-}
-
-function isPayloadTooLargeError(err: unknown): err is Error & {
-  status?: number;
-  type?: string;
-  limit?: number | string;
-  length?: number;
-  expected?: number;
-} {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    (("status" in err && (err as { status?: unknown }).status === 413) ||
-      ("type" in err && (err as { type?: unknown }).type === "entity.too.large"))
-  );
-}
-
-export function createBodyLimitMiddleware(options: BodyLimitOptions = {}): Array<RequestHandler | ErrorRequestHandler> {
-  const parser = express.json({ limit: normalizeLimit(options.limit) });
-
-  const payloadTooLargeHandler: ErrorRequestHandler = (
-    err: unknown,
-    _req: Request,
-    _res: Response,
-    next: NextFunction,
-  ) => {
-    if (!isPayloadTooLargeError(err)) {
-      next(err);
-      return;
-    }
-
-    next(
-      new AppError(
-        ErrorCodes.REQUEST_FAILED,
-        "Request body too large",
-        413,
-        {
-          limit: err.limit,
-          length: err.length ?? err.expected,
-        },
-      ),
-    );
-  };
-
-  return [parser, payloadTooLargeHandler];
-}
-
-export const defaultBodyLimitMiddleware = createBodyLimitMiddleware();
-export const webhookBodyLimitMiddleware = createBodyLimitMiddleware({
-  limit: WEBHOOK_BODY_LIMIT,
-});
+export {
+  DEFAULT_BODY_LIMIT,
+  WEBHOOK_BODY_LIMIT,
+  createBodySizeLimitMiddleware as createBodyLimitMiddleware,
+  defaultBodySizeLimitMiddleware as defaultBodyLimitMiddleware,
+  webhookBodySizeLimitMiddleware as webhookBodyLimitMiddleware,
+  type BodySizeLimitOptions as BodyLimitOptions,
+} from "./bodySize";

--- a/src/middleware/bodySize.ts
+++ b/src/middleware/bodySize.ts
@@ -1,0 +1,92 @@
+import express, {
+  type ErrorRequestHandler,
+  type NextFunction,
+  type Request,
+  type RequestHandler,
+  type Response,
+} from "express";
+import type { OptionsJson } from "body-parser";
+import { logger } from "../config/logger";
+import { AppError, ErrorCodes } from "../errors";
+import { getRequestId } from "../lib/requestContext";
+
+export const DEFAULT_BODY_LIMIT = "256kb";
+export const WEBHOOK_BODY_LIMIT = "1mb";
+
+export interface BodySizeLimitOptions {
+  limit?: OptionsJson["limit"];
+  routeName?: string;
+}
+
+function normalizeLimit(limit?: OptionsJson["limit"]): OptionsJson["limit"] {
+  return limit ?? DEFAULT_BODY_LIMIT;
+}
+
+function isPayloadTooLargeError(err: unknown): err is Error & {
+  status?: number;
+  type?: string;
+  limit?: number | string;
+  length?: number;
+  expected?: number;
+} {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (("status" in err && (err as { status?: unknown }).status === 413) ||
+      ("type" in err && (err as { type?: unknown }).type === "entity.too.large"))
+  );
+}
+
+export function createBodySizeLimitMiddleware(
+  options: BodySizeLimitOptions = {},
+): Array<RequestHandler | ErrorRequestHandler> {
+  const limit = normalizeLimit(options.limit);
+  const parser = express.json({ limit });
+
+  const payloadTooLargeHandler: ErrorRequestHandler = (
+    err: unknown,
+    req: Request,
+    _res: Response,
+    next: NextFunction,
+  ) => {
+    if (!isPayloadTooLargeError(err)) {
+      next(err);
+      return;
+    }
+
+    const requestId =
+      getRequestId() ??
+      (typeof (req as { id?: unknown }).id === "string"
+        ? (req as { id: string }).id
+        : undefined);
+    logger.warn(
+      {
+        requestId,
+        correlationId: req.headers["x-correlation-id"] ?? requestId,
+        path: req.path,
+        method: req.method,
+        routeName: options.routeName,
+        limit: err.limit,
+        length: err.length ?? err.expected,
+      },
+      "request_body_too_large",
+    );
+
+    next(
+      new AppError(ErrorCodes.REQUEST_FAILED, "Request body too large", 413, {
+        limit: err.limit,
+        length: err.length ?? err.expected,
+      }),
+    );
+  };
+
+  return [parser, payloadTooLargeHandler];
+}
+
+export const defaultBodySizeLimitMiddleware = createBodySizeLimitMiddleware({
+  routeName: "default",
+});
+export const webhookBodySizeLimitMiddleware = createBodySizeLimitMiddleware({
+  limit: WEBHOOK_BODY_LIMIT,
+  routeName: "admin-webhooks",
+});

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -46,7 +46,7 @@ export function errorHandler(
 
   // 2. AppError (legacy)
   if (err instanceof AppError) {
-    logger.error({ err, path: req.path, method: req.method, requestId: reqId }, "app_error");
+    logger.error({ err, path: req.path, method: req.method, correlationId, requestId: reqId }, "app_error");
     res.status(err.status).json({
       error: {
         code: err.code,
@@ -61,7 +61,7 @@ export function errorHandler(
 
   // 3. ZodError
   if (err instanceof ZodError) {
-    logger.warn({ err, path: req.path, method: req.method, requestId: reqId }, "validation_error");
+    logger.warn({ err, path: req.path, method: req.method, correlationId, requestId: reqId }, "validation_error");
     res.status(400).json({
       error: {
         code: ErrorCodes.VALIDATION_ERROR,
@@ -75,7 +75,7 @@ export function errorHandler(
   }
 
   // 4. Unknown error
-  logger.error({ err, path: req.path, method: req.method, requestId: reqId }, "unknown_error");
+  logger.error({ err, path: req.path, method: req.method, correlationId, requestId: reqId }, "unknown_error");
   res.status(500).json({
     error: {
       code: ErrorCodes.INTERNAL_ERROR,

--- a/tests/bodyLimit.test.ts
+++ b/tests/bodyLimit.test.ts
@@ -1,11 +1,11 @@
 import request from "supertest";
 import express from "express";
-import { createBodyLimitMiddleware, DEFAULT_BODY_LIMIT, WEBHOOK_BODY_LIMIT } from "../src/middleware/bodyLimit";
+import { createBodySizeLimitMiddleware, DEFAULT_BODY_LIMIT, WEBHOOK_BODY_LIMIT } from "../src/middleware/bodySize";
 import { errorHandler } from "../src/middleware/errorHandler";
 
 function buildApp(path: string, limit?: string) {
   const app = express();
-  app.use(path, createBodyLimitMiddleware(limit ? { limit } : undefined));
+  app.use(path, createBodySizeLimitMiddleware(limit ? { limit } : undefined));
   app.post(path, (req, res) => {
     res.status(200).json({ ok: true, size: JSON.stringify(req.body).length });
   });


### PR DESCRIPTION
Motivation
Provide per-route JSON body-size limits so webhook and other routes can opt into larger payloads without raising the global default.
Convert oversized-body errors into the repo-standard 413 request_failed envelope and include request/correlation IDs for client correlation and observability.
Emit structured warnings when payloads exceed limits so incidents are traceable with correlation and request IDs.

Description
Added src/middleware/bodySize.ts which exports createBodySizeLimitMiddleware, DEFAULT_BODY_LIMIT (256kb), and WEBHOOK_BODY_LIMIT (1mb), and converts parser entity.too.large errors into AppError(413) with limit/length details and structured logs including requestId and x-correlation-id.
Kept backwards compatibility by replacing the old bodyLimit module with a thin re-export in src/middleware/bodyLimit.ts that aliases the new API.
Mounted the webhook-specific middleware before the default JSON parser in src/index.ts so /api/admin/webhooks uses the 1mb override while the rest of the API uses the 256kb default.
Updated src/middleware/errorHandler.ts to include correlationId in structured error logs and adjusted the focused unit test tests/bodyLimit.test.ts and README.md to reference the new middleware API.

Testing
git diff --check ran cleanly and reported no whitespace/patch issues.
Attempts to install dependencies (npm ci, npm install) failed due to a lockfile mismatch / registry permission error (missing mkdirp-classic), so a full CI run could not be executed in this environment.
Because dependencies could not be installed, npm run lint and the TypeScript project check (npm exec tsc -- --noEmit -p tsconfig.json) could not complete successfully; the TypeScript check additionally surfaced a deprecated moduleResolution=node10 setting when run with a newer TypeScript.
Focused unit tests for the body-size change (tests/bodyLimit.test.ts) could not be executed here because the Jest binary was not available after failed installs; the test file was updated and is ready to run in CI where dependencies are available.

close #311 