### PR TITLE
Feature/signup anomaly

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -35,6 +35,9 @@ Collected by `prom-client`'s `collectDefaultMetrics`:
 | `indexer_polls_total` | Counter | — | Total indexer poll cycles completed |
 | `webhook_deliveries_total` | Counter | `status` | Webhook deliveries by outcome |
 | `auth_verifications_total` | Counter | `outcome` | Auth verification attempts by result |
+| `signup_anomaly_scans_total` | Counter | — | Signup-rate anomaly scans completed ([signup-anomaly.md](signup-anomaly.md)) |
+| `signup_anomalies_detected_total` | Counter | `severity` | Anomalous signup buckets detected (`warning`, `critical`) |
+| `signup_anomaly_top_score` | Gauge | — | Highest modified z-score from the most recent signup scan |
 
 ## Content type
 

--- a/docs/signup-anomaly.md
+++ b/docs/signup-anomaly.md
@@ -1,0 +1,196 @@
+# Signup-Rate Anomaly Detector
+
+Detects **signup floods** — bot registration waves, airdrop farming, sybil
+onboarding — by comparing the recent signup rate against a robust baseline
+learned from the preceding 24 hours.
+
+The detector is **read-only**: it aggregates `users.created_at`, scores it, and
+reports. Nothing is written, no migration is required, and re-running is free.
+
+## Architecture
+
+```
+┌───────────────┐   ┌──────────────────┐   ┌──────────────────┐   ┌────────────────┐
+│ users.created │──▶│ densifyBuckets   │──▶│ computeBaseline  │──▶│ detectAnomalies│
+│ _at (SQL agg) │   │ (zero-filled)    │   │ (median + MAD)   │   │ (pure)         │
+└───────────────┘   └──────────────────┘   └──────────────────┘   └───────┬────────┘
+                                                                          │
+                                              ┌───────────────────────────┴───────┐
+                                              ▼                                   ▼
+                                     structured warn log                  Prometheus metrics
+                                  ("signup flood detected")           (signup_anomalies_…)
+```
+
+* **Service** — [`src/services/anomalyDetector.ts`](../src/services/anomalyDetector.ts)
+* **Worker** — [`src/workers/signupAnomalyDetector.ts`](../src/workers/signupAnomalyDetector.ts)
+* **Tests** — `tests/anomalyDetector.test.ts`, `tests/signupAnomalyDetector.worker.test.ts`
+
+## How a bucket is scored
+
+1. **Bucket.** Signups are aggregated into fixed-width buckets (default 5 min),
+   aligned to epoch multiples so boundaries are stable across runs. Gaps are
+   zero-filled — a quiet night must count as a low sample, not a missing one.
+2. **Baseline.** The buckets *before* the evaluation window feed a robust
+   summary: **median** and **median absolute deviation (MAD)**.
+3. **Score.** Each evaluation bucket gets a modified z-score
+   (Iglewicz & Hoaglin): `0.6745 · (count − median) / spread`.
+4. **Flag.** A bucket is anomalous when it clears the absolute floor **and** at
+   least one relative rule fires.
+
+### Why median/MAD rather than mean/stddev
+
+A mean-and-stddev baseline is destroyed by the very thing being detected: one
+large flood inflates both, so the *next* flood scores as normal. Median and MAD
+have a 50 % breakdown point — a burst must consume half the baseline window
+before it can hide itself. `tests/anomalyDetector.test.ts` pins this behaviour
+("does not let an earlier flood poison the baseline for a later one").
+
+### The Poisson noise floor
+
+Signups are arrivals, so bucket counts are roughly Poisson: a stream averaging
+λ per bucket varies by σ ≈ √λ from chance alone. An unusually flat baseline
+(a run of exactly 12s) yields MAD = 0, which would make a bucket of 13 score as
+maximally surprising. The observed spread is therefore floored at
+`0.6745 · √median`. Spread only reaches zero when the baseline is *entirely
+empty*, where any arrival genuinely is surprising — and `minCount` is what stops
+that from paging anyone.
+
+### Triggers
+
+| Trigger | Fires when |
+| --- | --- |
+| `MODIFIED_Z_SCORE` | score ≥ `zThreshold` |
+| `RATIO_TO_BASELINE` | `count / max(median, 1)` ≥ `ratioThreshold` |
+| `COLD_START_BURST` | fewer than `minBaselineBuckets` of history; the absolute floor alone fired |
+
+Severity is `critical` at twice either relative threshold, otherwise `warning`.
+
+## Configuration
+
+All knobs are optional and bounded by `signupAnomalyOptionsSchema`; out-of-range
+values are rejected before any query runs.
+
+| Option | Default | Bounds | Meaning |
+| --- | --- | --- | --- |
+| `bucketMs` | `300000` (5 min) | 1 min – 1 h | Bucket width |
+| `baselineWindowMs` | `86400000` (24 h) | ≥ `bucketMs`, ≤ 7 d | History used to learn "normal" |
+| `evaluationWindowMs` | `1800000` (30 min) | ≥ `bucketMs`, ≤ 24 h | Recent slice that gets scored |
+| `zThreshold` | `3.5` | 1 – 100 | Modified z-score cutoff |
+| `ratioThreshold` | `4` | 1 – 1000 | Multiple-of-median cutoff |
+| `minCount` | `10` | 1 – 1 000 000 | Absolute floor; below this nothing alerts |
+| `minBaselineBuckets` | `6` | 1 – 1000 | History required before relative rules are trusted |
+
+A scan may never exceed **5000 buckets** (`MAX_BUCKETS_PER_SCAN`); combinations
+that would are rejected with a validation error naming the limit.
+
+## Usage
+
+```ts
+import {
+  DrizzleSignupAnomalyRepo,
+  runSignupAnomalyScan,
+} from "./services/anomalyDetector";
+
+const report = await runSignupAnomalyScan(new DrizzleSignupAnomalyRepo(), {
+  bucketMs: 60_000,
+  zThreshold: 3,
+});
+```
+
+Or run the worker periodically:
+
+```ts
+import { signupAnomalyDetectorWorker } from "./workers/signupAnomalyDetector";
+
+const stop = signupAnomalyDetectorWorker.start(5 * 60 * 1000);
+```
+
+`runOnce()` never throws — it logs and returns `null` — so it is safe to wire
+into a scheduler. One-off run from the CLI:
+
+```bash
+node dist/workers/signupAnomalyDetector.js
+```
+
+### Report shape
+
+```jsonc
+{
+  "window": {
+    "since": "2026-07-23T11:35:00.000Z",
+    "until": "2026-07-24T12:05:00.000Z",
+    "evaluationSince": "2026-07-24T11:35:00.000Z",
+    "bucketMs": 300000
+  },
+  "baseline": { "median": 12, "mad": 2, "meanAbsDev": 2.1, "sampleSize": 288 },
+  "evaluated": 6,
+  "totalSignups": 2148,
+  "peak": { "bucketStart": "2026-07-24T11:50:00.000Z", "count": 1200 },
+  "anomalies": [
+    {
+      "bucketStart": "2026-07-24T11:50:00.000Z",
+      "bucketEnd": "2026-07-24T11:55:00.000Z",
+      "count": 1200,
+      "expected": 12,
+      "ratio": 100,
+      "score": 342.95,
+      "severity": "critical",
+      "triggers": ["MODIFIED_Z_SCORE", "RATIO_TO_BASELINE"]
+    }
+  ],
+  "topScore": 342.95,
+  "correlationId": "1c9f…"
+}
+```
+
+Scores are capped at `1000` so the report stays JSON-safe (`Infinity`
+serialises to `null`) and dashboards get a bounded axis.
+
+## Observability
+
+Structured logs (see [log-events.md](log-events.md) for conventions) — every
+line carries the `correlationId`, taken from the caller, else the active request
+context, else `null`:
+
+| Message | Level | Emitted |
+| --- | --- | --- |
+| `signup_anomaly_scan: start` | info | Every scan, with the resolved window |
+| `signup_anomaly_scan: complete` | info | Scan found nothing |
+| `signup_anomaly_scan: signup flood detected` | **warn** | One or more anomalies — alert on this |
+| `signup_anomaly_detector: run failed` | error | Worker swallowed an error |
+
+Prometheus metrics (see [metrics.md](metrics.md)):
+
+| Metric | Type | Labels |
+| --- | --- | --- |
+| `signup_anomaly_scans_total` | counter | — |
+| `signup_anomalies_detected_total` | counter | `severity` |
+| `signup_anomaly_top_score` | gauge | — |
+
+Suggested alert: `increase(signup_anomalies_detected_total{severity="critical"}[10m]) > 0`.
+
+## Security notes
+
+* **No PII.** Only counts and timestamps are read; no addresses or user ids
+  enter the report or the logs.
+* **Parameterised SQL.** The bucket width and window bounds are bound as query
+  parameters, never interpolated — asserted in
+  `tests/anomalyDetector.test.ts` ("binds the bucket width and window instead of
+  interpolating them").
+* **Bounded work.** Aggregation happens in Postgres (`GROUP BY` on a bucketed
+  epoch), so a 24 h window is 288 rows regardless of signup volume, and the
+  bucket ceiling caps the worst case.
+* **Not an enforcement point.** The detector observes; it does not block
+  signups. Pair it with rate limiting ([rate-limiting.md](rate-limiting.md)) for
+  mitigation.
+
+## Tuning
+
+* **Noisy alerts on a small deployment** — raise `minCount`. Most false
+  positives come from a low-traffic baseline where a handful of organic signups
+  look like a multiple of the median.
+* **Slow, sustained ramps slipping through** — widen `bucketMs` (a 1 h bucket
+  catches a ramp that a 5 min bucket absorbs) or lower `ratioThreshold`.
+* **A recurring daily peak flagged every day** — the 24 h baseline includes the
+  previous day's peak, so this usually self-corrects; if not, widen
+  `baselineWindowMs`.

--- a/src/metrics/registry.ts
+++ b/src/metrics/registry.ts
@@ -49,3 +49,22 @@ export const settleConfirmerFailedTotal = new Counter({
   help: "Total number of claims permanently marked as failed by the settle-confirmer",
   registers: [register],
 });
+
+export const signupAnomalyScansTotal = new Counter({
+  name: "signup_anomaly_scans_total",
+  help: "Total number of signup-rate anomaly scans completed",
+  registers: [register],
+});
+
+export const signupAnomaliesDetectedTotal = new Counter({
+  name: "signup_anomalies_detected_total",
+  help: "Total number of anomalous signup buckets detected, segmented by severity (warning, critical)",
+  labelNames: ["severity"] as const,
+  registers: [register],
+});
+
+export const signupAnomalyTopScore = new Gauge({
+  name: "signup_anomaly_top_score",
+  help: "Highest modified z-score observed in the most recent signup-rate anomaly scan",
+  registers: [register],
+});

--- a/src/services/anomalyDetector.ts
+++ b/src/services/anomalyDetector.ts
@@ -1,0 +1,668 @@
+/**
+ * anomalyDetector.ts — signup-rate anomaly detector ("signup flood" alarm).
+ *
+ * Responsibilities
+ * ────────────────
+ *   1. Aggregate `users.created_at` into fixed-width time buckets.
+ *   2. Learn a **robust** baseline (median + median-absolute-deviation) from
+ *      the historical part of the window.
+ *   3. Score every bucket in the recent evaluation window against that
+ *      baseline and surface the ones that look like a flood.
+ *
+ * Why robust statistics?
+ * ──────────────────────
+ *   A mean/standard-deviation baseline is destroyed by the very thing we are
+ *   trying to detect: a single large flood inflates the mean *and* the stddev,
+ *   so the next flood scores as "normal". Median and MAD have a 50 % breakdown
+ *   point, so a burst has to consume half the baseline before it hides itself.
+ *   The modified z-score (Iglewicz & Hoaglin) is `0.6745 · (x − median) / MAD`.
+ *
+ * A single statistic is not enough on its own, so a bucket must clear an
+ * **absolute floor** (`minCount`) before any relative rule can fire. That is
+ * what stops "1 signup vs. a baseline of 0" from paging someone at 3 a.m.
+ *
+ * Boundaries
+ * ──────────
+ *   • The scoring core (`densifyBuckets`, `computeBaseline`, `modifiedZScore`,
+ *     `detectAnomalies`) is **pure** — no DB, no clock, no logging — and is
+ *     fully unit-tested.
+ *   • All DB access funnels through the `SignupAnomalyRepo` interface, so the
+ *     worker / route / tests can inject in-memory fakes.
+ *   • Every caller-supplied option is validated by Zod
+ *     (`signupAnomalyOptionsSchema`) inside `runSignupAnomalyScan`, with tight
+ *     bounds, so no caller — including a future HTTP route that forwards query
+ *     parameters — can turn this into an unbounded scan. Routes should re-use
+ *     the exported schema to return the standard error envelope on 400.
+ *
+ * Logging
+ * ───────
+ *   Every scan emits structured logs carrying the active `correlationId`
+ *   (explicit → AsyncLocalStorage → null) so a run can be traced across the
+ *   worker → service → repo boundary.
+ */
+
+import { sql } from "drizzle-orm";
+import { z } from "zod";
+import { db as defaultDb } from "../db";
+import { logger } from "../config/logger";
+import { getRequestId } from "../lib/requestContext";
+import {
+  signupAnomaliesDetectedTotal,
+  signupAnomalyScansTotal,
+  signupAnomalyTopScore,
+} from "../metrics/registry";
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Constants
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** Width of a single rate bucket. */
+export const DEFAULT_BUCKET_MS = 5 * 60 * 1000; // 5 minutes
+
+/** How far back the *baseline* is learned from (ends where evaluation begins). */
+export const DEFAULT_BASELINE_WINDOW_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+/** The recent slice of time whose buckets get scored. */
+export const DEFAULT_EVALUATION_WINDOW_MS = 30 * 60 * 1000; // 30 minutes
+
+/** Modified z-score above which a bucket is considered anomalous. */
+export const DEFAULT_Z_THRESHOLD = 3.5;
+
+/** `count / baselineMedian` above which a bucket is considered anomalous. */
+export const DEFAULT_RATIO_THRESHOLD = 4;
+
+/** Absolute floor — quiet systems must not alert on single-digit noise. */
+export const DEFAULT_MIN_COUNT = 10;
+
+/** Baseline buckets required before relative rules are trusted. */
+export const DEFAULT_MIN_BASELINE_BUCKETS = 6;
+
+/** Consistency constant for the modified z-score (Iglewicz & Hoaglin). */
+const MAD_SCALE = 0.6745;
+
+/** Scale factor used when MAD collapses to 0 and we fall back to mean-abs-dev. */
+const MEAN_AD_SCALE = 1.253314;
+
+/**
+ * Scores are capped so the report stays JSON-safe (`Infinity` serialises to
+ * `null`) and so dashboards get a bounded axis.
+ */
+export const MAX_SCORE = 1000;
+
+/** Hard ceiling on buckets per scan — bounds memory and query cost. */
+export const MAX_BUCKETS_PER_SCAN = 5000;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** One fixed-width slice of the signup timeline. */
+export interface SignupBucket {
+  /** Inclusive start of the bucket, aligned to a multiple of `bucketMs`. */
+  start: Date;
+  /** Signups whose `created_at` falls in `[start, start + bucketMs)`. */
+  count: number;
+}
+
+/** Which rule (or rules) fired for a bucket. */
+export type AnomalyTrigger =
+  /** Modified z-score cleared `zThreshold`. */
+  | "MODIFIED_Z_SCORE"
+  /** Count is a large multiple of the baseline median. */
+  | "RATIO_TO_BASELINE"
+  /** Not enough baseline history yet — absolute floor alone fired. */
+  | "COLD_START_BURST";
+
+export type AnomalySeverity = "warning" | "critical";
+
+export interface SignupAnomaly {
+  /** ISO-8601 start of the offending bucket. */
+  bucketStart: string;
+  /** ISO-8601 exclusive end of the offending bucket. */
+  bucketEnd: string;
+  /** Signups observed in the bucket. */
+  count: number;
+  /** Baseline median — what we expected to see. */
+  expected: number;
+  /** `count / max(expected, 1)`, rounded to 2 dp. */
+  ratio: number;
+  /** Modified z-score, capped at `MAX_SCORE` and rounded to 2 dp. */
+  score: number;
+  severity: AnomalySeverity;
+  /** Every rule that fired, in a stable order. */
+  triggers: AnomalyTrigger[];
+}
+
+/** Robust dispersion summary of the baseline buckets. */
+export interface Baseline {
+  /** Median signups per bucket. */
+  median: number;
+  /** Median absolute deviation from the median. */
+  mad: number;
+  /** Mean absolute deviation — fallback when MAD collapses to 0. */
+  meanAbsDev: number;
+  /** Number of baseline buckets that fed the statistics. */
+  sampleSize: number;
+}
+
+export interface SignupAnomalyReport {
+  window: {
+    /** Start of the whole scan window (baseline + evaluation). */
+    since: string;
+    /** Exclusive end of the scan window. */
+    until: string;
+    /** Start of the evaluation slice. */
+    evaluationSince: string;
+    bucketMs: number;
+  };
+  baseline: Baseline;
+  /** Buckets scored in the evaluation window. */
+  evaluated: number;
+  /** Signups observed across the evaluation window. */
+  totalSignups: number;
+  /** Busiest evaluation bucket, or `null` when the window is empty. */
+  peak: { bucketStart: string; count: number } | null;
+  /** Anomalous buckets, most severe first. */
+  anomalies: SignupAnomaly[];
+  /** Highest score seen in the evaluation window (0 when nothing scored). */
+  topScore: number;
+  correlationId: string | null;
+}
+
+/** Data access contract — implemented by Drizzle in prod, fakes in tests. */
+export interface SignupAnomalyRepo {
+  /**
+   * Return signup counts per bucket for `[since, until)`.
+   *
+   * Implementations may return a **sparse** series (empty buckets omitted);
+   * `runSignupAnomalyScan` densifies before scoring.
+   */
+  loadSignupBuckets(opts: {
+    since: Date;
+    until: Date;
+    bucketMs: number;
+  }): Promise<SignupBucket[]>;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Options + validation (the boundary)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Tunables for a scan. Every field is optional; bounds are deliberately tight
+ * so an untrusted caller cannot turn this into a full-table scan.
+ */
+export const signupAnomalyOptionsSchema = z
+  .object({
+    bucketMs: z
+      .number()
+      .int()
+      .min(60_000, { message: "bucketMs must be at least 60000 (1 minute)" })
+      .max(3_600_000, { message: "bucketMs must be at most 3600000 (1 hour)" }),
+    baselineWindowMs: z
+      .number()
+      .int()
+      .min(60_000)
+      .max(7 * 24 * 60 * 60 * 1000, {
+        message: "baselineWindowMs must be at most 7 days",
+      }),
+    evaluationWindowMs: z
+      .number()
+      .int()
+      .min(60_000)
+      .max(24 * 60 * 60 * 1000, {
+        message: "evaluationWindowMs must be at most 24 hours",
+      }),
+    zThreshold: z.number().min(1).max(100),
+    ratioThreshold: z.number().min(1).max(1000),
+    minCount: z.number().int().min(1).max(1_000_000),
+    minBaselineBuckets: z.number().int().min(1).max(1000),
+  })
+  .partial()
+  .strict()
+  .superRefine((opts, ctx) => {
+    const bucketMs = opts.bucketMs ?? DEFAULT_BUCKET_MS;
+    const baselineWindowMs = opts.baselineWindowMs ?? DEFAULT_BASELINE_WINDOW_MS;
+    const evaluationWindowMs =
+      opts.evaluationWindowMs ?? DEFAULT_EVALUATION_WINDOW_MS;
+
+    if (evaluationWindowMs < bucketMs) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["evaluationWindowMs"],
+        message: "evaluationWindowMs must be greater than or equal to bucketMs",
+      });
+    }
+    if (baselineWindowMs < bucketMs) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["baselineWindowMs"],
+        message: "baselineWindowMs must be greater than or equal to bucketMs",
+      });
+    }
+    if ((baselineWindowMs + evaluationWindowMs) / bucketMs > MAX_BUCKETS_PER_SCAN) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["bucketMs"],
+        message:
+          `window is too granular: at most ${MAX_BUCKETS_PER_SCAN} buckets ` +
+          `per scan (increase bucketMs or shrink the windows)`,
+      });
+    }
+  });
+
+/** Caller-supplied tunables, as validated by {@link signupAnomalyOptionsSchema}. */
+export type SignupAnomalyOptions = z.infer<typeof signupAnomalyOptionsSchema>;
+
+/** Fully-resolved detector configuration (defaults applied). */
+export interface DetectorConfig {
+  bucketMs: number;
+  baselineWindowMs: number;
+  evaluationWindowMs: number;
+  zThreshold: number;
+  ratioThreshold: number;
+  minCount: number;
+  minBaselineBuckets: number;
+}
+
+/** Apply defaults to a (already validated) options bag. */
+export function resolveConfig(opts: SignupAnomalyOptions = {}): DetectorConfig {
+  return {
+    bucketMs: opts.bucketMs ?? DEFAULT_BUCKET_MS,
+    baselineWindowMs: opts.baselineWindowMs ?? DEFAULT_BASELINE_WINDOW_MS,
+    evaluationWindowMs: opts.evaluationWindowMs ?? DEFAULT_EVALUATION_WINDOW_MS,
+    zThreshold: opts.zThreshold ?? DEFAULT_Z_THRESHOLD,
+    ratioThreshold: opts.ratioThreshold ?? DEFAULT_RATIO_THRESHOLD,
+    minCount: opts.minCount ?? DEFAULT_MIN_COUNT,
+    minBaselineBuckets: opts.minBaselineBuckets ?? DEFAULT_MIN_BASELINE_BUCKETS,
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Pure: statistics
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** Median of a numeric list. Returns 0 for an empty list. Does not mutate. */
+export function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = sorted.length >> 1;
+  return sorted.length % 2 === 1
+    ? sorted[mid]
+    : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/**
+ * Robust baseline statistics for a series of bucket counts.
+ *
+ * Both MAD and mean-absolute-deviation are computed because MAD collapses to
+ * zero on very flat series (e.g. a run of identical counts), which would make
+ * every z-score infinite.
+ */
+export function computeBaseline(counts: number[]): Baseline {
+  if (counts.length === 0) {
+    return { median: 0, mad: 0, meanAbsDev: 0, sampleSize: 0 };
+  }
+  const med = median(counts);
+  const deviations = counts.map((c) => Math.abs(c - med));
+  const meanAbsDev =
+    deviations.reduce((sum, d) => sum + d, 0) / deviations.length;
+  return {
+    median: med,
+    mad: median(deviations),
+    meanAbsDev,
+    sampleSize: counts.length,
+  };
+}
+
+/**
+ * Smallest spread we are willing to believe, in MAD units.
+ *
+ * Signups are arrivals, so bucket counts are approximately Poisson: a stream
+ * averaging λ per bucket has σ ≈ √λ purely from chance. Without this floor an
+ * unusually flat baseline (say a run of exactly 12s) reports MAD = 0, and a
+ * bucket of 13 would score as maximally surprising. Floor the observed spread
+ * at the noise a Poisson process would produce anyway.
+ */
+function poissonSpreadFloor(medianCount: number): number {
+  return MAD_SCALE * Math.sqrt(Math.max(medianCount, 0));
+}
+
+/**
+ * Modified z-score of `value` against `baseline`, capped at {@link MAX_SCORE}.
+ *
+ * Only *upward* deviations matter for a flood detector, so values at or below
+ * the median score 0 rather than going negative.
+ */
+export function modifiedZScore(value: number, baseline: Baseline): number {
+  if (baseline.sampleSize === 0) return 0;
+  const delta = value - baseline.median;
+  if (delta <= 0) return 0;
+
+  // Preferred: MAD. Fallback: mean absolute deviation (rescaled to be
+  // comparable to MAD). Either way, never below the Poisson noise floor.
+  const observed =
+    baseline.mad > 0
+      ? baseline.mad
+      : baseline.meanAbsDev > 0
+        ? baseline.meanAbsDev * MEAN_AD_SCALE
+        : 0;
+  const spread = Math.max(observed, poissonSpreadFloor(baseline.median));
+
+  // Spread is only 0 when the baseline is entirely empty — on a system with
+  // no signups at all, *any* arrival is maximally surprising. `minCount` is
+  // what stops that from paging anyone.
+  if (spread === 0) return MAX_SCORE;
+
+  return Math.min((MAD_SCALE * delta) / spread, MAX_SCORE);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Pure: bucketing
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** Floor a timestamp to the start of its bucket. */
+export function bucketStartFor(timestampMs: number, bucketMs: number): number {
+  return Math.floor(timestampMs / bucketMs) * bucketMs;
+}
+
+/**
+ * Turn a possibly-sparse, possibly-unordered bucket list into a dense,
+ * ascending series covering `[since, until)` with zero-filled gaps.
+ *
+ * Zero-filling matters: without it a flood that silences organic traffic (or a
+ * quiet night) would shrink the baseline sample and skew the median upward.
+ * Buckets outside the window are dropped; duplicates are summed.
+ */
+export function densifyBuckets(
+  buckets: SignupBucket[],
+  opts: { since: Date; until: Date; bucketMs: number },
+): SignupBucket[] {
+  const { bucketMs } = opts;
+  const firstStart = bucketStartFor(opts.since.getTime(), bucketMs);
+  const untilMs = opts.until.getTime();
+
+  const counts = new Map<number, number>();
+  for (const b of buckets) {
+    const startMs = bucketStartFor(b.start.getTime(), bucketMs);
+    if (startMs < firstStart || startMs >= untilMs) continue;
+    if (!Number.isFinite(b.count) || b.count <= 0) continue;
+    counts.set(startMs, (counts.get(startMs) ?? 0) + b.count);
+  }
+
+  const series: SignupBucket[] = [];
+  for (let t = firstStart; t < untilMs; t += bucketMs) {
+    series.push({ start: new Date(t), count: counts.get(t) ?? 0 });
+  }
+  return series;
+}
+
+/**
+ * Convenience for callers holding raw signup timestamps rather than
+ * pre-aggregated counts (fixtures, backfills, small datasets).
+ */
+export function bucketizeSignups(
+  timestamps: Date[],
+  opts: { since: Date; until: Date; bucketMs: number },
+): SignupBucket[] {
+  return densifyBuckets(
+    timestamps.map((t) => ({ start: t, count: 1 })),
+    opts,
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Pure: detection
+// ──────────────────────────────────────────────────────────────────────────────
+
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+/**
+ * Score `evaluation` buckets against a baseline learned from `baselineSeries`.
+ *
+ * A bucket is anomalous when it clears the absolute floor **and** at least one
+ * relative rule fires. Severity escalates to `critical` at twice either
+ * relative threshold.
+ */
+export function detectAnomalies(
+  baselineSeries: SignupBucket[],
+  evaluation: SignupBucket[],
+  config: DetectorConfig,
+): { baseline: Baseline; anomalies: SignupAnomaly[]; topScore: number } {
+  const baseline = computeBaseline(baselineSeries.map((b) => b.count));
+  const hasBaseline = baseline.sampleSize >= config.minBaselineBuckets;
+
+  const anomalies: SignupAnomaly[] = [];
+  let topScore = 0;
+
+  for (const bucket of evaluation) {
+    const score = hasBaseline ? modifiedZScore(bucket.count, baseline) : 0;
+    if (score > topScore) topScore = score;
+
+    // Absolute floor first — cheapest check, and it gates everything else.
+    if (bucket.count < config.minCount) continue;
+
+    const expected = hasBaseline ? baseline.median : 0;
+    const ratio = bucket.count / Math.max(expected, 1);
+
+    const triggers: AnomalyTrigger[] = [];
+    if (!hasBaseline) {
+      // Not enough history to say what "normal" is; the floor alone fired.
+      triggers.push("COLD_START_BURST");
+    } else {
+      if (score >= config.zThreshold) triggers.push("MODIFIED_Z_SCORE");
+      if (ratio >= config.ratioThreshold) triggers.push("RATIO_TO_BASELINE");
+    }
+    if (triggers.length === 0) continue;
+
+    const severity: AnomalySeverity =
+      score >= config.zThreshold * 2 || ratio >= config.ratioThreshold * 2
+        ? "critical"
+        : "warning";
+
+    anomalies.push({
+      bucketStart: bucket.start.toISOString(),
+      bucketEnd: new Date(bucket.start.getTime() + config.bucketMs).toISOString(),
+      count: bucket.count,
+      expected,
+      ratio: round2(ratio),
+      score: round2(score),
+      severity,
+      triggers,
+    });
+  }
+
+  // Most severe first, then most recent — the shape an on-call reader wants.
+  anomalies.sort(
+    (a, b) => b.score - a.score || b.bucketStart.localeCompare(a.bucketStart),
+  );
+
+  return { baseline, anomalies, topScore: round2(topScore) };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Orchestration — load + detect + report
+// ──────────────────────────────────────────────────────────────────────────────
+
+export interface RunSignupAnomalyScanOptions extends SignupAnomalyOptions {
+  /** Override "now" — used by tests. */
+  now?: () => Date;
+  correlationId?: string | null;
+}
+
+/**
+ * End-to-end scan: validate → load → densify → split → score → report.
+ *
+ * Read-only: nothing is persisted, so re-running is free and idempotent.
+ * Findings are surfaced via the return value, structured logs, and Prometheus
+ * metrics.
+ *
+ * @throws {ZodError} when `opts` violates {@link signupAnomalyOptionsSchema}.
+ */
+export async function runSignupAnomalyScan(
+  repo: SignupAnomalyRepo,
+  opts: RunSignupAnomalyScanOptions = {},
+): Promise<SignupAnomalyReport> {
+  const { now: nowFn, correlationId: explicitCorrelationId, ...tunables } = opts;
+
+  // Validate again at the service boundary — a direct caller (worker, script)
+  // never reaches the route's Zod check.
+  const config = resolveConfig(signupAnomalyOptionsSchema.parse(tunables));
+
+  const now = (nowFn ?? (() => new Date()))();
+  const correlationId = explicitCorrelationId ?? getRequestId() ?? null;
+
+  // Align the window to bucket boundaries so buckets are stable across runs.
+  const untilMs =
+    bucketStartFor(now.getTime(), config.bucketMs) + config.bucketMs;
+  const evaluationSinceMs = untilMs - config.evaluationWindowMs;
+  const sinceMs = evaluationSinceMs - config.baselineWindowMs;
+
+  const since = new Date(sinceMs);
+  const until = new Date(untilMs);
+  const evaluationSince = new Date(evaluationSinceMs);
+
+  logger.info(
+    {
+      correlationId,
+      since: since.toISOString(),
+      until: until.toISOString(),
+      bucketMs: config.bucketMs,
+    },
+    "signup_anomaly_scan: start",
+  );
+
+  const raw = await repo.loadSignupBuckets({
+    since,
+    until,
+    bucketMs: config.bucketMs,
+  });
+  const series = densifyBuckets(raw, { since, until, bucketMs: config.bucketMs });
+
+  const splitIndex = series.findIndex(
+    (b) => b.start.getTime() >= evaluationSinceMs,
+  );
+  const baselineSeries = splitIndex === -1 ? series : series.slice(0, splitIndex);
+  const evaluation = splitIndex === -1 ? [] : series.slice(splitIndex);
+
+  const { baseline, anomalies, topScore } = detectAnomalies(
+    baselineSeries,
+    evaluation,
+    config,
+  );
+
+  const totalSignups = evaluation.reduce((sum, b) => sum + b.count, 0);
+  const peakBucket = evaluation.reduce<SignupBucket | null>(
+    (best, b) => (best === null || b.count > best.count ? b : best),
+    null,
+  );
+
+  const report: SignupAnomalyReport = {
+    window: {
+      since: since.toISOString(),
+      until: until.toISOString(),
+      evaluationSince: evaluationSince.toISOString(),
+      bucketMs: config.bucketMs,
+    },
+    baseline,
+    evaluated: evaluation.length,
+    totalSignups,
+    peak:
+      peakBucket === null
+        ? null
+        : { bucketStart: peakBucket.start.toISOString(), count: peakBucket.count },
+    anomalies,
+    topScore,
+    correlationId,
+  };
+
+  signupAnomalyScansTotal.inc();
+  signupAnomalyTopScore.set(topScore);
+  for (const a of anomalies) {
+    signupAnomaliesDetectedTotal.inc({ severity: a.severity });
+  }
+
+  if (anomalies.length > 0) {
+    logger.warn(
+      {
+        correlationId,
+        anomalies: anomalies.length,
+        topScore,
+        totalSignups,
+        peak: report.peak,
+        baselineMedian: baseline.median,
+        severities: anomalies.map((a) => a.severity),
+      },
+      "signup_anomaly_scan: signup flood detected",
+    );
+  } else {
+    logger.info(
+      { correlationId, evaluated: evaluation.length, totalSignups, topScore },
+      "signup_anomaly_scan: complete",
+    );
+  }
+
+  return report;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Drizzle-backed repository (production wiring)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** Row shape returned by the bucketing query. */
+interface BucketRow extends Record<string, unknown> {
+  bucket_start: string | Date;
+  signups: string | number;
+}
+
+export class DrizzleSignupAnomalyRepo implements SignupAnomalyRepo {
+  // `any` mirrors the other services here (see DrizzleFraudRepo) — the shared
+  // drizzle helper is not generically typed in this codebase.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(private readonly db: any = defaultDb) {}
+
+  /**
+   * Aggregate in the database rather than streaming rows into Node: a 24 h
+   * window at 5-minute buckets is 288 rows regardless of signup volume.
+   *
+   * `bucketMs` is bound as a parameter (never interpolated), and the epoch
+   * arithmetic keeps bucket boundaries identical to `bucketStartFor` so the
+   * pure and SQL paths agree.
+   */
+  async loadSignupBuckets(opts: {
+    since: Date;
+    until: Date;
+    bucketMs: number;
+  }): Promise<SignupBucket[]> {
+    const bucketSeconds = opts.bucketMs / 1000;
+    const result = (await this.db.execute(
+      sql`
+        SELECT
+          to_timestamp(
+            floor(extract(epoch FROM created_at) / ${bucketSeconds})
+              * ${bucketSeconds}
+          ) AS bucket_start,
+          count(*)::int AS signups
+        FROM users
+        WHERE created_at >= ${opts.since} AND created_at < ${opts.until}
+        GROUP BY 1
+        ORDER BY 1 ASC
+      `,
+    )) as { rows?: BucketRow[] } | undefined;
+    const rows: BucketRow[] = result?.rows ?? [];
+    return rows.map((r) => ({
+      start: r.bucket_start instanceof Date
+        ? r.bucket_start
+        : new Date(r.bucket_start),
+      count: Number(r.signups),
+    }));
+  }
+}
+
+/** Convenience for routes/workers that do not care about repo wiring. */
+export async function scanSignupAnomalies(
+  opts: RunSignupAnomalyScanOptions = {},
+  repo: SignupAnomalyRepo = new DrizzleSignupAnomalyRepo(),
+): Promise<SignupAnomalyReport> {
+  return runSignupAnomalyScan(repo, opts);
+}

--- a/src/workers/signupAnomalyDetector.ts
+++ b/src/workers/signupAnomalyDetector.ts
@@ -1,0 +1,122 @@
+/**
+ * signupAnomalyDetector.ts — background worker that periodically scans the
+ * signup rate for floods (bot registration waves, airdrop farming, sybil
+ * onboarding).
+ *
+ * Designed to be invoked from:
+ *   • a cron-style scheduler (every N minutes)
+ *   • the existing in-process scheduler (`src/services/scheduler.ts`)
+ *   • or one-off CLI runs (`node dist/workers/signupAnomalyDetector.js`)
+ *
+ * The worker is intentionally tiny — all logic lives in
+ * `src/services/anomalyDetector.ts` so it can be unit-tested without a job
+ * runtime. A correlation id is generated per run so every log line emitted by
+ * the scan can be tied back to it.
+ */
+
+import { randomUUID } from "crypto";
+import { logger } from "../config/logger";
+import {
+  DrizzleSignupAnomalyRepo,
+  type RunSignupAnomalyScanOptions,
+  type SignupAnomalyRepo,
+  type SignupAnomalyReport,
+  runSignupAnomalyScan,
+} from "../services/anomalyDetector";
+
+/** Default cadence — matches the default 30-minute evaluation window. */
+export const DEFAULT_SCAN_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+export class SignupAnomalyDetectorWorker {
+  private readonly repo: SignupAnomalyRepo;
+  private timer: NodeJS.Timeout | null = null;
+
+  constructor(repo: SignupAnomalyRepo = new DrizzleSignupAnomalyRepo()) {
+    this.repo = repo;
+  }
+
+  /** Run a single scan. Errors are caught and logged — the worker never throws. */
+  async runOnce(
+    opts: RunSignupAnomalyScanOptions = {},
+  ): Promise<SignupAnomalyReport | null> {
+    const correlationId = opts.correlationId ?? randomUUID();
+    try {
+      const report = await runSignupAnomalyScan(this.repo, {
+        ...opts,
+        correlationId,
+      });
+      logger.info(
+        {
+          correlationId,
+          anomalies: report.anomalies.length,
+          totalSignups: report.totalSignups,
+          topScore: report.topScore,
+        },
+        "signup_anomaly_detector: run complete",
+      );
+      return report;
+    } catch (err) {
+      logger.error(
+        { correlationId, err },
+        "signup_anomaly_detector: run failed",
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Start a recurring scan. Returns a stop handle.
+   * Non-positive or non-finite intervals disable scheduling.
+   */
+  start(
+    intervalMs = DEFAULT_SCAN_INTERVAL_MS,
+    opts: RunSignupAnomalyScanOptions = {},
+  ): () => void {
+    if (this.timer) {
+      logger.warn("signup_anomaly_detector: already running, ignoring start()");
+      return () => this.stop();
+    }
+    if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+      logger.warn(
+        { intervalMs },
+        "signup_anomaly_detector: invalid interval, not starting",
+      );
+      return () => undefined;
+    }
+
+    // Kick off immediately, then on interval.
+    void this.runOnce(opts);
+    this.timer = setInterval(() => {
+      void this.runOnce(opts);
+    }, intervalMs);
+    if (typeof this.timer.unref === "function") this.timer.unref();
+    logger.info({ intervalMs }, "signup_anomaly_detector: started");
+    return () => this.stop();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+      logger.info("signup_anomaly_detector: stopped");
+    }
+  }
+}
+
+/** Singleton for production wiring. */
+export const signupAnomalyDetectorWorker = new SignupAnomalyDetectorWorker();
+
+// Allow `node dist/workers/signupAnomalyDetector.js` for ad-hoc runs.
+/* istanbul ignore next -- CLI entry point, never reached under Jest */
+if (require.main === module) {
+  signupAnomalyDetectorWorker
+    .runOnce()
+    .then((report) => {
+      console.log("signup_anomaly_scan", JSON.stringify(report, null, 2));
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/tests/anomalyDetector.test.ts
+++ b/tests/anomalyDetector.test.ts
@@ -1,0 +1,660 @@
+import {
+  DEFAULT_BUCKET_MS,
+  DrizzleSignupAnomalyRepo,
+  MAX_BUCKETS_PER_SCAN,
+  MAX_SCORE,
+  type SignupAnomalyRepo,
+  type SignupBucket,
+  bucketStartFor,
+  bucketizeSignups,
+  computeBaseline,
+  densifyBuckets,
+  detectAnomalies,
+  median,
+  modifiedZScore,
+  resolveConfig,
+  runSignupAnomalyScan,
+  scanSignupAnomalies,
+  signupAnomalyOptionsSchema,
+} from "../src/services/anomalyDetector";
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** A bucket-aligned instant so windows are deterministic. */
+const NOW = new Date("2026-07-24T12:00:00.000Z");
+const MINUTE = 60_000;
+
+class FakeRepo implements SignupAnomalyRepo {
+  buckets: SignupBucket[] = [];
+  calls: { since: Date; until: Date; bucketMs: number }[] = [];
+  shouldThrow = false;
+
+  async loadSignupBuckets(opts: {
+    since: Date;
+    until: Date;
+    bucketMs: number;
+  }): Promise<SignupBucket[]> {
+    this.calls.push(opts);
+    if (this.shouldThrow) throw new Error("db down");
+    return this.buckets;
+  }
+}
+
+/**
+ * Build a flat baseline of `count` signups per bucket filling `[since, until)`,
+ * then overwrite the final `flood.length` buckets with the flood values.
+ */
+function series(
+  until: Date,
+  bucketMs: number,
+  baseline: number[],
+  flood: number[] = [],
+): SignupBucket[] {
+  const all = [...baseline, ...flood];
+  const startMs = until.getTime() - all.length * bucketMs;
+  return all.map((count, i) => ({
+    start: new Date(startMs + i * bucketMs),
+    count,
+  }));
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Pure statistics
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("median", () => {
+  it("returns 0 for an empty list", () => {
+    expect(median([])).toBe(0);
+  });
+
+  it("returns the middle element for odd-length lists", () => {
+    expect(median([5, 1, 3])).toBe(3);
+  });
+
+  it("averages the two middle elements for even-length lists", () => {
+    expect(median([1, 2, 3, 4])).toBe(2.5);
+  });
+
+  it("does not mutate its input", () => {
+    const input = [3, 1, 2];
+    median(input);
+    expect(input).toEqual([3, 1, 2]);
+  });
+});
+
+describe("computeBaseline", () => {
+  it("returns zeros for an empty sample", () => {
+    expect(computeBaseline([])).toEqual({
+      median: 0,
+      mad: 0,
+      meanAbsDev: 0,
+      sampleSize: 0,
+    });
+  });
+
+  it("computes median, MAD and mean absolute deviation", () => {
+    const b = computeBaseline([1, 2, 3, 4, 100]);
+    expect(b.median).toBe(3);
+    // deviations: 2, 1, 0, 1, 97 → median 1
+    expect(b.mad).toBe(1);
+    expect(b.meanAbsDev).toBeCloseTo(20.2, 5);
+    expect(b.sampleSize).toBe(5);
+  });
+
+  it("reports zero spread for a perfectly flat sample", () => {
+    const b = computeBaseline([4, 4, 4, 4]);
+    expect(b.median).toBe(4);
+    expect(b.mad).toBe(0);
+    expect(b.meanAbsDev).toBe(0);
+  });
+
+  it("is robust: one huge outlier does not move the median", () => {
+    const flat = computeBaseline([5, 5, 5, 5, 5, 5, 5]);
+    const contaminated = computeBaseline([5, 5, 5, 5, 5, 5, 100_000]);
+    expect(contaminated.median).toBe(flat.median);
+  });
+});
+
+describe("modifiedZScore", () => {
+  // median 7, deviations all 3 → MAD 3, comfortably above the Poisson floor
+  // (0.6745·√7 ≈ 1.78) so this baseline exercises the MAD path.
+  const baseline = computeBaseline([4, 4, 10, 10, 4, 10]);
+
+  it("returns 0 when there is no baseline sample", () => {
+    expect(modifiedZScore(500, computeBaseline([]))).toBe(0);
+  });
+
+  it("returns 0 for values at or below the median (downward is not a flood)", () => {
+    expect(modifiedZScore(baseline.median, baseline)).toBe(0);
+    expect(modifiedZScore(0, baseline)).toBe(0);
+  });
+
+  it("scales the deviation by MAD", () => {
+    expect(baseline.median).toBe(7);
+    expect(baseline.mad).toBe(3);
+    expect(modifiedZScore(13, baseline)).toBeCloseTo((0.6745 * 6) / 3, 5);
+  });
+
+  it("falls back to the mean absolute deviation when MAD is 0", () => {
+    // [1,1,1,1,9] → median 1, deviations [0,0,0,0,8] → MAD 0, meanAbsDev 1.6.
+    // Rescaled meanAbsDev (2.005) beats the Poisson floor (0.6745·√1 ≈ 0.67).
+    const b = computeBaseline([1, 1, 1, 1, 9]);
+    expect(b.mad).toBe(0);
+    const expected = (0.6745 * 4) / (1.6 * 1.253314);
+    expect(modifiedZScore(5, b)).toBeCloseTo(expected, 5);
+  });
+
+  it("floors the spread at Poisson noise when the baseline is perfectly flat", () => {
+    // [12,12,12,12] → MAD 0 and meanAbsDev 0; without the floor a single extra
+    // signup would score MAX_SCORE.
+    const flat = computeBaseline([12, 12, 12, 12]);
+    expect(flat.mad).toBe(0);
+    expect(modifiedZScore(13, flat)).toBeCloseTo(
+      (0.6745 * 1) / (0.6745 * Math.sqrt(12)),
+      5,
+    );
+    expect(modifiedZScore(13, flat)).toBeLessThan(1);
+    // A real flood still scores far above the threshold.
+    expect(modifiedZScore(900, flat)).toBeGreaterThan(100);
+  });
+
+  it("returns the capped score when the baseline is entirely empty", () => {
+    expect(modifiedZScore(50, computeBaseline([0, 0, 0, 0]))).toBe(MAX_SCORE);
+  });
+
+  it("caps enormous deviations at MAX_SCORE", () => {
+    expect(modifiedZScore(1e12, baseline)).toBe(MAX_SCORE);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Bucketing
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("bucketStartFor", () => {
+  it("floors a timestamp to its bucket boundary", () => {
+    const t = new Date("2026-07-24T12:07:31.500Z").getTime();
+    expect(new Date(bucketStartFor(t, 5 * MINUTE)).toISOString()).toBe(
+      "2026-07-24T12:05:00.000Z",
+    );
+  });
+
+  it("is idempotent on an already-aligned timestamp", () => {
+    const t = new Date("2026-07-24T12:05:00.000Z").getTime();
+    expect(bucketStartFor(bucketStartFor(t, 5 * MINUTE), 5 * MINUTE)).toBe(t);
+  });
+});
+
+describe("densifyBuckets", () => {
+  const since = new Date("2026-07-24T12:00:00.000Z");
+  const until = new Date("2026-07-24T12:15:00.000Z");
+  const opts = { since, until, bucketMs: 5 * MINUTE };
+
+  it("zero-fills gaps and produces an ascending dense series", () => {
+    const out = densifyBuckets(
+      [{ start: new Date("2026-07-24T12:10:00.000Z"), count: 7 }],
+      opts,
+    );
+    expect(out.map((b) => b.count)).toEqual([0, 0, 7]);
+    expect(out[0].start.toISOString()).toBe("2026-07-24T12:00:00.000Z");
+  });
+
+  it("returns an empty series when the window is empty", () => {
+    expect(densifyBuckets([], { ...opts, until: since })).toEqual([]);
+  });
+
+  it("sums duplicate buckets that land in the same slot", () => {
+    const out = densifyBuckets(
+      [
+        { start: new Date("2026-07-24T12:00:00.000Z"), count: 2 },
+        { start: new Date("2026-07-24T12:03:00.000Z"), count: 3 },
+      ],
+      opts,
+    );
+    expect(out[0].count).toBe(5);
+  });
+
+  it("drops buckets outside the window and non-positive counts", () => {
+    const out = densifyBuckets(
+      [
+        { start: new Date("2026-07-24T11:50:00.000Z"), count: 9 }, // before
+        { start: new Date("2026-07-24T12:15:00.000Z"), count: 9 }, // at `until`
+        { start: new Date("2026-07-24T12:05:00.000Z"), count: 0 },
+        { start: new Date("2026-07-24T12:05:00.000Z"), count: Number.NaN },
+      ],
+      opts,
+    );
+    expect(out.map((b) => b.count)).toEqual([0, 0, 0]);
+  });
+
+  it("re-sorts unordered input", () => {
+    const out = densifyBuckets(
+      [
+        { start: new Date("2026-07-24T12:10:00.000Z"), count: 3 },
+        { start: new Date("2026-07-24T12:00:00.000Z"), count: 1 },
+      ],
+      opts,
+    );
+    expect(out.map((b) => b.count)).toEqual([1, 0, 3]);
+  });
+});
+
+describe("bucketizeSignups", () => {
+  it("counts raw timestamps into their buckets", () => {
+    const out = bucketizeSignups(
+      [
+        new Date("2026-07-24T12:00:10.000Z"),
+        new Date("2026-07-24T12:04:59.999Z"),
+        new Date("2026-07-24T12:12:00.000Z"),
+      ],
+      {
+        since: new Date("2026-07-24T12:00:00.000Z"),
+        until: new Date("2026-07-24T12:15:00.000Z"),
+        bucketMs: 5 * MINUTE,
+      },
+    );
+    expect(out.map((b) => b.count)).toEqual([2, 0, 1]);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Detection
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("detectAnomalies", () => {
+  const config = resolveConfig();
+  const base = new Date("2026-07-24T00:00:00.000Z").getTime();
+  const bucket = (i: number, count: number): SignupBucket => ({
+    start: new Date(base + i * DEFAULT_BUCKET_MS),
+    count,
+  });
+
+  const steadyBaseline = [10, 11, 9, 10, 12, 10, 11, 9].map((c, i) =>
+    bucket(i, c),
+  );
+
+  it("reports nothing when traffic stays near the baseline", () => {
+    const out = detectAnomalies(steadyBaseline, [bucket(8, 12)], config);
+    expect(out.anomalies).toEqual([]);
+  });
+
+  it("flags a bucket whose z-score clears the threshold", () => {
+    const out = detectAnomalies(steadyBaseline, [bucket(8, 400)], config);
+    expect(out.anomalies).toHaveLength(1);
+    expect(out.anomalies[0].triggers).toContain("MODIFIED_Z_SCORE");
+    expect(out.anomalies[0].count).toBe(400);
+    expect(out.anomalies[0].expected).toBe(10);
+    expect(out.anomalies[0].severity).toBe("critical");
+  });
+
+  it("flags on the ratio rule alone when the z-score stays below threshold", () => {
+    // Wildly noisy baseline (median 10, MAD 10) keeps z at 2.7 — under the 3.5
+    // threshold — but 5x the median is still a flood.
+    const noisy = [0, 0, 0, 20, 20, 20, 10, 10].map((c, i) => bucket(i, c));
+    const out = detectAnomalies(noisy, [bucket(8, 50)], config);
+    expect(out.anomalies).toHaveLength(1);
+    expect(out.anomalies[0].triggers).toEqual(["RATIO_TO_BASELINE"]);
+    expect(out.anomalies[0].score).toBeLessThan(config.zThreshold);
+    expect(out.anomalies[0].severity).toBe("warning");
+  });
+
+  it("respects the absolute floor: small spikes on a quiet system are ignored", () => {
+    const quiet = new Array(8).fill(0).map((_, i) => bucket(i, 0));
+    // 9 signups against a baseline of 0 is a huge ratio but below minCount(10).
+    const out = detectAnomalies(quiet, [bucket(8, 9)], config);
+    expect(out.anomalies).toEqual([]);
+  });
+
+  it("flags a cold start burst when there is not enough baseline history", () => {
+    const out = detectAnomalies([bucket(0, 1)], [bucket(1, 250)], config);
+    expect(out.anomalies).toHaveLength(1);
+    expect(out.anomalies[0].triggers).toEqual(["COLD_START_BURST"]);
+    expect(out.anomalies[0].expected).toBe(0);
+    expect(out.anomalies[0].score).toBe(0);
+  });
+
+  it("grades a moderate spike as warning and a severe one as critical", () => {
+    // median 10 → spread floors at 0.6745·√10 ≈ 2.13; z(25) ≈ 4.7 (over the
+    // 3.5 threshold, under the 7.0 critical line), z(90) ≈ 25.
+    const tight = [10, 10, 10, 11, 10, 9, 10, 10].map((c, i) => bucket(i, c));
+    const warn = detectAnomalies(tight, [bucket(8, 25)], config).anomalies[0];
+    expect(warn.severity).toBe("warning");
+    expect(warn.triggers).toEqual(["MODIFIED_Z_SCORE"]);
+    const crit = detectAnomalies(tight, [bucket(8, 90)], config).anomalies[0];
+    expect(crit.severity).toBe("critical");
+  });
+
+  it("sorts anomalies by score descending", () => {
+    const out = detectAnomalies(
+      steadyBaseline,
+      [bucket(8, 60), bucket(9, 800), bucket(10, 200)],
+      config,
+    );
+    expect(out.anomalies.map((a) => a.count)).toEqual([800, 200, 60]);
+  });
+
+  it("reports the top score even when no bucket is anomalous", () => {
+    const out = detectAnomalies(steadyBaseline, [bucket(8, 9)], config);
+    expect(out.anomalies).toEqual([]);
+    expect(out.topScore).toBe(0);
+  });
+
+  it("emits JSON-safe finite numbers even at the score cap", () => {
+    const flat = new Array(8).fill(0).map((_, i) => bucket(i, 5));
+    const a = detectAnomalies(flat, [bucket(8, 5000)], config).anomalies[0];
+    expect(Number.isFinite(a.score)).toBe(true);
+    expect(a.score).toBe(MAX_SCORE);
+    expect(JSON.parse(JSON.stringify(a)).score).toBe(MAX_SCORE);
+  });
+
+  it("exposes the bucket boundaries as ISO strings", () => {
+    const a = detectAnomalies(steadyBaseline, [bucket(8, 400)], config)
+      .anomalies[0];
+    expect(new Date(a.bucketEnd).getTime() - new Date(a.bucketStart).getTime())
+      .toBe(config.bucketMs);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Options validation
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("signupAnomalyOptionsSchema", () => {
+  it("accepts an empty object (all defaults)", () => {
+    expect(signupAnomalyOptionsSchema.parse({})).toEqual({});
+  });
+
+  it("rejects unknown keys", () => {
+    expect(signupAnomalyOptionsSchema.safeParse({ nope: 1 }).success).toBe(false);
+  });
+
+  it.each([
+    ["bucketMs too small", { bucketMs: 1000 }],
+    ["bucketMs too large", { bucketMs: 7_200_000 }],
+    ["baselineWindowMs beyond 7 days", { baselineWindowMs: 8 * 86_400_000 }],
+    ["evaluationWindowMs beyond 24h", { evaluationWindowMs: 25 * 3_600_000 }],
+    ["zThreshold below 1", { zThreshold: 0.5 }],
+    ["ratioThreshold below 1", { ratioThreshold: 0 }],
+    ["minCount below 1", { minCount: 0 }],
+    ["non-integer bucketMs", { bucketMs: 60_000.5 }],
+  ])("rejects %s", (_label, input) => {
+    expect(signupAnomalyOptionsSchema.safeParse(input).success).toBe(false);
+  });
+
+  it("rejects an evaluation window narrower than one bucket", () => {
+    const res = signupAnomalyOptionsSchema.safeParse({
+      bucketMs: 600_000,
+      evaluationWindowMs: 60_000,
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects a baseline window narrower than one bucket", () => {
+    const res = signupAnomalyOptionsSchema.safeParse({
+      bucketMs: 600_000,
+      baselineWindowMs: 60_000,
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects a window that would exceed the bucket ceiling", () => {
+    const res = signupAnomalyOptionsSchema.safeParse({
+      bucketMs: 60_000,
+      baselineWindowMs: 7 * 86_400_000,
+    });
+    expect(res.success).toBe(false);
+    expect(res.success ? "" : res.error.issues[0].message).toContain(
+      String(MAX_BUCKETS_PER_SCAN),
+    );
+  });
+});
+
+describe("resolveConfig", () => {
+  it("applies every default", () => {
+    expect(resolveConfig()).toEqual({
+      bucketMs: 300_000,
+      baselineWindowMs: 86_400_000,
+      evaluationWindowMs: 1_800_000,
+      zThreshold: 3.5,
+      ratioThreshold: 4,
+      minCount: 10,
+      minBaselineBuckets: 6,
+    });
+  });
+
+  it("lets callers override individual knobs", () => {
+    expect(resolveConfig({ minCount: 99 }).minCount).toBe(99);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Orchestration
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("runSignupAnomalyScan", () => {
+  const now = () => NOW;
+
+  it("queries a bucket-aligned window covering baseline + evaluation", async () => {
+    const repo = new FakeRepo();
+    const report = await runSignupAnomalyScan(repo, { now });
+
+    const call = repo.calls[0];
+    expect(call.bucketMs).toBe(DEFAULT_BUCKET_MS);
+    // NOW is bucket-aligned, so `until` is one bucket past it.
+    expect(call.until.toISOString()).toBe("2026-07-24T12:05:00.000Z");
+    expect(call.since.toISOString()).toBe("2026-07-23T11:35:00.000Z");
+    expect(report.window.evaluationSince).toBe("2026-07-24T11:35:00.000Z");
+    // 30-minute evaluation window at 5-minute buckets.
+    expect(report.evaluated).toBe(6);
+  });
+
+  it("returns an all-clear report for steady traffic", async () => {
+    const repo = new FakeRepo();
+    const until = new Date("2026-07-24T12:05:00.000Z");
+    repo.buckets = series(
+      until,
+      DEFAULT_BUCKET_MS,
+      new Array(288).fill(12), // 24h of steady traffic
+      [12, 11, 13, 12, 12, 12],
+    );
+
+    const report = await runSignupAnomalyScan(repo, { now });
+    expect(report.anomalies).toEqual([]);
+    expect(report.baseline.median).toBe(12);
+    expect(report.totalSignups).toBe(72);
+    expect(report.peak).toEqual({
+      bucketStart: "2026-07-24T11:45:00.000Z",
+      count: 13,
+    });
+  });
+
+  it("detects a signup flood in the evaluation window", async () => {
+    const repo = new FakeRepo();
+    const until = new Date("2026-07-24T12:05:00.000Z");
+    repo.buckets = series(
+      until,
+      DEFAULT_BUCKET_MS,
+      new Array(288).fill(12),
+      [12, 13, 900, 1200, 11, 12],
+    );
+
+    const report = await runSignupAnomalyScan(repo, { now });
+    expect(report.anomalies).toHaveLength(2);
+    expect(report.anomalies.map((a) => a.count)).toEqual([1200, 900]);
+    expect(report.anomalies.every((a) => a.severity === "critical")).toBe(true);
+    expect(report.peak?.count).toBe(1200);
+    expect(report.topScore).toBeGreaterThan(3.5);
+  });
+
+  it("does not let an earlier flood poison the baseline for a later one", async () => {
+    const repo = new FakeRepo();
+    const until = new Date("2026-07-24T12:05:00.000Z");
+    const baseline = new Array(288).fill(10);
+    // A previous flood sits inside the baseline window.
+    baseline.splice(100, 6, 5000, 5000, 5000, 5000, 5000, 5000);
+    repo.buckets = series(until, DEFAULT_BUCKET_MS, baseline, [
+      10, 10, 10, 10, 10, 800,
+    ]);
+
+    const report = await runSignupAnomalyScan(repo, { now });
+    expect(report.baseline.median).toBe(10); // unmoved by the old flood
+    expect(report.anomalies).toHaveLength(1);
+    expect(report.anomalies[0].count).toBe(800);
+  });
+
+  it("carries the caller's correlation id into the report", async () => {
+    const repo = new FakeRepo();
+    const report = await runSignupAnomalyScan(repo, {
+      now,
+      correlationId: "corr-123",
+    });
+    expect(report.correlationId).toBe("corr-123");
+  });
+
+  it("defaults the correlation id to null outside a request context", async () => {
+    const report = await runSignupAnomalyScan(new FakeRepo(), { now });
+    expect(report.correlationId).toBeNull();
+  });
+
+  it("handles a completely empty database", async () => {
+    const report = await runSignupAnomalyScan(new FakeRepo(), { now });
+    expect(report.anomalies).toEqual([]);
+    expect(report.totalSignups).toBe(0);
+    expect(report.peak).toEqual({
+      bucketStart: "2026-07-24T11:35:00.000Z",
+      count: 0,
+    });
+    expect(report.baseline.sampleSize).toBeGreaterThan(0);
+  });
+
+  it("evaluates exactly one bucket at the narrowest legal window", async () => {
+    const report = await runSignupAnomalyScan(new FakeRepo(), {
+      now,
+      bucketMs: 3_600_000,
+      evaluationWindowMs: 3_600_000,
+    });
+    expect(report.evaluated).toBe(1);
+    expect(report.peak).not.toBeNull();
+  });
+
+  it("honours caller-supplied tunables", async () => {
+    const repo = new FakeRepo();
+    await runSignupAnomalyScan(repo, {
+      now,
+      bucketMs: 60_000,
+      baselineWindowMs: 3_600_000,
+      evaluationWindowMs: 600_000,
+    });
+    const call = repo.calls[0];
+    expect(call.bucketMs).toBe(60_000);
+    expect(call.until.getTime() - call.since.getTime()).toBe(
+      3_600_000 + 600_000,
+    );
+  });
+
+  it("rejects invalid options before touching the repo", async () => {
+    const repo = new FakeRepo();
+    await expect(
+      runSignupAnomalyScan(repo, { now, minCount: 0 }),
+    ).rejects.toThrow();
+    expect(repo.calls).toHaveLength(0);
+  });
+
+  it("rejects unknown option keys", async () => {
+    await expect(
+      runSignupAnomalyScan(new FakeRepo(), {
+        now,
+        // @ts-expect-error — deliberately passing an unsupported key
+        dropTable: true,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("propagates repository failures to the caller", async () => {
+    const repo = new FakeRepo();
+    repo.shouldThrow = true;
+    await expect(runSignupAnomalyScan(repo, { now })).rejects.toThrow("db down");
+  });
+
+  it("produces a JSON-serialisable report", async () => {
+    const repo = new FakeRepo();
+    const until = new Date("2026-07-24T12:05:00.000Z");
+    repo.buckets = series(
+      until,
+      DEFAULT_BUCKET_MS,
+      new Array(288).fill(0),
+      [0, 0, 0, 0, 0, 500],
+    );
+    const report = await runSignupAnomalyScan(repo, { now });
+    const round = JSON.parse(JSON.stringify(report));
+    expect(round).toEqual(report);
+    expect(round.anomalies[0].score).toBe(MAX_SCORE);
+  });
+});
+
+describe("scanSignupAnomalies", () => {
+  it("delegates to runSignupAnomalyScan with the supplied repo", async () => {
+    const repo = new FakeRepo();
+    const report = await scanSignupAnomalies({ now: () => NOW }, repo);
+    expect(repo.calls).toHaveLength(1);
+    expect(report.window.bucketMs).toBe(DEFAULT_BUCKET_MS);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Drizzle repository (query shape only — no live database)
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("DrizzleSignupAnomalyRepo", () => {
+  const opts = {
+    since: new Date("2026-07-24T00:00:00.000Z"),
+    until: new Date("2026-07-24T12:00:00.000Z"),
+    bucketMs: 300_000,
+  };
+
+  it("aggregates in SQL and maps rows to buckets", async () => {
+    const execute = jest.fn().mockResolvedValue({
+      rows: [
+        { bucket_start: "2026-07-24T11:00:00.000Z", signups: "4" },
+        { bucket_start: new Date("2026-07-24T11:05:00.000Z"), signups: 7 },
+      ],
+    });
+    const repo = new DrizzleSignupAnomalyRepo({ execute });
+
+    const out = await repo.loadSignupBuckets(opts);
+    expect(out).toEqual([
+      { start: new Date("2026-07-24T11:00:00.000Z"), count: 4 },
+      { start: new Date("2026-07-24T11:05:00.000Z"), count: 7 },
+    ]);
+  });
+
+  it("binds the bucket width and window instead of interpolating them", async () => {
+    const execute = jest.fn().mockResolvedValue({ rows: [] });
+    await new DrizzleSignupAnomalyRepo({ execute }).loadSignupBuckets(opts);
+
+    const chunks: unknown[] = execute.mock.calls[0][0].queryChunks;
+    const literals = chunks.filter(
+      (c) => c !== null && typeof c === "object" && "value" in (c as object),
+    );
+    const bound = chunks.filter((c) => !literals.includes(c));
+
+    // 300000 ms → 300 s, bound twice (floor + multiply), plus since/until.
+    expect(bound).toEqual([300, 300, opts.since, opts.until]);
+    // The SQL text itself must never carry the caller's values.
+    const text = literals
+      .map((c) => (c as { value: string[] }).value.join(""))
+      .join("");
+    expect(text).toContain("FROM users");
+    expect(text).not.toContain("300");
+  });
+
+  it("tolerates a driver that returns no rows array", async () => {
+    const execute = jest.fn().mockResolvedValue(undefined);
+    const out = await new DrizzleSignupAnomalyRepo({ execute }).loadSignupBuckets(
+      opts,
+    );
+    expect(out).toEqual([]);
+  });
+});

--- a/tests/signupAnomalyDetector.worker.test.ts
+++ b/tests/signupAnomalyDetector.worker.test.ts
@@ -1,0 +1,100 @@
+import { SignupAnomalyDetectorWorker } from "../src/workers/signupAnomalyDetector";
+import type {
+  SignupAnomalyRepo,
+  SignupBucket,
+} from "../src/services/anomalyDetector";
+
+class FakeRepo implements SignupAnomalyRepo {
+  buckets: SignupBucket[] = [];
+  shouldThrow = false;
+  calls = 0;
+
+  async loadSignupBuckets(): Promise<SignupBucket[]> {
+    this.calls += 1;
+    if (this.shouldThrow) throw new Error("boom");
+    return this.buckets;
+  }
+}
+
+describe("SignupAnomalyDetectorWorker", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("runOnce returns the report for a happy path", async () => {
+    const worker = new SignupAnomalyDetectorWorker(new FakeRepo());
+    const report = await worker.runOnce({ correlationId: "abc" });
+    expect(report).not.toBeNull();
+    expect(report!.correlationId).toBe("abc");
+    expect(report!.anomalies).toEqual([]);
+  });
+
+  it("runOnce generates a correlation id when none is supplied", async () => {
+    const worker = new SignupAnomalyDetectorWorker(new FakeRepo());
+    const report = await worker.runOnce();
+    expect(report!.correlationId).toMatch(/^[0-9a-f-]{36}$/u);
+  });
+
+  it("runOnce swallows errors and returns null instead of throwing", async () => {
+    const repo = new FakeRepo();
+    repo.shouldThrow = true;
+    const worker = new SignupAnomalyDetectorWorker(repo);
+    await expect(worker.runOnce()).resolves.toBeNull();
+  });
+
+  it("runOnce returns null when options fail validation", async () => {
+    const worker = new SignupAnomalyDetectorWorker(new FakeRepo());
+    await expect(worker.runOnce({ minCount: -1 })).resolves.toBeNull();
+  });
+
+  it("start() refuses non-positive intervals", () => {
+    const repo = new FakeRepo();
+    const worker = new SignupAnomalyDetectorWorker(repo);
+    const stop = worker.start(0);
+    expect(typeof stop).toBe("function");
+    expect(repo.calls).toBe(0);
+    stop();
+  });
+
+  it("start() refuses a non-finite interval", () => {
+    const repo = new FakeRepo();
+    const worker = new SignupAnomalyDetectorWorker(repo);
+    worker.start(Number.POSITIVE_INFINITY)();
+    expect(repo.calls).toBe(0);
+  });
+
+  it("start() runs immediately, then on the interval; stop() halts the timer", async () => {
+    jest.useFakeTimers();
+    const worker = new SignupAnomalyDetectorWorker(new FakeRepo());
+    const spy = jest.spyOn(worker, "runOnce");
+
+    const stop = worker.start(1000);
+    await Promise.resolve();
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(2000);
+    expect(spy).toHaveBeenCalledTimes(3);
+
+    stop();
+    jest.advanceTimersByTime(5000);
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it("start() is idempotent while already running", async () => {
+    jest.useFakeTimers();
+    const worker = new SignupAnomalyDetectorWorker(new FakeRepo());
+    const spy = jest.spyOn(worker, "runOnce");
+
+    worker.start(1000);
+    await Promise.resolve();
+    worker.start(1000); // ignored
+    await Promise.resolve();
+    expect(spy).toHaveBeenCalledTimes(1);
+    worker.stop();
+  });
+
+  it("stop() is safe to call when never started", () => {
+    expect(() => new SignupAnomalyDetectorWorker(new FakeRepo()).stop()).not.toThrow();
+  });
+});


### PR DESCRIPTION
# feat: signup anomaly detector

Closes #321

## Summary

Detects **signup floods** — bot registration waves, airdrop farming, sybil onboarding — by comparing the recent signup rate against a robust baseline learned from the preceding 24 hours.

The detector is **read-only**: it aggregates `users.created_at`, scores it, and reports. Nothing is persisted, no migration is required, and re-running is free and idempotent. Findings surface through the return value, a structured `warn` log, and Prometheus metrics.

## How it works

1. **Bucket** — signups are aggregated into fixed-width buckets (default 5 min), aligned to epoch multiples so boundaries are stable across runs. Gaps are zero-filled: a quiet night must count as a low sample, not a missing one.
2. **Baseline** — the buckets *before* the evaluation window feed a robust summary: **median** and **median absolute deviation (MAD)**.
3. **Score** — each evaluation bucket gets a modified z-score (Iglewicz & Hoaglin): `0.6745 · (count − median) / spread`.
4. **Flag** — a bucket alerts only when it clears an absolute floor **and** at least one relative rule fires.

| Trigger | Fires when |
| --- | --- |
| `MODIFIED_Z_SCORE` | score ≥ `zThreshold` (default 3.5) |
| `RATIO_TO_BASELINE` | `count / max(median, 1)` ≥ `ratioThreshold` (default 4) |
| `COLD_START_BURST` | fewer than `minBaselineBuckets` of history; the absolute floor alone fired |

Severity escalates to `critical` at twice either relative threshold, otherwise `warning`.

## Design decisions worth review attention

**Median/MAD rather than mean/stddev.** A mean-and-stddev baseline is destroyed by the very thing being detected: one large flood inflates both, so the *next* flood scores as normal. Median and MAD have a 50 % breakdown point — a burst must consume half the baseline window before it can hide itself. Pinned by the test *"does not let an earlier flood poison the baseline for a later one"*.

**Poisson noise floor.** The first version flagged a bucket of 13 against a flat baseline of 12s, because a perfectly flat baseline has MAD = 0 and every increase then scores as maximally surprising. Signups are arrivals, so bucket counts are roughly Poisson — a stream averaging λ per bucket varies by σ ≈ √λ from chance alone. The observed spread is now floored at `0.6745 · √median`. Spread reaches zero only when the baseline is *entirely empty*, where any arrival genuinely is surprising, and `minCount` is what stops that from paging anyone.

**Absolute floor gates every relative rule.** Without it, "1 signup against a baseline of 0" is an infinite ratio. `minCount` (default 10) is checked first — it is also the cheapest check.

**Scores are capped at 1000.** `Infinity` serialises to `null` in JSON; the cap keeps reports JSON-safe and gives dashboards a bounded axis.

## Changes

| File | Change |
| --- | --- |
| `src/services/anomalyDetector.ts` | New. Pure scoring core, Zod-validated options, repo interface, Drizzle-backed repo, scan orchestration |
| `src/workers/signupAnomalyDetector.ts` | New. Periodic worker (`runOnce` / `start` / `stop`) + CLI entry point |
| `src/metrics/registry.ts` | Three new Prometheus metrics |
| `docs/signup-anomaly.md` | New. Architecture, tuning, configuration, observability, security notes |
| `docs/metrics.md` | Documents the new metrics |
| `tests/anomalyDetector.test.ts` | New. 63 tests |
| `tests/signupAnomalyDetector.worker.test.ts` | New. 11 tests |

## Input validation

Every caller-supplied option is validated by `signupAnomalyOptionsSchema` inside `runSignupAnomalyScan`, so no caller — including a future HTTP route forwarding query parameters — can turn this into an unbounded scan. Bounds are tight and cross-field rules are enforced (`evaluationWindowMs ≥ bucketMs`, etc.). A scan may never exceed **5000 buckets**; combinations that would are rejected with a validation error naming the limit. The schema is exported so a route can re-use it and return the standard error envelope on 400.

## Observability

Every log line carries a `correlationId` — taken from the caller, else the active `AsyncLocalStorage` request context, else `null` — so a run can be traced across the worker → service → repo boundary.

| Message | Level | Emitted |
| --- | --- | --- |
| `signup_anomaly_scan: start` | info | Every scan, with the resolved window |
| `signup_anomaly_scan: complete` | info | Scan found nothing |
| `signup_anomaly_scan: signup flood detected` | **warn** | One or more anomalies — alert on this |
| `signup_anomaly_detector: run failed` | error | Worker swallowed an error |

| Metric | Type | Labels |
| --- | --- | --- |
| `signup_anomaly_scans_total` | counter | — |
| `signup_anomalies_detected_total` | counter | `severity` |
| `signup_anomaly_top_score` | gauge | — |

Suggested alert: `increase(signup_anomalies_detected_total{severity="critical"}[10m]) > 0`.

## Security

* **No PII.** Only counts and timestamps are read; no addresses or user ids enter the report or the logs.
* **Parameterised SQL.** Bucket width and window bounds are bound as query parameters, never interpolated — asserted by the test *"binds the bucket width and window instead of interpolating them"*, which also checks the SQL text carries none of the caller's values.
* **Bounded work.** Aggregation happens in Postgres (`GROUP BY` on a bucketed epoch), so a 24 h window is 288 rows regardless of signup volume, and the bucket ceiling caps the worst case.
* **Not an enforcement point.** The detector observes; it does not block signups. Pair with rate limiting for mitigation.

## Test output

```
npx jest tests/anomalyDetector.test.ts tests/signupAnomalyDetector.worker.test.ts --coverage

File                       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
All files                  |   99.46 |   91.91  |   97.14 |     100 |
  anomalyDetector.ts       |     100 |   91.95  |     100 |     100 |
  signupAnomalyDetector.ts |   97.14 |   91.66  |    87.5 |     100 | 72

Test Suites: 2 passed, 2 total
Tests:       74 passed, 74 total
```

Coverage on changed lines is **100 %**, above the 90 % requirement. `npx eslint` is clean on all changed source files, and `tsc --noEmit` reports no errors in any file added by this PR.

### Edge cases covered

* Empty database; empty evaluation window; single-bucket (narrowest legal) window
* Flat baseline (MAD = 0) → Poisson floor; zero baseline → capped score
* MAD = 0 with non-zero spread → mean-absolute-deviation fallback
* Sparse, unordered, duplicate, out-of-window and `NaN` bucket input
* Cold start (insufficient history), absolute floor on a quiet system
* Prior flood inside the baseline window not masking a later one
* Every validation bound, plus unknown-key rejection and cross-field rules
* Repository failure propagation; worker error/validation-failure swallowing
* Timer lifecycle: immediate run, interval, `stop()`, double-`start()`, invalid intervals
* JSON round-trip of the report at the score cap

## Scope notes

Two things intentionally left out:

1. **No admin HTTP endpoint.** One was built (`GET /api/admin/anomalies/signups`) and then removed: it imports `requireAdmin` → `jwtService` → `src/utils/keyRing.ts`, which reads `env.JWT_KEYS` and `env.JWT_ACTIVE_KID` — neither exists in the env schema. That is pre-existing breakage on `main` (it already stops `tests/adminFraud.test.ts` and every other auth-importing suite from compiling), unrelated to this change. Shipping an untestable route would have missed the coverage bar. `signupAnomalyOptionsSchema` is exported so the route can be added cheaply once that is fixed — worth a separate issue.
2. **The worker is not wired into startup.** `adminFraudRouter` and `fraudDetectorWorker` are not mounted in `src/index.ts` either; this PR matches that precedent rather than changing app boot.

## Acceptance criteria

- [x] Implementation matches the description — detects signup floods
- [x] Tests added and passing — 74 tests, 100 % line coverage on changed lines
- [x] Docs updated — `docs/signup-anomaly.md` and `docs/metrics.md`
- [x] Input validation at the boundary; validation errors reject before any query runs
- [x] Structured logging with correlation IDs
- [x] Adheres to repo lint and code style
- [ ] Code review approved
