### PR TITLE
feat: admin db vacuum

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -11,6 +11,8 @@ const schema = z.object({
   JWT_ISSUER: z.string().default("predictify"),
   JWT_AUDIENCE: z.string().default("predictify-app"),
   JWT_TTL_SECONDS: z.coerce.number().int().positive().default(3600),
+  JWT_KEYS: z.string().optional(),
+  JWT_ACTIVE_KID: z.string().optional(),
   WORKER_HEARTBEAT_SECONDS: z.coerce.number().int().positive().default(30),
   STELLAR_NETWORK: z.enum(["testnet", "mainnet"]).default("testnet"),
   SOROBAN_RPC_URL: z.string().url(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { notificationsRouter } from "./routes/notifications";
 import { socialRouter } from "./routes/social";
 import { adminAuditRouter } from "./routes/admin/audit";
 import { adminMarketsRouter } from "./routes/admin/markets";
+import { adminDbVacuumRouter } from "./routes/admin/db/vacuum";
 import { errorHandler } from "./middleware/errorHandler";
 import { requestContextStorage } from "./lib/requestContext";
 import { REQUEST_ID_HEADER } from "./lib/http";
@@ -105,6 +106,7 @@ export function createApp(_options?: unknown): express.Express {
   app.use("/api/me/devices", devicesRouter);
   app.use("/api/admin/audit", adminAuditRouter);
   app.use("/api/admin/markets", adminMarketsRouter);
+  app.use("/api/admin/db", adminDbVacuumRouter);
 
   app.get("/metrics", async (req, res) => {
     const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;

--- a/src/routes/admin/db/vacuum.ts
+++ b/src/routes/admin/db/vacuum.ts
@@ -1,0 +1,255 @@
+/**
+ * admin/db/vacuum.ts
+ *
+ * POST /api/admin/db/vacuum
+ *
+ * Triggers PostgreSQL VACUUM on selected tables to reclaim storage and
+ * improve query performance. Supports optional ANALYZE to update planner
+ * statistics after vacuuming.
+ *
+ * Security:
+ *  - Requires a valid admin JWT (role: "admin") via requireAdmin.
+ *  - Rate-limited to 30 requests per minute per admin token.
+ *  - Table names are validated against a strict allowlist — no raw SQL
+ *    interpolation of user input.
+ *  - Returns the project's standard error envelope on failure.
+ *  - Echoes the X-Request-Id so the client can correlate logs.
+ *
+ * HTTP status codes:
+ *  - 200 OK            vacuum completed (check vacuumResults for per-table status)
+ *  - 400 Bad Request   validation error
+ *  - 403 Forbidden     missing/invalid/non-admin JWT
+ *  - 429 Too Many Requests
+ *
+ * Does NOT write to the audit log — this is a maintenance operation.
+ */
+
+import { Router } from "express";
+import { rateLimit } from "express-rate-limit";
+import { z } from "zod";
+import { requireAdmin } from "../../../middleware/requireAdmin";
+import { getRequestId } from "../../../lib/requestContext";
+import { logger } from "../../../config/logger";
+import type { Pool } from "pg";
+import { pool } from "../../../db/client";
+
+// ── Allowlist ──────────────────────────────────────────────────────────────
+
+const ALLOWED_TABLES = [
+  "users",
+  "auth_challenges",
+  "refresh_tokens",
+  "webhook_subscriptions",
+  "webhook_deliveries",
+  "webhook_deliveries_dlq",
+  "markets",
+  "market_audit_log",
+  "predictions",
+  "fraud_flags",
+  "claims",
+  "disputes",
+  "admin_audit_log",
+  "indexer_cursor",
+  "contract_events",
+  "indexer_events",
+  "idempotency_records",
+  "notification_preferences",
+  "audit_logs",
+  "feature_flags",
+] as const;
+
+type AllowedTable = (typeof ALLOWED_TABLES)[number];
+
+function isAllowedTable(name: string): name is AllowedTable {
+  return (ALLOWED_TABLES as readonly string[]).includes(name);
+}
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface AdminDbVacuumRouterOptions {
+  /** Requests per minute per admin token. Default: 30 */
+  rateLimitPerMinute?: number;
+}
+
+export interface VacuumResult {
+  tables: string[];
+  vacuumingTimeMs: number;
+  analyzingTimeMs: number;
+  vacuumResults: Array<{
+    table: string;
+    status: "success" | "failed";
+    message?: string;
+  }>;
+}
+
+// ── Validation schema ──────────────────────────────────────────────────────
+
+const vacuumBodySchema = z
+  .object({
+    tables: z
+      .array(z.string())
+      .min(1, "At least one table must be specified")
+      .max(10, "Cannot specify more than 10 tables at once")
+      .optional(),
+    analyze: z.boolean().default(false),
+  })
+  .strict();
+
+// ── Default tables ─────────────────────────────────────────────────────────
+
+const DEFAULT_TABLES: AllowedTable[] = [
+  "idempotency_records",
+  "webhook_deliveries",
+  "webhook_deliveries_dlq",
+  "contract_events",
+  "indexer_events",
+  "audit_logs",
+];
+
+// ── Router factory ─────────────────────────────────────────────────────────
+
+export function createAdminDbVacuumRouter(
+  opts: AdminDbVacuumRouterOptions = {},
+): Router {
+  const router = Router();
+  const limit = opts.rateLimitPerMinute ?? 30;
+
+  // ── Rate limiter ──────────────────────────────────────────────────────────
+  router.use(
+    rateLimit({
+      windowMs: 60_000,
+      limit,
+      keyGenerator: (req) =>
+        (req.headers.authorization as string | undefined) ??
+        req.ip ??
+        "unknown",
+      standardHeaders: "draft-6",
+      legacyHeaders: false,
+      message: { error: { code: "rate_limit_exceeded" } },
+    }),
+  );
+
+  // ── Admin guard ───────────────────────────────────────────────────────────
+  router.use(requireAdmin);
+
+  // ── POST / ────────────────────────────────────────────────────────────────
+  router.post("/", async (req, res, next) => {
+    const requestId = getRequestId();
+
+    try {
+      const parsed = vacuumBodySchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({
+          error: {
+            code: "validation_error",
+            message:
+              parsed.error.issues[0]?.message ?? "invalid request body",
+            details: parsed.error.issues,
+            requestId,
+          },
+        });
+        return;
+      }
+
+      const { tables, analyze } = parsed.data;
+
+      // Validate table names against the allowlist
+      const targetNames = tables ?? DEFAULT_TABLES;
+      const invalid = targetNames.filter((t) => !isAllowedTable(t));
+      if (invalid.length > 0) {
+        res.status(400).json({
+          error: {
+            code: "validation_error",
+            message: `Invalid table name(s): ${invalid.join(", ")}`,
+            requestId,
+          },
+        });
+        return;
+      }
+
+      const result = await executeVacuum(pool, targetNames, { analyze }, requestId ?? "");
+
+      logger.info(
+        {
+          event: "db_vacuum_completed",
+          requestId,
+          adminAddress: req.adminAddress,
+          tables: targetNames,
+          analyze,
+          vacuumingTimeMs: result.vacuumingTimeMs,
+          analyzingTimeMs: result.analyzingTimeMs,
+        },
+        "Database vacuum completed",
+      );
+
+      res.json({ data: result });
+    } catch (e) {
+      next(e);
+    }
+  });
+
+  return router;
+}
+
+// Default export wired into src/index.ts
+export const adminDbVacuumRouter = createAdminDbVacuumRouter();
+
+// ── Execute vacuum ─────────────────────────────────────────────────────────
+
+/**
+ * Run VACUUM (and optionally ANALYZE) on each table in the list.
+ *
+ * Errors per table are caught and reported individually so one failing
+ * table does not abort the rest.
+ */
+export async function executeVacuum(
+  poolInstance: Pool,
+  tables: string[],
+  options: { analyze: boolean },
+  requestId: string,
+): Promise<VacuumResult> {
+  const vacuumResults: VacuumResult["vacuumResults"] = [];
+
+  let vacuumTime = 0;
+  let analyzeTime = 0;
+
+  for (const table of tables) {
+    // VACUUM must not run inside a transaction block. pool.query() checks
+    // out a fresh client for each call, so no transaction is active.
+    const t0 = Date.now();
+    try {
+      await poolInstance.query(`VACUUM ${table}`);
+      vacuumTime += Date.now() - t0;
+
+      if (options.analyze) {
+        const a0 = Date.now();
+        await poolInstance.query(`ANALYZE ${table}`);
+        analyzeTime += Date.now() - a0;
+      }
+
+      vacuumResults.push({
+        table,
+        status: "success",
+      });
+    } catch (err) {
+      vacuumTime += Date.now() - t0;
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn(
+        { table, error: msg, requestId },
+        "VACUUM failed for table",
+      );
+      vacuumResults.push({
+        table,
+        status: "failed",
+        message: msg,
+      });
+    }
+  }
+
+  return {
+    tables,
+    vacuumingTimeMs: vacuumTime,
+    analyzingTimeMs: analyzeTime,
+    vacuumResults,
+  };
+}

--- a/tests/adminDbVacuum.test.ts
+++ b/tests/adminDbVacuum.test.ts
@@ -1,0 +1,296 @@
+/**
+ * adminDbVacuum.test.ts
+ *
+ * Tests for POST /api/admin/db/vacuum.
+ *
+ * All external I/O is replaced by in-memory stubs — no real DB required.
+ * The route is tested via supertest (integration) and the executeVacuum
+ * helper is tested directly (unit).
+ */
+
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { errorHandler } from "../src/middleware/errorHandler";
+import {
+  createAdminDbVacuumRouter,
+  executeVacuum,
+} from "../src/routes/admin/db/vacuum";
+
+// ── Prevent real DB connections ────────────────────────────────────────────
+
+jest.mock("../src/db/client", () => ({
+  pool: {
+    query: jest.fn().mockResolvedValue({ rows: [] }),
+  },
+}));
+
+// ── JWT helpers ────────────────────────────────────────────────────────────
+
+const SECRET = process.env.JWT_SECRET!;
+const ISSUER = process.env.JWT_ISSUER ?? "predictify";
+const AUDIENCE = process.env.JWT_AUDIENCE ?? "predictify-app";
+const ADMIN_ADDR =
+  "GADMIN0000000000000000000000000000000000000000000000000000";
+const USER_ADDR =
+  "GUSER0000000000000000000000000000000000000000000000000000";
+
+function sign(payload: object): string {
+  return jwt.sign(payload, SECRET, {
+    issuer: ISSUER,
+    audience: AUDIENCE,
+    expiresIn: "1h",
+  });
+}
+
+const adminToken = sign({ sub: ADMIN_ADDR, role: "admin" });
+const userToken = sign({ sub: USER_ADDR, role: "user" });
+
+// ── App factory ────────────────────────────────────────────────────────────
+
+const MOUNT = "/api/admin/db";
+
+function makeApp(rateLimitPerMinute = 30): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use(MOUNT, createAdminDbVacuumRouter({ rateLimitPerMinute }));
+  app.use(errorHandler);
+  return app;
+}
+
+// ── Mock pool factory ──────────────────────────────────────────────────────
+
+function makeMockPool(
+  failTables: string[] = [],
+): { query: jest.Mock } {
+  return {
+    query: jest.fn().mockImplementation(async (sql: string) => {
+      for (const t of failTables) {
+        if (sql.includes(t)) {
+          throw new Error(`VACUUM failed for ${t}`);
+        }
+      }
+      return { rows: [] };
+    }),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service unit tests — executeVacuum
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("executeVacuum — service unit tests", () => {
+  it("vacuums a single table successfully", async () => {
+    const pool = makeMockPool() as never;
+    const result = await executeVacuum(
+      pool,
+      ["fraud_flags"],
+      { analyze: false },
+      "req-1",
+    );
+
+    expect(result.tables).toEqual(["fraud_flags"]);
+    expect(result.vacuumResults).toHaveLength(1);
+    expect(result.vacuumResults[0]).toEqual({
+      table: "fraud_flags",
+      status: "success",
+    });
+    expect(result.vacuumingTimeMs).toBeGreaterThanOrEqual(0);
+    expect(result.analyzingTimeMs).toBe(0);
+  });
+
+  it("vacuums multiple tables with analyze", async () => {
+    const pool = makeMockPool() as never;
+    const result = await executeVacuum(
+      pool,
+      ["fraud_flags", "idempotency_records"],
+      { analyze: true },
+      "req-2",
+    );
+
+    expect(result.tables).toEqual(["fraud_flags", "idempotency_records"]);
+    expect(result.vacuumResults).toHaveLength(2);
+    expect(result.vacuumResults.every((r) => r.status === "success")).toBe(
+      true,
+    );
+    expect(result.analyzingTimeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("reports failed status for tables that error", async () => {
+    const pool = makeMockPool(["fraud_flags"]) as never;
+    const result = await executeVacuum(
+      pool,
+      ["fraud_flags", "idempotency_records"],
+      { analyze: false },
+      "req-3",
+    );
+
+    expect(result.vacuumResults).toHaveLength(2);
+    expect(result.vacuumResults[0].status).toBe("failed");
+    expect(result.vacuumResults[0].message).toContain("VACUUM failed");
+    expect(result.vacuumResults[1].status).toBe("success");
+  });
+
+  it("returns timing values as numbers", async () => {
+    const pool = makeMockPool() as never;
+    const result = await executeVacuum(
+      pool,
+      ["fraud_flags"],
+      { analyze: true },
+      "req-4",
+    );
+
+    expect(typeof result.vacuumingTimeMs).toBe("number");
+    expect(typeof result.analyzingTimeMs).toBe("number");
+  });
+
+  it("handles empty table list gracefully", async () => {
+    const pool = makeMockPool() as never;
+    const result = await executeVacuum(pool, [], { analyze: false }, "req-5");
+
+    expect(result.tables).toEqual([]);
+    expect(result.vacuumResults).toHaveLength(0);
+    expect(result.vacuumingTimeMs).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HTTP integration tests — POST /api/admin/db/vacuum
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("POST /api/admin/db — HTTP", () => {
+  it("returns 403 with no Authorization header", async () => {
+    const res = await request(makeApp()).post(MOUNT).send({});
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("forbidden");
+  });
+
+  it("returns 403 for a non-admin JWT", async () => {
+    const res = await request(makeApp())
+      .post(MOUNT)
+      .set("Authorization", `Bearer ${userToken}`)
+      .send({});
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 for a JWT signed with wrong secret", async () => {
+    const badToken = jwt.sign(
+      { sub: ADMIN_ADDR, role: "admin" },
+      "wrong-secret-at-least-32-characters-long",
+      { issuer: ISSUER, audience: AUDIENCE },
+    );
+    const res = await request(makeApp())
+      .post(MOUNT)
+      .set("Authorization", `Bearer ${badToken}`)
+      .send({});
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 with default tables when body is empty", async () => {
+    const res = await request(makeApp())
+      .post(MOUNT)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toBeDefined();
+    expect(res.body.data.tables).toBeDefined();
+    expect(res.body.data.vacuumResults).toBeDefined();
+    expect(Array.isArray(res.body.data.vacuumResults)).toBe(true);
+  });
+
+  it("returns 200 for valid explicit tables", async () => {
+    const res = await request(makeApp())
+      .post(MOUNT)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({
+        tables: ["fraud_flags", "idempotency_records"],
+        analyze: true,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.tables).toEqual([
+      "fraud_flags",
+      "idempotency_records",
+    ]);
+    expect(res.body.data.vacuumResults).toHaveLength(2);
+    expect(
+      res.body.data.vacuumResults.every(
+        (r: { status: string }) => r.status === "success",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns 400 for invalid table name", async () => {
+    const res = await request(makeApp())
+      .post(MOUNT)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({ tables: ["nonexistent_table"] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+    expect(res.body.error.message).toContain("Invalid table name");
+  });
+
+  it("returns 400 for empty table name", async () => {
+    const res = await request(makeApp())
+      .post(MOUNT)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({ tables: [""] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("returns 400 when more than 10 tables specified", async () => {
+    const manyTables = [
+      "users",
+      "markets",
+      "predictions",
+      "fraud_flags",
+      "claims",
+      "disputes",
+      "webhook_deliveries",
+      "contract_events",
+      "indexer_events",
+      "audit_logs",
+      "feature_flags",
+    ];
+    const res = await request(makeApp())
+      .post(MOUNT)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({ tables: manyTables });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+    expect(res.body.error.message).toContain("10");
+  });
+
+  it("returns 400 for unknown body fields (strict mode)", async () => {
+    const res = await request(makeApp())
+      .post(MOUNT)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({ tables: ["users"], extraField: true });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("returns 429 when rate limit is breached", async () => {
+    const app = makeApp(1);
+    const agent = request.agent(app);
+
+    await agent
+      .post(MOUNT)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({ tables: ["users"] });
+
+    const res = await agent
+      .post(MOUNT)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({ tables: ["users"] });
+
+    expect(res.status).toBe(429);
+    expect(res.body.error.code).toBe("rate_limit_exceeded");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `POST /api/admin/db/vacuum` — triggers PostgreSQL VACUUM on selected tables to reclaim storage and improve query performance.

## Changes

- **New:** `src/routes/admin/db/vacuum.ts` — endpoint implementation
- **New:** `tests/adminDbVacuum.test.ts` — 15 tests (5 unit + 10 HTTP integration)
- **Modified:** `src/index.ts` — import + mount at `/api/admin/db`
- **Modified:** `src/config/env.ts` — added missing `JWT_KEYS` / `JWT_ACTIVE_KID` optional fields (pre-existing bug fix to unblock tests)

## Endpoint

```
POST /api/admin/db/vacuum
```

| Aspect | Detail |
|---|---|
| Auth | Admin JWT required (`requireAdmin`) |
| Rate limit | 30 req/min per admin token |
| Input | `{ tables?: string[], analyze?: boolean }` (strict Zod) |
| Table validation | Strict allowlist of all 20 schema tables — no SQL injection |
| Default tables | `idempotency_records`, `webhook_deliveries`, `webhook_deliveries_dlq`, `contract_events`, `indexer_events`, `audit_logs` |
| Error handling | Per-table isolation — one failure doesn't abort others |
| Logging | Structured `pino` with `requestId` correlation |

## Tests

All 15 tests passing, 0 lint errors.

Closes #323