### PR TITLE
feat: admin plugins CRUD endpoints

### DIFF
--- a/drizzle/migrations/0014_plugins.sql
+++ b/drizzle/migrations/0014_plugins.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "plugins" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"config" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "plugins_name_unique" UNIQUE("name")
+);

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -11,6 +11,9 @@ const schema = z.object({
   JWT_ISSUER: z.string().default("predictify"),
   JWT_AUDIENCE: z.string().default("predictify-app"),
   JWT_TTL_SECONDS: z.coerce.number().int().positive().default(3600),
+  // See src/utils/keyRing.ts for the "kid:secret,..." format and rotation flow.
+  JWT_KEYS: z.string().optional(),
+  JWT_ACTIVE_KID: z.string().optional(),
   WORKER_HEARTBEAT_SECONDS: z.coerce.number().int().positive().default(30),
   STELLAR_NETWORK: z.enum(["testnet", "mainnet"]).default("testnet"),
   SOROBAN_RPC_URL: z.string().url(),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -345,6 +345,26 @@ export const auditLogs = pgTable(
 );
 
 // ---------------------------------------------------------------------------
+// Plugins (admin-managed CRUD)
+// ---------------------------------------------------------------------------
+
+export const plugins = pgTable("plugins", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  name: text("name").notNull().unique(),
+  description: text("description"),
+  enabled: boolean("enabled").notNull().default(true),
+  config: jsonb("config").notNull().default({}),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+export type Plugin = typeof plugins.$inferSelect;
+
+// ---------------------------------------------------------------------------
 // Feature Flags
 // ---------------------------------------------------------------------------
 export const featureFlags = pgTable("feature_flags", {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { notificationsRouter } from "./routes/notifications";
 import { socialRouter } from "./routes/social";
 import { adminAuditRouter } from "./routes/admin/audit";
 import { adminMarketsRouter } from "./routes/admin/markets";
+import { adminPluginsRouter } from "./routes/admin/plugins";
 import { errorHandler } from "./middleware/errorHandler";
 import { requestContextStorage } from "./lib/requestContext";
 import { REQUEST_ID_HEADER } from "./lib/http";
@@ -105,6 +106,7 @@ export function createApp(_options?: unknown): express.Express {
   app.use("/api/me/devices", devicesRouter);
   app.use("/api/admin/audit", adminAuditRouter);
   app.use("/api/admin/markets", adminMarketsRouter);
+  app.use("/api/admin/plugins", adminPluginsRouter);
 
   app.get("/metrics", async (req, res) => {
     const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;

--- a/src/openapi/registry.ts
+++ b/src/openapi/registry.ts
@@ -946,6 +946,236 @@ registry.registerPath({
   },
 });
 
+// ── /api/admin/plugins ─────────────────────────────────────────────────────
+
+const PluginView = z
+  .object({
+    id: z.string().uuid(),
+    name: z.string(),
+    description: z.string().nullable(),
+    enabled: z.boolean(),
+    config: z.any(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+  })
+  .openapi("PluginView");
+
+const CreatePluginRequest = z
+  .object({
+    name: z.string().min(1).max(255),
+    description: z.string().max(1000).optional(),
+    enabled: z.boolean().optional(),
+    config: z.record(z.unknown()).optional(),
+  })
+  .openapi("CreatePluginRequest");
+
+const UpdatePluginRequest = z
+  .object({
+    name: z.string().min(1).max(255).optional(),
+    description: z.string().max(1000).nullable().optional(),
+    enabled: z.boolean().optional(),
+    config: z.record(z.unknown()).optional(),
+  })
+  .openapi("UpdatePluginRequest");
+
+const DeletePluginResult = z
+  .object({
+    id: z.string().uuid(),
+    name: z.string(),
+  })
+  .openapi("DeletePluginResult");
+
+// GET /api/admin/plugins
+registry.registerPath({
+  method: "get",
+  path: "/api/admin/plugins",
+  operationId: "listAdminPlugins",
+  tags: ["Admin"],
+  summary: "List all plugins (admin only)",
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: z.object({
+      enabled: z.enum(["true", "false"]).optional(),
+      limit: z.coerce.number().int().min(1).max(200).optional(),
+      offset: z.coerce.number().int().nonnegative().optional(),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Paginated list of plugins",
+      content: {
+        "application/json": {
+          schema: z.object({
+            data: z.array(PluginView),
+            total: z.number().int(),
+          }),
+        },
+      },
+    },
+    400: {
+      description: "Validation error",
+      content: { "application/json": { schema: ValidationErrorBody } },
+    },
+    403: {
+      description: "Forbidden — missing or non-admin JWT",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    429: {
+      description: "Rate limit exceeded",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+  },
+});
+
+// POST /api/admin/plugins
+registry.registerPath({
+  method: "post",
+  path: "/api/admin/plugins",
+  operationId: "createAdminPlugin",
+  tags: ["Admin"],
+  summary: "Create a new plugin (admin only)",
+  security: [{ bearerAuth: [] }],
+  request: {
+    body: {
+      content: { "application/json": { schema: CreatePluginRequest } },
+    },
+  },
+  responses: {
+    201: {
+      description: "Plugin created",
+      content: {
+        "application/json": { schema: z.object({ data: PluginView }) },
+      },
+    },
+    400: {
+      description: "Validation error",
+      content: { "application/json": { schema: ValidationErrorBody } },
+    },
+    403: {
+      description: "Forbidden — missing or non-admin JWT",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    409: {
+      description: "Plugin name already exists",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    429: {
+      description: "Rate limit exceeded",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+  },
+});
+
+// GET /api/admin/plugins/{id}
+registry.registerPath({
+  method: "get",
+  path: "/api/admin/plugins/{id}",
+  operationId: "getAdminPlugin",
+  tags: ["Admin"],
+  summary: "Get a single plugin by ID (admin only)",
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ id: z.string().uuid() }) },
+  responses: {
+    200: {
+      description: "Plugin details",
+      content: {
+        "application/json": { schema: z.object({ data: PluginView }) },
+      },
+    },
+    400: {
+      description: "Invalid ID",
+      content: { "application/json": { schema: ValidationErrorBody } },
+    },
+    403: {
+      description: "Forbidden — missing or non-admin JWT",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    404: {
+      description: "Plugin not found",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    429: {
+      description: "Rate limit exceeded",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+  },
+});
+
+// PATCH /api/admin/plugins/{id}
+registry.registerPath({
+  method: "patch",
+  path: "/api/admin/plugins/{id}",
+  operationId: "updateAdminPlugin",
+  tags: ["Admin"],
+  summary: "Update a plugin (admin only)",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+    body: {
+      content: { "application/json": { schema: UpdatePluginRequest } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Plugin updated",
+      content: {
+        "application/json": { schema: z.object({ data: PluginView }) },
+      },
+    },
+    400: {
+      description: "Validation error",
+      content: { "application/json": { schema: ValidationErrorBody } },
+    },
+    403: {
+      description: "Forbidden — missing or non-admin JWT",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    404: {
+      description: "Plugin not found",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    429: {
+      description: "Rate limit exceeded",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+  },
+});
+
+// DELETE /api/admin/plugins/{id}
+registry.registerPath({
+  method: "delete",
+  path: "/api/admin/plugins/{id}",
+  operationId: "deleteAdminPlugin",
+  tags: ["Admin"],
+  summary: "Delete a plugin (admin only)",
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ id: z.string().uuid() }) },
+  responses: {
+    200: {
+      description: "Plugin deleted",
+      content: {
+        "application/json": { schema: z.object({ data: DeletePluginResult }) },
+      },
+    },
+    400: {
+      description: "Invalid ID",
+      content: { "application/json": { schema: ValidationErrorBody } },
+    },
+    403: {
+      description: "Forbidden — missing or non-admin JWT",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    404: {
+      description: "Plugin not found",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    429: {
+      description: "Rate limit exceeded",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+  },
+});
+
 // ── /api/admin/health/detail ─────────────────────────────────────────────────
 
 const CheckStatus = z

--- a/src/routes/admin/plugins.ts
+++ b/src/routes/admin/plugins.ts
@@ -1,0 +1,351 @@
+/**
+ * Admin plugin CRUD router.
+ *
+ *   GET    /api/admin/plugins          — list plugins (optional ?enabled=true|false)
+ *   POST   /api/admin/plugins          — create a plugin
+ *   GET    /api/admin/plugins/:id      — get a single plugin
+ *   PATCH  /api/admin/plugins/:id      — partially update a plugin
+ *   DELETE /api/admin/plugins/:id      — delete a plugin
+ *
+ * All routes require a valid admin JWT (role: "admin") in the Authorization
+ * header and are rate-limited per admin token.
+ */
+
+import { Router, type Request } from "express";
+import { rateLimit } from "express-rate-limit";
+import { z } from "zod";
+import { requireAdmin } from "../../middleware/requireAdmin";
+import { REQUEST_ID_HEADER } from "../../lib/http";
+import { getRequestId } from "../../lib/requestContext";
+import type { PluginRepository } from "../../services/pluginService";
+import {
+  DrizzlePluginRepository,
+  PluginNotFoundError,
+  PluginNameConflictError,
+  listPlugins,
+  getPlugin,
+  createPlugin,
+  updatePlugin,
+  deletePlugin,
+} from "../../services/pluginService";
+
+// ─── Schemas ────────────────────────────────────────────────────────────────
+
+const listQuerySchema = z.object({
+  enabled: z
+    .enum(["true", "false"])
+    .transform((v) => v === "true")
+    .optional(),
+  limit: z
+    .string()
+    .regex(/^\d+$/, { message: "limit must be a positive integer" })
+    .transform((v) => parseInt(v, 10))
+    .refine((n) => n >= 1 && n <= 200, {
+      message: "limit must be between 1 and 200",
+    })
+    .optional(),
+  offset: z
+    .string()
+    .regex(/^\d+$/, { message: "offset must be a non-negative integer" })
+    .transform((v) => parseInt(v, 10))
+    .optional(),
+});
+
+const createBodySchema = z.object({
+  name: z.string().trim().min(1).max(255),
+  description: z.string().max(1000).optional(),
+  enabled: z.boolean().optional(),
+  config: z.record(z.unknown()).optional(),
+});
+
+const updateBodySchema = z.object({
+  name: z.string().trim().min(1).max(255).optional(),
+  description: z.string().max(1000).nullable().optional(),
+  enabled: z.boolean().optional(),
+  config: z.record(z.unknown()).optional(),
+});
+
+const paramsSchema = z.object({
+  id: z.string().uuid({ message: "id must be a valid UUID" }),
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function requestIdOf(req: { id?: unknown }): string {
+  return (
+    getRequestId() ??
+    (typeof req.id === "string" ? req.id : "")
+  );
+}
+
+function extractClientIp(req: Request): string {
+  const forwarded = req.headers["x-forwarded-for"];
+  if (typeof forwarded === "string") {
+    const first = forwarded.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  if (Array.isArray(forwarded) && forwarded.length > 0) {
+    return forwarded[0]!;
+  }
+  return req.ip ?? req.socket.remoteAddress ?? "unknown";
+}
+
+// ─── Router factory ─────────────────────────────────────────────────────────
+
+export interface AdminPluginsRouterOptions {
+  /** Inject a fake repo in tests. */
+  repo?: PluginRepository;
+  /** Requests per minute per admin token. Default: 60 */
+  rateLimitPerMinute?: number;
+}
+
+export function createAdminPluginsRouter(
+  opts: AdminPluginsRouterOptions = {},
+): Router {
+  const router = Router();
+  const repo = opts.repo ?? new DrizzlePluginRepository();
+  const limit = opts.rateLimitPerMinute ?? 60;
+
+  // ── Rate limiter ──────────────────────────────────────────────────────────
+  router.use(
+    rateLimit({
+      windowMs: 60_000,
+      limit,
+      keyGenerator: (req) =>
+        (req.headers.authorization as string | undefined) ??
+        req.ip ??
+        "unknown",
+      standardHeaders: "draft-6",
+      legacyHeaders: false,
+      message: { error: { code: "rate_limit_exceeded" } },
+    }),
+  );
+
+  // ── Admin guard ───────────────────────────────────────────────────────────
+  router.use(requireAdmin);
+
+  // ── GET / ── list plugins ─────────────────────────────────────────────────
+  router.get("/", async (req, res, next) => {
+    try {
+      const requestId = requestIdOf({ id: (req as { id?: unknown }).id });
+      const parsed = listQuerySchema.safeParse(req.query);
+      if (!parsed.success) {
+        res.setHeader(REQUEST_ID_HEADER, requestId);
+        res.status(400).json({
+          error: {
+            code: "validation_error",
+            message:
+              parsed.error.issues[0]?.message ?? "invalid query parameters",
+            details: parsed.error.issues,
+            requestId,
+          },
+        });
+        return;
+      }
+
+      const result = await listPlugins(parsed.data, repo);
+      res.setHeader(REQUEST_ID_HEADER, requestId);
+      res.json({ data: result.data, total: result.total });
+    } catch (e) {
+      next(e);
+    }
+  });
+
+  // ── POST / ── create plugin ───────────────────────────────────────────────
+  router.post("/", async (req, res, next) => {
+    try {
+      const requestId = requestIdOf({ id: (req as { id?: unknown }).id });
+
+      const parsed = createBodySchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.setHeader(REQUEST_ID_HEADER, requestId);
+        res.status(400).json({
+          error: {
+            code: "validation_error",
+            message:
+              parsed.error.issues[0]?.message ?? "invalid request body",
+            details: parsed.error.issues,
+            requestId,
+          },
+        });
+        return;
+      }
+
+      if (!req.adminAddress) {
+        res.status(401).json({ error: { code: "unauthorized", requestId } });
+        return;
+      }
+
+      const plugin = await createPlugin(parsed.data, {
+        adminAddress: req.adminAddress,
+        ip: extractClientIp(req),
+        correlationId: requestId,
+      }, repo);
+
+      res.setHeader(REQUEST_ID_HEADER, requestId);
+      res.status(201).json({ data: plugin });
+    } catch (e) {
+      if (e instanceof PluginNameConflictError) {
+        const requestId = requestIdOf({ id: (req as { id?: unknown }).id });
+        res.setHeader(REQUEST_ID_HEADER, requestId);
+        res.status(409).json({
+          error: { code: "name_conflict", message: e.message, requestId },
+        });
+        return;
+      }
+      next(e);
+    }
+  });
+
+  // ── GET /:id ── get plugin by ID ─────────────────────────────────────────
+  router.get("/:id", async (req, res, next) => {
+    try {
+      const requestId = requestIdOf({ id: (req as { id?: unknown }).id });
+      const parsed = paramsSchema.safeParse(req.params);
+      if (!parsed.success) {
+        res.setHeader(REQUEST_ID_HEADER, requestId);
+        res.status(400).json({
+          error: {
+            code: "validation_error",
+            message:
+              parsed.error.issues[0]?.message ?? "invalid id parameter",
+            details: parsed.error.issues,
+            requestId,
+          },
+        });
+        return;
+      }
+
+      const plugin = await getPlugin(parsed.data.id, repo);
+      if (!plugin) {
+        res.setHeader(REQUEST_ID_HEADER, requestId);
+        res.status(404).json({ error: { code: "not_found", requestId } });
+        return;
+      }
+
+      res.setHeader(REQUEST_ID_HEADER, requestId);
+      res.json({ data: plugin });
+    } catch (e) {
+      next(e);
+    }
+  });
+
+  // ── PATCH /:id ── update plugin ──────────────────────────────────────────
+  router.patch("/:id", async (req, res, next) => {
+    try {
+      const requestId = requestIdOf({ id: (req as { id?: unknown }).id });
+
+      const paramsParsed = paramsSchema.safeParse(req.params);
+      if (!paramsParsed.success) {
+        res.setHeader(REQUEST_ID_HEADER, requestId);
+        res.status(400).json({
+          error: {
+            code: "validation_error",
+            message:
+              paramsParsed.error.issues[0]?.message ?? "invalid id parameter",
+            details: paramsParsed.error.issues,
+            requestId,
+          },
+        });
+        return;
+      }
+
+      const bodyParsed = updateBodySchema.safeParse(req.body);
+      if (!bodyParsed.success) {
+        res.setHeader(REQUEST_ID_HEADER, requestId);
+        res.status(400).json({
+          error: {
+            code: "validation_error",
+            message:
+              bodyParsed.error.issues[0]?.message ?? "invalid request body",
+            details: bodyParsed.error.issues,
+            requestId,
+          },
+        });
+        return;
+      }
+
+      if (Object.keys(bodyParsed.data).length === 0) {
+        res.setHeader(REQUEST_ID_HEADER, requestId);
+        res.status(400).json({
+          error: {
+            code: "validation_error",
+            message: "at least one field must be provided for update",
+            requestId,
+          },
+        });
+        return;
+      }
+
+      if (!req.adminAddress) {
+        res.status(401).json({ error: { code: "unauthorized", requestId } });
+        return;
+      }
+
+      const plugin = await updatePlugin(paramsParsed.data.id, bodyParsed.data, {
+        adminAddress: req.adminAddress,
+        ip: extractClientIp(req),
+        correlationId: requestId,
+      }, repo);
+
+      res.setHeader(REQUEST_ID_HEADER, requestId);
+      res.json({ data: plugin });
+    } catch (e) {
+      if (e instanceof PluginNotFoundError) {
+        const requestId = requestIdOf({ id: (req as { id?: unknown }).id });
+        res.setHeader(REQUEST_ID_HEADER, requestId);
+        res.status(404).json({ error: { code: "not_found", requestId } });
+        return;
+      }
+      next(e);
+    }
+  });
+
+  // ── DELETE /:id ── delete plugin ─────────────────────────────────────────
+  router.delete("/:id", async (req, res, next) => {
+    try {
+      const requestId = requestIdOf({ id: (req as { id?: unknown }).id });
+      const parsed = paramsSchema.safeParse(req.params);
+      if (!parsed.success) {
+        res.setHeader(REQUEST_ID_HEADER, requestId);
+        res.status(400).json({
+          error: {
+            code: "validation_error",
+            message:
+              parsed.error.issues[0]?.message ?? "invalid id parameter",
+            details: parsed.error.issues,
+            requestId,
+          },
+        });
+        return;
+      }
+
+      if (!req.adminAddress) {
+        res.status(401).json({ error: { code: "unauthorized", requestId } });
+        return;
+      }
+
+      const result = await deletePlugin(parsed.data.id, {
+        adminAddress: req.adminAddress,
+        ip: extractClientIp(req),
+        correlationId: requestId,
+      }, repo);
+
+      res.setHeader(REQUEST_ID_HEADER, requestId);
+      res.json({ data: result });
+    } catch (e) {
+      if (e instanceof PluginNotFoundError) {
+        const requestId = requestIdOf({ id: (req as { id?: unknown }).id });
+        res.setHeader(REQUEST_ID_HEADER, requestId);
+        res.status(404).json({ error: { code: "not_found", requestId } });
+        return;
+      }
+      next(e);
+    }
+  });
+
+  return router;
+}
+
+// Default export wired into src/index.ts.
+export const adminPluginsRouter = createAdminPluginsRouter();

--- a/src/services/pluginService.ts
+++ b/src/services/pluginService.ts
@@ -1,0 +1,304 @@
+/**
+ * @module pluginService
+ *
+ * Owns plugin CRUD for the admin dashboard.
+ *
+ * Responsibilities:
+ *  - List all plugins with optional status filter
+ *  - Create a new plugin with unique name enforcement
+ *  - Read a single plugin by ID
+ *  - Partially update plugin fields (name, description, enabled, config)
+ *  - Delete a plugin by ID
+ *
+ * All mutations are audited through the standard audit service.
+ */
+
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "../db/client";
+import { plugins } from "../db/schema";
+import type { Plugin } from "../db/schema";
+import { createAuditLog } from "./auditService";
+import { logger } from "../config/logger";
+
+// ─── PostgreSQL error codes ──────────────────────────────────────────────────
+
+const PG_UNIQUE_VIOLATION = "23505";
+
+/**
+ * Checks if an error is a PostgreSQL unique-constraint violation.
+ * Drizzle wraps the original pg driver error inside a nested object.
+ */
+function isUniqueViolation(err: unknown): err is { code: string } {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code: string }).code === PG_UNIQUE_VIOLATION
+  );
+}
+
+// ─── Error types ─────────────────────────────────────────────────────────────
+
+export class PluginNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Plugin not found: ${id}`);
+    this.name = "PluginNotFoundError";
+  }
+}
+
+export class PluginNameConflictError extends Error {
+  constructor(name: string) {
+    super(`Plugin with name "${name}" already exists`);
+    this.name = "PluginNameConflictError";
+  }
+}
+
+// ─── DTO types ──────────────────────────────────────────────────────────────
+
+export interface PluginView {
+  id: string;
+  name: string;
+  description: string | null;
+  enabled: boolean;
+  config: unknown;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreatePluginInput {
+  name: string;
+  description?: string;
+  enabled?: boolean;
+  config?: Record<string, unknown>;
+}
+
+export interface UpdatePluginInput {
+  name?: string;
+  description?: string | null;
+  enabled?: boolean;
+  config?: Record<string, unknown>;
+}
+
+export interface ListPluginsFilters {
+  enabled?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface PluginListResult {
+  data: PluginView[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+function toPluginView(p: Plugin): PluginView {
+  return {
+    id: p.id,
+    name: p.name,
+    description: p.description ?? null,
+    enabled: p.enabled,
+    config: p.config,
+    createdAt: p.createdAt instanceof Date ? p.createdAt.toISOString() : String(p.createdAt),
+    updatedAt: p.updatedAt instanceof Date ? p.updatedAt.toISOString() : String(p.updatedAt),
+  };
+}
+
+// ─── Repository contract ────────────────────────────────────────────────────
+
+export interface PluginRepository {
+  list(filters: ListPluginsFilters): Promise<PluginListResult>;
+  getById(id: string): Promise<Plugin | null>;
+  create(input: CreatePluginInput): Promise<Plugin>;
+  update(id: string, input: UpdatePluginInput): Promise<Plugin>;
+  delete(id: string): Promise<string | null>;
+}
+
+// ─── Repository implementation (Drizzle) ────────────────────────────────────
+
+export class DrizzlePluginRepository implements PluginRepository {
+  constructor(private readonly database: typeof db = db) {}
+
+  async list(filters: ListPluginsFilters): Promise<PluginListResult> {
+    const limit = filters.limit ?? 50;
+    const offset = filters.offset ?? 0;
+
+    const conditions = [];
+    if (filters.enabled !== undefined) {
+      conditions.push(eq(plugins.enabled, filters.enabled));
+    }
+
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const [rows, countRows] = await Promise.all([
+      this.database
+        .select()
+        .from(plugins)
+        .where(where)
+        .orderBy(plugins.createdAt)
+        .limit(limit)
+        .offset(offset),
+      this.database
+        .select({ count: sql<number>`count(*)` })
+        .from(plugins)
+        .where(where),
+    ]);
+
+    return {
+      data: rows.map(toPluginView),
+      total: Number(countRows[0]?.count ?? 0),
+      limit,
+      offset,
+    };
+  }
+
+  async getById(id: string): Promise<Plugin | null> {
+    const rows = await this.database
+      .select()
+      .from(plugins)
+      .where(eq(plugins.id, id))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  async create(input: CreatePluginInput): Promise<Plugin> {
+    const rows = await this.database
+      .insert(plugins)
+      .values({
+        name: input.name,
+        description: input.description ?? null,
+        enabled: input.enabled ?? true,
+        config: input.config ?? {},
+      })
+      .returning();
+    return rows[0]!;
+  }
+
+  async update(id: string, input: UpdatePluginInput): Promise<Plugin> {
+    const now = new Date();
+    const updateData: Record<string, unknown> = { updatedAt: now };
+
+    if (input.name !== undefined) updateData.name = input.name;
+    if (input.description !== undefined) updateData.description = input.description;
+    if (input.enabled !== undefined) updateData.enabled = input.enabled;
+    if (input.config !== undefined) updateData.config = input.config;
+
+    const rows = await this.database
+      .update(plugins)
+      .set(updateData)
+      .where(eq(plugins.id, id))
+      .returning();
+
+    if (rows.length === 0) {
+      throw new PluginNotFoundError(id);
+    }
+    return rows[0]!;
+  }
+
+  async delete(id: string): Promise<string | null> {
+    const rows = await this.database
+      .delete(plugins)
+      .where(eq(plugins.id, id))
+      .returning({ id: plugins.id, name: plugins.name });
+
+    return rows[0]?.name ?? null;
+  }
+}
+
+// ─── Audit context ──────────────────────────────────────────────────────────
+
+export interface PluginAuditContext {
+  adminAddress: string;
+  ip: string;
+  correlationId?: string;
+}
+
+async function audit(
+  action: string,
+  pluginId: string,
+  pluginName: string,
+  ctx: PluginAuditContext,
+): Promise<void> {
+  await createAuditLog({
+    action,
+    walletAddress: ctx.adminAddress,
+    ip: ctx.ip,
+    correlationId: ctx.correlationId,
+  });
+
+  logger.info(
+    {
+      correlationId: ctx.correlationId,
+      pluginId,
+      pluginName,
+      adminAddress: ctx.adminAddress,
+      action,
+    },
+    action,
+  );
+}
+
+// ─── Public service API ─────────────────────────────────────────────────────
+
+export async function listPlugins(
+  filters: ListPluginsFilters,
+  repo: PluginRepository = new DrizzlePluginRepository(),
+): Promise<PluginListResult> {
+  return repo.list(filters);
+}
+
+export async function getPlugin(
+  id: string,
+  repo: PluginRepository = new DrizzlePluginRepository(),
+): Promise<PluginView | null> {
+  const plugin = await repo.getById(id);
+  return plugin ? toPluginView(plugin) : null;
+}
+
+export async function createPlugin(
+  input: CreatePluginInput,
+  ctx: PluginAuditContext,
+  repo: PluginRepository = new DrizzlePluginRepository(),
+): Promise<PluginView> {
+  try {
+    const plugin = await repo.create(input);
+    await audit("admin.plugin.create", plugin.id, plugin.name, ctx);
+    return toPluginView(plugin);
+  } catch (e) {
+    if (isUniqueViolation(e)) {
+      throw new PluginNameConflictError(input.name);
+    }
+    throw e;
+  }
+}
+
+export async function updatePlugin(
+  id: string,
+  input: UpdatePluginInput,
+  ctx: PluginAuditContext,
+  repo: PluginRepository = new DrizzlePluginRepository(),
+): Promise<PluginView> {
+  try {
+    const plugin = await repo.update(id, input);
+    await audit("admin.plugin.update", plugin.id, plugin.name, ctx);
+    return toPluginView(plugin);
+  } catch (e) {
+    if (isUniqueViolation(e)) {
+      throw new PluginNameConflictError(input.name ?? "(unknown)");
+    }
+    throw e;
+  }
+}
+
+export async function deletePlugin(
+  id: string,
+  ctx: PluginAuditContext,
+  repo: PluginRepository = new DrizzlePluginRepository(),
+): Promise<{ id: string; name: string }> {
+  const name = await repo.delete(id);
+  if (!name) {
+    throw new PluginNotFoundError(id);
+  }
+  await audit("admin.plugin.delete", id, name, ctx);
+  return { id, name };
+}

--- a/tests/adminPlugins.test.ts
+++ b/tests/adminPlugins.test.ts
@@ -1,0 +1,799 @@
+/**
+ * Tests for the admin plugin CRUD routes.
+ *
+ *   GET    /api/admin/plugins
+ *   POST   /api/admin/plugins
+ *   GET    /api/admin/plugins/:id
+ *   PATCH  /api/admin/plugins/:id
+ *   DELETE /api/admin/plugins/:id
+ *
+ * Strategy:
+ *  - Use a FakePluginRepository so no real DB is needed.
+ *  - Sign real JWTs (with role:"admin") to exercise the full requireAdmin path.
+ *  - Mount `createAdminPluginsRouter()` directly on a minimal express app so
+ *    the rate-limit ceiling can be lowered for the 429 test.
+ */
+
+import express from "express";
+import jwt from "jsonwebtoken";
+import request from "supertest";
+import { createAdminPluginsRouter } from "../src/routes/admin/plugins";
+import { errorHandler } from "../src/middleware/errorHandler";
+import type {
+  PluginRepository,
+  PluginListResult,
+  CreatePluginInput,
+  UpdatePluginInput,
+} from "../src/services/pluginService";
+import { PluginNotFoundError } from "../src/services/pluginService";
+import type { Plugin } from "../src/db/schema";
+
+// ── JWT fixtures ─────────────────────────────────────────────────────────────
+const SECRET =
+  process.env.JWT_SECRET || "test-jwt-secret-at-least-32-bytes-long-000000";
+const ISSUER = process.env.JWT_ISSUER || "predictify";
+const AUDIENCE = process.env.JWT_AUDIENCE || "predictify-app";
+
+const ADMIN_ADDR =
+  "GADMIN7777777777777777777777777777777777777777777777777777";
+const USER_ADDR =
+  "GUSER88888888888888888888888888888888888888888888888888888";
+
+function signJwt(payload: object): string {
+  return jwt.sign(payload, SECRET, {
+    issuer: ISSUER,
+    audience: AUDIENCE,
+    expiresIn: "1h",
+  });
+}
+
+const adminJwt = signJwt({ sub: ADMIN_ADDR, role: "admin" });
+const userJwt = signJwt({ sub: USER_ADDR, role: "user" });
+
+// ── DB mock (prevents Pool connection at import time) ───────────────────────
+jest.mock("../src/db/client", () => ({ db: {} }));
+
+// ── Fake repository ─────────────────────────────────────────────────────────
+
+class FakePluginRepo implements PluginRepository {
+  plugins: Plugin[] = [];
+  private nextId = 1;
+
+  private makePlugin(input: CreatePluginInput): Plugin {
+    const now = new Date();
+    const id = `00000000-0000-0000-0000-${String(this.nextId++).padStart(12, "0")}`;
+    return {
+      id,
+      name: input.name,
+      description: input.description ?? null,
+      enabled: input.enabled ?? true,
+      config: input.config ?? {},
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  async list(filters: {
+    enabled?: boolean;
+    limit?: number;
+    offset?: number;
+  }): Promise<PluginListResult> {
+    let filtered = [...this.plugins];
+    if (filters.enabled !== undefined) {
+      filtered = filtered.filter((p) => p.enabled === filters.enabled);
+    }
+    const limit = filters.limit ?? 50;
+    const offset = filters.offset ?? 0;
+    const page = filtered.slice(offset, offset + limit);
+    return {
+      data: page.map((p) => ({
+        id: p.id,
+        name: p.name,
+        description: p.description ?? null,
+        enabled: p.enabled,
+        config: p.config,
+        createdAt:
+          p.createdAt instanceof Date
+            ? p.createdAt.toISOString()
+            : String(p.createdAt),
+        updatedAt:
+          p.updatedAt instanceof Date
+            ? p.updatedAt.toISOString()
+            : String(p.updatedAt),
+      })),
+      total: filtered.length,
+      limit,
+      offset,
+    };
+  }
+
+  async getById(id: string): Promise<Plugin | null> {
+    return this.plugins.find((p) => p.id === id) ?? null;
+  }
+
+  async create(input: CreatePluginInput): Promise<Plugin> {
+    // Simulate DB unique constraint on name
+    if (this.plugins.some((p) => p.name === input.name)) {
+      const err = new Error(
+        'duplicate key value violates unique constraint "plugins_name_unique"',
+      ) as Error & { code: string };
+      err.code = "23505";
+      throw err;
+    }
+    const plugin = this.makePlugin(input);
+    this.plugins.push(plugin);
+    return plugin;
+  }
+
+  async update(id: string, input: UpdatePluginInput): Promise<Plugin> {
+    const idx = this.plugins.findIndex((p) => p.id === id);
+    if (idx === -1) throw new PluginNotFoundError(id);
+    // Simulate DB unique constraint on name
+    if (
+      input.name !== undefined &&
+      this.plugins.some((p) => p.id !== id && p.name === input.name)
+    ) {
+      const err = new Error(
+        'duplicate key value violates unique constraint "plugins_name_unique"',
+      ) as Error & { code: string };
+      err.code = "23505";
+      throw err;
+    }
+    const now = new Date();
+    const p = this.plugins[idx]!;
+    if (input.name !== undefined) p.name = input.name;
+    if (input.description !== undefined) p.description = input.description;
+    if (input.enabled !== undefined) p.enabled = input.enabled;
+    if (input.config !== undefined) p.config = input.config;
+    p.updatedAt = now;
+    return p;
+  }
+
+  async delete(id: string): Promise<string | null> {
+    const idx = this.plugins.findIndex((p) => p.id === id);
+    if (idx === -1) return null;
+    const name = this.plugins[idx]!.name;
+    this.plugins.splice(idx, 1);
+    return name;
+  }
+}
+
+// ── App factory ─────────────────────────────────────────────────────────────
+
+function makeApp(rateLimitPerMinute = 600): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (
+      req as express.Request & { id?: string }
+    ).id =
+      (req.headers["x-request-id"] as string | undefined) ?? "admin-plugins-req";
+    next();
+  });
+  app.use(
+    "/api/admin/plugins",
+    createAdminPluginsRouter({
+      repo: new FakePluginRepo(),
+      rateLimitPerMinute,
+    }),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+function makeAppWithRepo(
+  repo: PluginRepository,
+  rateLimitPerMinute = 600,
+): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (
+      req as express.Request & { id?: string }
+    ).id =
+      (req.headers["x-request-id"] as string | undefined) ?? "admin-plugins-req";
+    next();
+  });
+  app.use(
+    "/api/admin/plugins",
+    createAdminPluginsRouter({ repo, rateLimitPerMinute }),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+// ── Lifecycle ───────────────────────────────────────────────────────────────
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ── Auth guard ──────────────────────────────────────────────────────────────
+
+describe("requireAdmin guard", () => {
+  it("GET / returns 403 without an Authorization header", async () => {
+    const res = await request(makeApp()).get("/api/admin/plugins");
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: { code: "forbidden" } });
+  });
+
+  it("POST / returns 403 without an Authorization header", async () => {
+    const res = await request(makeApp()).post("/api/admin/plugins").send({});
+    expect(res.status).toBe(403);
+  });
+
+  it("PATCH / returns 403 without an Authorization header", async () => {
+    const res = await request(makeApp())
+      .patch("/api/admin/plugins/some-id")
+      .send({});
+    expect(res.status).toBe(403);
+  });
+
+  it("DELETE / returns 403 without an Authorization header", async () => {
+    const res = await request(makeApp()).delete("/api/admin/plugins/some-id");
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 with a non-admin JWT", async () => {
+    const res = await request(makeApp())
+      .get("/api/admin/plugins")
+      .set("Authorization", `Bearer ${userJwt}`);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 with a JWT signed by a different secret", async () => {
+    const forged = jwt.sign(
+      { sub: ADMIN_ADDR, role: "admin" },
+      "not-the-real-secret-but-32-chars-long",
+      { issuer: ISSUER, audience: AUDIENCE },
+    );
+    const res = await request(makeApp())
+      .get("/api/admin/plugins")
+      .set("Authorization", `Bearer ${forged}`);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 with an expired JWT", async () => {
+    const expired = jwt.sign(
+      { sub: ADMIN_ADDR, role: "admin" },
+      SECRET,
+      { issuer: ISSUER, audience: AUDIENCE, expiresIn: -1 },
+    );
+    const res = await request(makeApp())
+      .get("/api/admin/plugins")
+      .set("Authorization", `Bearer ${expired}`);
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── GET / ── list plugins ──────────────────────────────────────────────────
+
+describe("GET /api/admin/plugins — list plugins", () => {
+  it("returns empty list when no plugins exist", async () => {
+    const res = await request(makeApp())
+      .get("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ data: [], total: 0 });
+  });
+
+  it("returns all plugins", async () => {
+    const app = makeApp();
+    // Create plugins via POST
+    await request(app)
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "plugin-a" });
+    await request(app)
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "plugin-b", enabled: false });
+
+    const res = await request(app)
+      .get("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.total).toBe(2);
+    expect(res.body.data[0].name).toBe("plugin-a");
+    expect(res.body.data[1].name).toBe("plugin-b");
+  });
+
+  it("filters by enabled=true", async () => {
+    const app = makeApp();
+    await request(app)
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "enabled-plugin", enabled: true });
+    await request(app)
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "disabled-plugin", enabled: false });
+
+    const res = await request(app)
+      .get("/api/admin/plugins?enabled=true")
+      .set("Authorization", `Bearer ${adminJwt}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].name).toBe("enabled-plugin");
+  });
+
+  it("filters by enabled=false", async () => {
+    const app = makeApp();
+    await request(app)
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "enabled-plugin", enabled: true });
+    await request(app)
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "disabled-plugin", enabled: false });
+
+    const res = await request(app)
+      .get("/api/admin/plugins?enabled=false")
+      .set("Authorization", `Bearer ${adminJwt}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].name).toBe("disabled-plugin");
+  });
+
+  it("supports limit and offset", async () => {
+    const app = makeApp();
+    for (let i = 0; i < 5; i++) {
+      await request(app)
+        .post("/api/admin/plugins")
+        .set("Authorization", `Bearer ${adminJwt}`)
+        .send({ name: `plugin-${i}` });
+    }
+
+    const res = await request(app)
+      .get("/api/admin/plugins?limit=2&offset=1")
+      .set("Authorization", `Bearer ${adminJwt}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.total).toBe(5);
+  });
+
+  it("rejects invalid enabled value", async () => {
+    const res = await request(makeApp())
+      .get("/api/admin/plugins?enabled=maybe")
+      .set("Authorization", `Bearer ${adminJwt}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("rejects non-numeric limit", async () => {
+    const res = await request(makeApp())
+      .get("/api/admin/plugins?limit=abc")
+      .set("Authorization", `Bearer ${adminJwt}`);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects limit out of range", async () => {
+    const res = await request(makeApp())
+      .get("/api/admin/plugins?limit=9999")
+      .set("Authorization", `Bearer ${adminJwt}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+});
+
+// ── POST / ── create plugin ────────────────────────────────────────────────
+
+describe("POST /api/admin/plugins — create plugin", () => {
+  it("creates a plugin and returns 201", async () => {
+    const res = await request(makeApp())
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "my-plugin", description: "my desc", config: { key: "val" } });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.name).toBe("my-plugin");
+    expect(res.body.data.description).toBe("my desc");
+    expect(res.body.data.enabled).toBe(true);
+    expect(res.body.data.config).toEqual({ key: "val" });
+    expect(res.body.data.id).toBeDefined();
+    expect(res.body.data.createdAt).toBeDefined();
+  });
+
+  it("defaults enabled to true and config to {}", async () => {
+    const res = await request(makeApp())
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "minimal" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.enabled).toBe(true);
+    expect(res.body.data.config).toEqual({});
+    expect(res.body.data.description).toBeNull();
+  });
+
+  it("returns 400 when name is missing", async () => {
+    const res = await request(makeApp())
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("returns 400 when name is empty after trim", async () => {
+    const res = await request(makeApp())
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "   " });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 409 when name already exists", async () => {
+    const app = makeApp();
+    await request(app)
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "unique" });
+
+    const res = await request(app)
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "unique" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("name_conflict");
+  });
+
+  it("returns 201 with only the name field (extra keys ignored)", async () => {
+    const res = await request(makeApp())
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "ok" });
+
+    expect(res.status).toBe(201);
+  });
+});
+
+// ── GET /:id ── get plugin by ID ──────────────────────────────────────────
+
+describe("GET /api/admin/plugins/:id — get plugin by ID", () => {
+  it("returns a plugin by ID", async () => {
+    const app = makeApp();
+    const create = await request(app)
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "read-me" });
+    const id = create.body.data.id;
+
+    const res = await request(app)
+      .get(`/api/admin/plugins/${id}`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.id).toBe(id);
+    expect(res.body.data.name).toBe("read-me");
+  });
+
+  it("returns 404 for a non-existent plugin", async () => {
+    const res = await request(makeApp())
+      .get("/api/admin/plugins/00000000-0000-0000-0000-000000000000")
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("not_found");
+  });
+
+  it("returns 400 for an invalid UUID", async () => {
+    const res = await request(makeApp())
+      .get("/api/admin/plugins/not-a-uuid")
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+});
+
+// ── PATCH /:id ── update plugin ───────────────────────────────────────────
+
+describe("PATCH /api/admin/plugins/:id — update plugin", () => {
+  it("updates a plugin name", async () => {
+    const app = makeApp();
+    const create = await request(app)
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "old-name" });
+    const id = create.body.data.id;
+
+    const res = await request(app)
+      .patch(`/api/admin/plugins/${id}`)
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "new-name" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.name).toBe("new-name");
+  });
+
+  it("updates enabled status", async () => {
+    const app = makeApp();
+    const create = await request(app)
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "toggle-me" });
+    const id = create.body.data.id;
+
+    const res = await request(app)
+      .patch(`/api/admin/plugins/${id}`)
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ enabled: false });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.enabled).toBe(false);
+  });
+
+  it("updates config", async () => {
+    const app = makeApp();
+    const create = await request(app)
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "config-me" });
+    const id = create.body.data.id;
+
+    const res = await request(app)
+      .patch(`/api/admin/plugins/${id}`)
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ config: { newKey: "newVal" } });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.config).toEqual({ newKey: "newVal" });
+  });
+
+  it("clears description when set to null", async () => {
+    const app = makeApp();
+    const create = await request(app)
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "clear-me", description: "was here" });
+    const id = create.body.data.id;
+
+    const res = await request(app)
+      .patch(`/api/admin/plugins/${id}`)
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ description: null });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.description).toBeNull();
+  });
+
+  it("returns 400 when no fields are provided", async () => {
+    const res = await request(makeApp())
+      .patch("/api/admin/plugins/00000000-0000-0000-0000-000000000001")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+    expect(res.body.error.message).toMatch(/at least one field/);
+  });
+
+  it("returns 404 for a non-existent plugin", async () => {
+    const res = await request(makeApp())
+      .patch("/api/admin/plugins/00000000-0000-0000-0000-000000000000")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "ghost" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("not_found");
+  });
+
+  it("returns 400 for an invalid UUID", async () => {
+    const res = await request(makeApp())
+      .patch("/api/admin/plugins/not-a-uuid")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "nope" });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── DELETE /:id ── delete plugin ──────────────────────────────────────────
+
+describe("DELETE /api/admin/plugins/:id — delete plugin", () => {
+  it("deletes a plugin and returns its id and name", async () => {
+    const app = makeApp();
+    const create = await request(app)
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "delete-me" });
+    const id = create.body.data.id;
+
+    const res = await request(app)
+      .delete(`/api/admin/plugins/${id}`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.id).toBe(id);
+    expect(res.body.data.name).toBe("delete-me");
+  });
+
+  it("returns 404 when deleting a non-existent plugin", async () => {
+    const res = await request(makeApp())
+      .delete("/api/admin/plugins/00000000-0000-0000-0000-000000000000")
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("not_found");
+  });
+
+  it("returns 400 for an invalid UUID", async () => {
+    const res = await request(makeApp())
+      .delete("/api/admin/plugins/not-a-uuid")
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("plugin is gone after deletion", async () => {
+    const app = makeApp();
+    const create = await request(app)
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "gone-soon" });
+    const id = create.body.data.id;
+
+    await request(app)
+      .delete(`/api/admin/plugins/${id}`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    const get = await request(app)
+      .get(`/api/admin/plugins/${id}`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(get.status).toBe(404);
+  });
+});
+
+// ── Rate limiting ──────────────────────────────────────────────────────────
+
+describe("rate limiting", () => {
+  it("returns 429 after the per-token ceiling is exceeded", async () => {
+    const app = makeAppWithRepo(new FakePluginRepo(), 2);
+
+    await request(app)
+      .get("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`);
+    await request(app)
+      .get("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    const third = await request(app)
+      .get("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(third.status).toBe(429);
+    expect(third.body).toEqual({ error: { code: "rate_limit_exceeded" } });
+  });
+
+  it("isolates buckets per admin token", async () => {
+    const otherAdminJwt = signJwt({
+      sub: "GOTHERADMINADMINADMINADMINADMINADMINADMINADMINADMINADMIN",
+      role: "admin",
+    });
+
+    const app = makeAppWithRepo(new FakePluginRepo(), 1);
+    const a = await request(app)
+      .get("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`);
+    const b = await request(app)
+      .get("/api/admin/plugins")
+      .set("Authorization", `Bearer ${otherAdminJwt}`);
+
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+  });
+});
+
+// ── Response surface ───────────────────────────────────────────────────────
+
+describe("response surface", () => {
+  it("exposes standard rate-limit headers on successful responses", async () => {
+    const res = await request(makeApp())
+      .get("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(res.headers["ratelimit-limit"]).toBeDefined();
+    expect(res.headers["ratelimit-remaining"]).toBeDefined();
+  });
+
+  it("returns the documented error envelope on validation failure", async () => {
+    const res = await request(makeApp())
+      .get("/api/admin/plugins?enabled=invalid")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .set("X-Request-Id", "shape-test");
+
+    expect(res.body).toMatchObject({
+      error: {
+        code: "validation_error",
+        details: expect.any(Array),
+        requestId: "shape-test",
+      },
+    });
+  });
+});
+
+// ── Full CRUD lifecycle ────────────────────────────────────────────────────
+
+describe("full CRUD lifecycle", () => {
+  it("create → read → update → delete works end-to-end", async () => {
+    const app = makeApp();
+
+    // Create
+    const create = await request(app)
+      .post("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({
+        name: "lifecycle-plugin",
+        description: "testing lifecycle",
+        config: { version: 1 },
+      });
+    expect(create.status).toBe(201);
+    const id = create.body.data.id;
+
+    // Read
+    const read = await request(app)
+      .get(`/api/admin/plugins/${id}`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+    expect(read.status).toBe(200);
+    expect(read.body.data.name).toBe("lifecycle-plugin");
+
+    // Update
+    const update = await request(app)
+      .patch(`/api/admin/plugins/${id}`)
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ name: "updated-lifecycle" });
+    expect(update.status).toBe(200);
+    expect(update.body.data.name).toBe("updated-lifecycle");
+
+    // List verification
+    const list = await request(app)
+      .get("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`);
+    expect(list.body.data).toHaveLength(1);
+    expect(list.body.data[0].name).toBe("updated-lifecycle");
+
+    // Delete
+    const del = await request(app)
+      .delete(`/api/admin/plugins/${id}`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+    expect(del.status).toBe(200);
+
+    // Verify gone
+    const gone = await request(app)
+      .get(`/api/admin/plugins/${id}`)
+      .set("Authorization", `Bearer ${adminJwt}`);
+    expect(gone.status).toBe(404);
+  });
+});
+
+// ── Error propagation ─────────────────────────────────────────────────────
+
+describe("error propagation", () => {
+  it("unexpected errors bubble to global handler (500)", async () => {
+    // Use a repo that throws unexpectedly
+    const brokenRepo: PluginRepository = {
+      list: async () => {
+        throw new Error("db down");
+      },
+      getById: async () => null,
+      create: async () => ({} as Plugin),
+      update: async () => {
+        throw new PluginNotFoundError("x");
+      },
+      delete: async () => null,
+    };
+
+    const app = makeAppWithRepo(brokenRepo);
+    const res = await request(app)
+      .get("/api/admin/plugins")
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
Add /api/admin/plugins endpoints with full CRUD support.
- GET /api/admin/plugins — list plugins with optional enabled filter
- POST /api/admin/plugins — create a new plugin
- GET /api/admin/plugins/:id — get a single plugin by UUID
- PATCH /api/admin/plugins/:id — partially update a plugin
- DELETE /api/admin/plugins/:id — delete a plugin

Includes:
- Plugins DB schema with unique name constraint
- Migration SQL (0014_plugins)
- Service layer with repository pattern and dependency injection
- Admin auth guard + rate limiting per admin token
- Zod input validation at boundary
- Audit logging for all mutations
- OpenAPI documentation for all 5 endpoints
- 41 unit tests covering auth, CRUD, validation, rate limiting, and error propagation

Also fixes pre-existing JWT_KEYS/JWT_ACTIVE_KID type error in env.ts that was blocking test compilation.

Closes #316