### PR TITLE
feat: deep ready check

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,38 @@ Once running:
 - **Audit export** → `GET /api/admin/audit/export` streams admin audit logs as `application/x-ndjson`
 
 
+## Health Endpoints
+
+| Endpoint | Auth | Description |
+|---|---|---|
+| `GET /health` | None | Liveness check — returns `{ "status": "ok" }` immediately. Use this to verify the process is up. |
+| `GET /healthz/dependencies` | None | Shallow dependency probe — Postgres, Soroban RPC, Horizon, webhook queue (Redis). Cached for 5 s. Returns 200/207/503. |
+| `GET /api/health/ready` | None | **Deep readiness check** — runs four parallel probes with 1-second timeouts each. Returns 200 when ready, 503 when unready. |
+
+### `GET /api/health/ready` response
+
+```json
+{
+  "status": "ready",
+  "correlationId": "<uuid>",
+  "checkedAt": "2026-07-24T12:00:00.000Z",
+  "checks": {
+    "db":         { "status": "pass", "durationMs": 4,  "message": "Database connection healthy" },
+    "sorobanRpc": { "status": "pass", "durationMs": 18, "message": "Soroban RPC healthy" },
+    "indexerLag": { "status": "pass", "durationMs": 22, "message": "Indexer lag healthy: 12 ≤ 200 ledgers" },
+    "queue":      { "status": "pass", "durationMs": 2,  "message": "Queue (Redis) healthy" }
+  }
+}
+```
+
+- `status` is `"ready"` only when **all four** probes pass; otherwise `"unready"`.
+- HTTP 200 → ready, HTTP 503 → unready.
+- Pass `x-correlation-id` header to correlate log entries with the request.
+- `READINESS_MAX_LAG_LEDGERS` (env, default `200`) controls the indexer lag threshold.
+- Not cached — orchestrators (Kubernetes, ECS) get a fresh signal on every poll.
+
+See [docs/health-ready.md](docs/health-ready.md) for full runbook.
+
 ## Request body size limits
 
 - Default JSON request body limit: `256kb`.
@@ -98,7 +130,7 @@ This starter is intentionally minimal. The full backlog is tracked in GitHub Iss
 - Predictions + claims endpoints
 - Leaderboards & user profiles
 - Webhook delivery + DLQ
-- Observability (metrics, tracing, /readyz with deep checks)
+- Observability (metrics, tracing, /readyz with deep checks ✅ `/api/health/ready`)
 - OpenAPI spec + contract tests
 
 ## Auth Refresh Flow

--- a/docs/health-ready.md
+++ b/docs/health-ready.md
@@ -1,0 +1,116 @@
+# `/api/health/ready` — Deep Readiness Check Runbook
+
+## Overview
+
+`GET /api/health/ready` is an uncached deep readiness probe intended for use by
+Kubernetes/ECS readiness probes, load-balancer health checks, and monitoring systems.
+
+Unlike `/healthz/dependencies` (cached 5 s, returns 207 for degraded), this endpoint:
+
+- Runs **every call**, uncached
+- Returns only `200` (ready) or `503` (unready) — no 207
+- Declares ready only when **all four** probes pass
+
+## Response shape
+
+```json
+{
+  "status": "ready",
+  "correlationId": "550e8400-e29b-41d4-a716-446655440000",
+  "checkedAt": "2026-07-24T12:00:00.000Z",
+  "checks": {
+    "db":         { "status": "pass", "durationMs": 4,  "message": "Database connection healthy" },
+    "sorobanRpc": { "status": "pass", "durationMs": 18, "message": "Soroban RPC healthy" },
+    "indexerLag": { "status": "pass", "durationMs": 22, "message": "Indexer lag healthy: 12 ≤ 200 ledgers" },
+    "queue":      { "status": "pass", "durationMs": 2,  "message": "Queue (Redis) healthy" }
+  }
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `status` | `"ready"` \| `"unready"` | Aggregate |
+| `correlationId` | UUID | Echoed from `x-correlation-id` header, or auto-generated |
+| `checkedAt` | ISO 8601 | Timestamp when the check completed |
+| `checks.*.status` | `"pass"` \| `"fail"` | Per-probe |
+| `checks.*.durationMs` | number | Probe elapsed time (ms) |
+| `checks.*.message` | string | Human-readable result or error |
+
+## HTTP status codes
+
+| Code | Meaning |
+|---|---|
+| `200 OK` | All probes passed — ready to accept traffic |
+| `503 Service Unavailable` | One or more probes failed |
+
+## Probes
+
+### `db` — Postgres
+Runs `SELECT 1` with a 1 s timeout. Fails if the pool is exhausted, the query throws, or it times out.
+
+### `sorobanRpc` — Soroban RPC
+Calls `getLatestLedger()` on `SOROBAN_RPC_URL` with a 1 s timeout.
+
+### `indexerLag` — Indexer cursor lag
+Reads `indexer_cursor.last_ledger` and compares to `getLatestLedger().sequence`. Fails when:
+- The row doesn't exist (indexer never started)
+- `chainTip − lastIndexed > READINESS_MAX_LAG_LEDGERS` (default 200)
+
+Mainnet produces ~1 ledger/5 s, so 200 ledgers ≈ ~17 minutes of tolerated lag.
+
+### `queue` — Redis / BullMQ
+Issues a Redis `PING` with a 1 s timeout. Fails if the response is not `PONG`.
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `REDIS_URL` | `redis://localhost:6379` | BullMQ Redis connection |
+| `SOROBAN_RPC_URL` | — | Soroban RPC endpoint (required) |
+| `READINESS_MAX_LAG_LEDGERS` | `200` | Max tolerated indexer lag ledgers |
+
+## Correlation IDs
+
+Pass `x-correlation-id` in the request header; it is echoed in the response body
+and every structured log line, making it easy to correlate probe failures in the
+pino log stream:
+
+```bash
+kubectl logs -l app=predictify-backend | jq 'select(.correlationId == "my-run-id")'
+```
+
+## Kubernetes example
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /api/health/ready
+    port: 3001
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  failureThreshold: 3
+  timeoutSeconds: 3
+```
+
+## Structured logs
+
+Each call emits one INFO entry on completion:
+
+```json
+{
+  "level": 30,
+  "msg": "health_ready_check_complete",
+  "correlationId": "…",
+  "status": "ready",
+  "elapsedMs": 28,
+  "checks": { "db": { … }, "sorobanRpc": { … }, "indexerLag": { … }, "queue": { … } }
+}
+```
+
+Individual probe failures are additionally logged at ERROR (`msg: "readiness_*_check_failed"`).
+
+## Security
+
+No authentication required. The endpoint exposes only health metadata — no
+application data. Restrict access at the infrastructure level (VPC / ingress allowlist)
+so orchestrators can reach it but it is not publicly exposed.

--- a/src/config/env-schema.ts
+++ b/src/config/env-schema.ts
@@ -68,6 +68,14 @@ const baseSchema = z.object({
   SETTLE_CONFIRMER_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(5_000),
   SETTLE_CONFIRMER_CONFIRMATION_LEDGERS: z.coerce.number().int().positive().default(2),
 
+  // ── Slow Query Alerter ────────────────────────────────────
+  SLOW_QUERY_ALERTER_ENABLED: z.coerce.boolean().default(false),
+  SLOW_QUERY_ALERTER_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(60_000),
+  SLOW_QUERY_ALERTER_MEAN_EXEC_TIME_THRESHOLD_MS: z.coerce.number().int().positive().default(100),
+  SLOW_QUERY_ALERTER_MAX_EXEC_TIME_THRESHOLD_MS: z.coerce.number().int().positive().default(500),
+  SLOW_QUERY_ALERTER_LIMIT: z.coerce.number().int().positive().default(10),
+  SLOW_QUERY_ALERTER_QUERY_MAX_LENGTH: z.coerce.number().int().positive().default(1000),
+
   // ── Metrics ───────────────────────────────────────────────
   /** Bearer token required to access /api/metrics. Empty string (default) means no auth. */
   METRICS_AUTH_TOKEN: z.string().default(""),

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,53 +1,13 @@
-import pino from "pino";
-import { envSchema } from "./env-schema";
+import { envSchema, formatEnvErrors } from "./env-schema";
 
-const schema = z.object({
-  NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
-  PORT: z.coerce.number().int().positive().default(3001),
-  LOG_LEVEL: z.enum(["fatal", "error", "warn", "info", "debug", "trace"]).default("info"),
-  FLAGS_CACHE_TTL_SECONDS: z.coerce.number().int().positive().default(30),
-  DATABASE_URL: z.string().url(),
-  REDIS_URL: z.string().url().default("redis://localhost:6379"),
-  JWT_SECRET: z.string().min(32),
-  JWT_ISSUER: z.string().default("predictify"),
-  JWT_AUDIENCE: z.string().default("predictify-app"),
-  JWT_TTL_SECONDS: z.coerce.number().int().positive().default(3600),
-  // Optional multi-key ring for zero-downtime JWT rotation.
-  // Format: "kid1:secret1,kid2:secret2" — see src/utils/keyRing.ts.
-  JWT_KEYS: z.string().optional(),
-  JWT_ACTIVE_KID: z.string().optional(),
-  WORKER_HEARTBEAT_SECONDS: z.coerce.number().int().positive().default(30),
-  STELLAR_NETWORK: z.enum(["testnet", "mainnet"]).default("testnet"),
-  SOROBAN_RPC_URL: z.string().url(),
-  HORIZON_URL: z.string().url(),
-  PREDICTIFY_CONTRACT_ID: z.string().min(1),
-  INDEXER_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(5000),
-  INDEXER_START_LEDGER: z.coerce.number().int().nonnegative().default(0),
-  INDEXER_REWIND_LEDGERS: z.coerce.number().int().nonnegative().default(100),
-  INDEXER_BACKFILL_CHUNK_SIZE: z.coerce.number().int().positive().default(500),
-  INDEXER_GAP_SCAN_INTERVAL_MS: z.coerce.number().int().positive().default(60000),
-  // Lag (in ledgers) above which the health probe emits an alert log  (default: 200)
-  INDEXER_LAG_ALERT_THRESHOLD: z.coerce.number().int().positive().default(200),
-  RECONCILIATION_ENABLED: z.coerce.boolean().default(false),
-  RECONCILIATION_SCHEDULE: z.string().default("0 2 * * *"),
-  ADMIN_ALLOWLIST: z.string().default("").transform((val) => val.split(",").map((s) => s.trim()).filter(Boolean)),
-  PG_POOL_MAX: z.coerce.number().int().positive().default(10),
-  PG_STATEMENT_TIMEOUT_MS: z.coerce.number().int().positive().default(5000),
-  ANON_RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
-  ANON_RATE_LIMIT_MAX: z.coerce.number().int().positive().default(60),
-  TRUST_PROXY: z.coerce.boolean().default(false),
-  // ── Captcha gate ──────────────────────────────────────────
-  CAPTCHA_THRESHOLD: z.coerce.number().int().nonnegative().default(10),
-  CAPTCHA_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
-  // ── Settle confirmer ──────────────────────────────────────────
-  SETTLE_CONFIRMER_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(5_000),
-  SETTLE_CONFIRMER_CONFIRMATION_LEDGERS: z.coerce.number().int().positive().default(2),
-  // ── Slow Query Alerter ──────────────────────────────────────────
-  SLOW_QUERY_ALERTER_ENABLED: z.coerce.boolean().default(false),
-  SLOW_QUERY_ALERTER_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(60000), // 1 minute
-  SLOW_QUERY_ALERTER_MEAN_EXEC_TIME_THRESHOLD_MS: z.coerce.number().int().positive().default(100), // 100ms
-  SLOW_QUERY_ALERTER_MAX_EXEC_TIME_THRESHOLD_MS: z.coerce.number().int().positive().default(500), // 500ms
-  SLOW_QUERY_ALERTER_LIMIT: z.coerce.number().int().positive().default(10),
-  SLOW_QUERY_ALERTER_QUERY_MAX_LENGTH: z.coerce.number().int().positive().default(1000),
-});
+const result = envSchema.safeParse(process.env);
 
+if (!result.success) {
+  // Print all validation failures at startup and hard-exit so misconfigured
+  // deployments fail fast rather than blowing up at request time.
+  console.error("❌  Invalid environment configuration:\n" + formatEnvErrors(result.error));
+  process.exit(1);
+}
+
+export const env = result.data;
+export type Env = typeof env;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ import { apiVersionMiddleware } from "./middleware/apiVersion";
 import { defaultBodyLimitMiddleware, webhookBodyLimitMiddleware } from "./middleware/bodyLimit";
 import { healthRouter } from "./routes/health";
 import dependenciesRouter from "./routes/healthz/dependencies";
+import { createReadyRouter } from "./routes/health/ready";
+import { redisConnection } from "./queue";
 import { authRouter } from "./routes/auth";
 import { marketsRouter } from "./routes/markets";
 import { predictionsRouter } from "./routes/predictions";
@@ -23,8 +25,8 @@ import { socialRouter } from "./routes/social";
 import { adminAuditRouter } from "./routes/admin/audit";
 import { adminMarketsRouter } from "./routes/admin/markets";
 import { adminSchemaVersionsRouter } from "./routes/admin/schema-versions";
+import { devicesRouter } from "./routes/devices";
 import { errorHandler } from "./middleware/errorHandler";
-import { startIndexerHealthProbe, stopIndexerHealthProbe } from "./jobs/indexerHealthProbe";
 import { requestContextStorage } from "./lib/requestContext";
 import { REQUEST_ID_HEADER } from "./lib/http";
 import { register } from "./metrics/registry";
@@ -51,7 +53,7 @@ export interface AppDeps {
   webhooks?: any;
 }
 
-export function createApp(deps: AppDeps = {}): express.Express {
+export function createApp(_deps: AppDeps = {}): express.Express {
   const app = express();
 
   if (env.TRUST_PROXY) {
@@ -96,6 +98,7 @@ export function createApp(deps: AppDeps = {}): express.Express {
   app.use(metricsMiddleware);
   app.use("/health", healthRouter);
   app.use("/healthz/dependencies", dependenciesRouter);
+  app.use("/api/health/ready", createReadyRouter({ db, redis: redisConnection }));
 
   const mutationMethods = ["POST", "PATCH"] as const;
   app.use("/api", (req, res, next) =>
@@ -138,7 +141,6 @@ export function createApp(deps: AppDeps = {}): express.Express {
 if (require.main === module) {
   const app = createApp();
   let webhookWorker: WebhookWorker | null = null;
-  let probeHandle: NodeJS.Timeout | null = null;
 
   const stopWorkers = async (): Promise<void> => {
     logger.info("Stopping queue workers");
@@ -172,7 +174,6 @@ if (require.main === module) {
           process.exit(1);
         }, 5000).unref();
 
-        if (probeHandle) stopIndexerHealthProbe(probeHandle);
         stopScheduler();
         await closeDb();
         clearTimeout(forceExit);
@@ -181,7 +182,6 @@ if (require.main === module) {
 
       process.on("SIGINT", () => {
         logger.info("SIGINT received, shutting down gracefully");
-        if (probeHandle) stopIndexerHealthProbe(probeHandle);
         stopScheduler();
         process.exit(0);
       });

--- a/src/routes/health/ready.ts
+++ b/src/routes/health/ready.ts
@@ -1,0 +1,118 @@
+/**
+ * health/ready.ts
+ *
+ * GET /api/health/ready — deep readiness check
+ *
+ * Probes all four runtime dependencies in parallel:
+ *  1. db          — Postgres (SELECT 1)
+ *  2. sorobanRpc  — Soroban RPC (getLatestLedger)
+ *  3. indexerLag  — compares indexer cursor to chain tip
+ *  4. queue       — Redis / BullMQ (PING)
+ *
+ * HTTP response codes
+ * ───────────────────
+ *  200 OK                  — all probes pass ("ready")
+ *  503 Service Unavailable — one or more probes fail ("unready")
+ *
+ * Response shape
+ * ──────────────
+ * {
+ *   "status":       "ready" | "unready",
+ *   "correlationId": "<uuid>",
+ *   "checkedAt":     "<ISO-8601>",
+ *   "checks": {
+ *     "db":         { "status": "pass"|"fail", "durationMs": <n>, "message": "…" },
+ *     "sorobanRpc": { … },
+ *     "indexerLag": { … },
+ *     "queue":      { … }
+ *   }
+ * }
+ *
+ * Security
+ * ────────
+ * No authentication required — the endpoint returns no sensitive data and is
+ * intended for Kubernetes liveness/readiness probes and load-balancer checks.
+ * In production, restrict access to internal network paths at the infra level.
+ *
+ * The response is NOT cached (unlike /healthz/dependencies) because readiness
+ * probes are used by orchestrators that need a fresh signal on every poll.
+ *
+ * Structured logging
+ * ──────────────────
+ * Each request logs at INFO level with:
+ *  - correlationId (from x-correlation-id header or generated UUID)
+ *  - overall status
+ *  - per-probe results
+ *  - total elapsed time
+ */
+
+import { Router, Request, Response } from "express";
+import { randomUUID } from "crypto";
+import { logger } from "../../config/logger";
+import {
+  performReadinessCheck,
+  type DbLike,
+  type RedisLike,
+} from "../../services/readinessService";
+
+// ── Injectable dependencies ───────────────────────────────────────────────────
+
+export interface ReadyRouterDeps {
+  /** Drizzle DB instance (or compatible test stub). */
+  db: DbLike;
+  /** IORedis connection used by BullMQ (or compatible test stub). */
+  redis: RedisLike;
+}
+
+// ── Router factory ────────────────────────────────────────────────────────────
+
+/**
+ * Creates the ready-check router with injected dependencies.
+ *
+ * Accepting deps as a parameter makes the router fully testable without
+ * touching real infrastructure.
+ */
+export function createReadyRouter(deps: ReadyRouterDeps): Router {
+  const router = Router();
+
+  /**
+   * GET /
+   *
+   * Runs all probes and returns 200 when ready, 503 when unready.
+   */
+  router.get("/", async (req: Request, res: Response, next) => {
+    const correlationId =
+      (req.headers["x-correlation-id"] as string | undefined)?.trim() ||
+      randomUUID();
+
+    const requestStart = Date.now();
+
+    try {
+      const result = await performReadinessCheck(deps.db, deps.redis);
+
+      const httpStatus = result.status === "ready" ? 200 : 503;
+
+      logger.info(
+        {
+          correlationId,
+          status: result.status,
+          checks: result.checks,
+          elapsedMs: Date.now() - requestStart,
+        },
+        "health_ready_check_complete",
+      );
+
+      res.status(httpStatus).json({
+        status: result.status,
+        correlationId,
+        checkedAt: new Date().toISOString(),
+        checks: result.checks,
+      });
+    } catch (err) {
+      // Unexpected error — propagate to the global error handler.
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/src/services/readinessService.ts
+++ b/src/services/readinessService.ts
@@ -1,162 +1,278 @@
+/**
+ * readinessService.ts
+ *
+ * Deep readiness probes used by GET /api/health/ready.
+ *
+ * Each probe is exported individually so they can be injected in tests without
+ * touching real infrastructure. The top-level `performReadinessCheck` function
+ * wires them together with the production dependencies.
+ *
+ * Probes
+ * ──────
+ *  • database    — lightweight SELECT 1 against the Postgres pool
+ *  • sorobanRpc  — getLatestLedger() call to the Soroban RPC node
+ *  • indexerLag  — compares indexer cursor to chain tip; fails when lag > threshold
+ *  • queue       — Redis PING via the BullMQ connection
+ *
+ * Each probe has a 1-second timeout to prevent a single slow dependency from
+ * blocking the readiness response. All four run in parallel via Promise.allSettled.
+ */
+
 import { env } from "../config/env";
 import { NodePgDatabase } from "drizzle-orm/node-postgres";
 import { logger } from "../config/logger";
 import * as sdk from "@stellar/stellar-sdk";
 import { sql } from "drizzle-orm";
 
+// ── Types ─────────────────────────────────────────────────────────────────────
+
 export interface ReadinessCheck {
   status: "pass" | "fail";
+  /** Elapsed milliseconds for the probe. */
+  durationMs: number;
   message: string;
-  timestamp: number;
 }
 
 export interface ReadinessStatus {
   db: ReadinessCheck;
   sorobanRpc: ReadinessCheck;
   indexerLag: ReadinessCheck;
+  queue: ReadinessCheck;
 }
 
 export interface ReadinessResult {
+  /** "ready" only when every probe passes. */
   status: "ready" | "unready";
   checks: ReadinessStatus;
 }
 
-async function checkDatabase(db: NodePgDatabase): Promise<ReadinessCheck> {
+// ── Injectable dependency interfaces ─────────────────────────────────────────
+
+/** Minimal Drizzle DB surface the DB probe needs. */
+export interface DbLike {
+  execute(query: unknown): Promise<unknown>;
+}
+
+/** Minimal Redis surface the queue probe needs. */
+export interface RedisLike {
+  ping(): Promise<string>;
+}
+
+// ── Timeout helper ────────────────────────────────────────────────────────────
+
+const PROBE_TIMEOUT_MS = 1_000;
+
+function withProbeTimeout<T>(p: Promise<T>): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error("Probe timed out")),
+        PROBE_TIMEOUT_MS,
+      ),
+    ),
+  ]);
+}
+
+// ── Individual probes ─────────────────────────────────────────────────────────
+
+/**
+ * Probe Postgres with a lightweight SELECT 1.
+ *
+ * @param db - Drizzle DB instance (or compatible test stub).
+ */
+export async function checkDatabase(db: DbLike): Promise<ReadinessCheck> {
   const start = Date.now();
   try {
-    await Promise.race([
-      db.execute(sql`SELECT 1`),
-      new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new Error("Database check timeout")), 1000);
-      }),
-    ]);
+    await withProbeTimeout(db.execute(sql`SELECT 1`));
     return {
       status: "pass",
+      durationMs: Date.now() - start,
       message: "Database connection healthy",
-      timestamp: Date.now() - start,
     };
   } catch (error) {
-    logger.error({ error }, "Database health check failed");
+    logger.error({ error }, "readiness_db_check_failed");
     return {
       status: "fail",
-      message: error instanceof Error ? error.message : "Database connection failed",
-      timestamp: Date.now() - start,
+      durationMs: Date.now() - start,
+      message:
+        error instanceof Error ? error.message : "Database connection failed",
     };
   }
 }
 
-async function checkSorobanRpc(): Promise<ReadinessCheck> {
+/**
+ * Probe the Soroban RPC node by calling getLatestLedger.
+ */
+export async function checkSorobanRpc(): Promise<ReadinessCheck> {
   const start = Date.now();
   try {
     const client = new sdk.SorobanRpc.Server(env.SOROBAN_RPC_URL, {
       allowHttp: env.STELLAR_NETWORK === "testnet",
     });
-
-    await Promise.race([
-      client.getHealth(),
-      new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new Error("Soroban RPC check timeout")), 1000);
-      }),
-    ]);
-
+    await withProbeTimeout(client.getLatestLedger());
     return {
       status: "pass",
+      durationMs: Date.now() - start,
       message: "Soroban RPC healthy",
-      timestamp: Date.now() - start,
     };
   } catch (error) {
-    logger.error({ error }, "Soroban RPC health check failed");
+    logger.error({ error }, "readiness_rpc_check_failed");
     return {
       status: "fail",
-      message: error instanceof Error ? error.message : "Soroban RPC failed",
-      timestamp: Date.now() - start,
+      durationMs: Date.now() - start,
+      message:
+        error instanceof Error ? error.message : "Soroban RPC failed",
     };
   }
 }
 
-async function checkIndexerLag(db: NodePgDatabase): Promise<ReadinessCheck> {
+/**
+ * Probe indexer lag by comparing the cursor in `indexer_cursor` to the chain
+ * tip returned by Soroban RPC. Fails when the absolute lag exceeds
+ * `READINESS_MAX_LAG_LEDGERS` (env, default 200).
+ *
+ * The SQL query is intentionally simple — it reads the `indexer_cursor` row
+ * and calls getLatestLedger() in parallel rather than attempting the complex
+ * ledger-entry query that requires a live Soroban contract state.
+ *
+ * @param db - Drizzle DB instance (or compatible test stub).
+ */
+export async function checkIndexerLag(db: DbLike): Promise<ReadinessCheck> {
   const start = Date.now();
   const maxLag = Number(process.env.READINESS_MAX_LAG_LEDGERS) || 200;
 
   try {
-    const { rows } = await Promise.race([
-      db.execute(sql`
-        WITH current_tip AS (
-          SELECT ledger
-          FROM soroban_get_ledger_entry(
-            '0x0000000000000000000000000000000000000000000000000000000000'
-          )
-          WHERE key = 'current'
-        ), latest_indexed AS (
-          SELECT last_ledger
-          FROM indexer_cursor
-          ORDER BY updated_at DESC
-          LIMIT 1
-        )
-        SELECT 
-          COALESCE(lt.ledger, 0) - COALESCE(li.last_ledger, 0) AS lag
-        FROM current_tip lt
-        CROSS JOIN latest_indexed li
-      `),
-      new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new Error("Indexer lag check timeout")), 1000);
-      }),
-    ]);
+    // Fetch both the cursor and the chain tip in parallel.
+    const rpcClient = new sdk.SorobanRpc.Server(env.SOROBAN_RPC_URL, {
+      allowHttp: env.STELLAR_NETWORK === "testnet",
+    });
 
-    const lag = Number(rows[0]?.lag) || 0;
+    const [cursorResult, ledgerResult] = await withProbeTimeout(
+      Promise.all([
+        (db as NodePgDatabase).execute(
+          sql`SELECT last_ledger FROM indexer_cursor WHERE id = 1 LIMIT 1`,
+        ),
+        rpcClient.getLatestLedger(),
+      ]),
+    );
+
+    // `cursorResult` is a Drizzle result with a `rows` array.
+    const rows = (cursorResult as unknown as { rows: Array<{ last_ledger: number }> }).rows;
+    const lastIndexed = rows[0]?.last_ledger ?? null;
+    const chainTip = ledgerResult.sequence;
+
+    if (lastIndexed === null) {
+      return {
+        status: "fail",
+        durationMs: Date.now() - start,
+        message: "Indexer cursor not found — indexer may not have started",
+      };
+    }
+
+    const lag = Math.max(0, chainTip - lastIndexed);
 
     if (lag <= maxLag) {
       return {
         status: "pass",
-        message: `Indexer lag healthy: ${lag} ≤ ${maxLag}`,
-        timestamp: Date.now() - start,
-      };
-    } else {
-      return {
-        status: "fail",
-        message: `Indexer lag too high: ${lag} > ${maxLag}`,
-        timestamp: Date.now() - start,
+        durationMs: Date.now() - start,
+        message: `Indexer lag healthy: ${lag} ≤ ${maxLag} ledgers`,
       };
     }
-  } catch (error) {
-    logger.error({ error }, "Indexer lag health check failed");
+
     return {
       status: "fail",
-      message: error instanceof Error ? error.message : "Indexer lag check failed",
-      timestamp: Date.now() - start,
+      durationMs: Date.now() - start,
+      message: `Indexer lag too high: ${lag} > ${maxLag} ledgers`,
+    };
+  } catch (error) {
+    logger.error({ error }, "readiness_indexer_lag_check_failed");
+    return {
+      status: "fail",
+      durationMs: Date.now() - start,
+      message:
+        error instanceof Error ? error.message : "Indexer lag check failed",
     };
   }
 }
 
-export async function performReadinessCheck(db: NodePgDatabase): Promise<ReadinessResult> {
-  const checks = await Promise.allSettled([
-    checkDatabase(db),
-    checkSorobanRpc(),
-    checkIndexerLag(db),
-  ]);
+/**
+ * Probe the BullMQ Redis connection with a PING.
+ *
+ * @param redis - IORedis-compatible connection (or compatible test stub).
+ */
+export async function checkQueue(redis: RedisLike): Promise<ReadinessCheck> {
+  const start = Date.now();
+  try {
+    const pong = await withProbeTimeout(redis.ping());
+    if (pong !== "PONG") {
+      return {
+        status: "fail",
+        durationMs: Date.now() - start,
+        message: `Unexpected Redis PING response: ${pong}`,
+      };
+    }
+    return {
+      status: "pass",
+      durationMs: Date.now() - start,
+      message: "Queue (Redis) healthy",
+    };
+  } catch (error) {
+    logger.error({ error }, "readiness_queue_check_failed");
+    return {
+      status: "fail",
+      durationMs: Date.now() - start,
+      message:
+        error instanceof Error ? error.message : "Queue (Redis) connection failed",
+    };
+  }
+}
 
-  const results = {
-    db: checks[0].status === "fulfilled" ? checks[0].value : {
-      status: "fail",
-      message: "Database check failed",
-      timestamp: Date.now(),
-    },
-    sorobanRpc: checks[1].status === "fulfilled" ? checks[1].value : {
-      status: "fail",
-      message: "Soroban RPC check failed",
-      timestamp: Date.now(),
-    },
-    indexerLag: checks[2].status === "fulfilled" ? checks[2].value : {
-      status: "fail",
-      message: "Indexer lag check failed",
-      timestamp: Date.now(),
-    },
-  } as ReadinessStatus;
+// ── Top-level orchestrator ────────────────────────────────────────────────────
 
-  const ready = results.db.status === "pass" && results.sorobanRpc.status === "pass" && results.indexerLag.status === "pass";
+/**
+ * Run all four readiness probes in parallel and return a consolidated result.
+ *
+ * A failed `Promise.allSettled` branch (i.e. an unexpected throw that bypasses
+ * the probe's own try/catch) is mapped to a generic "fail" check so the
+ * overall response always has a consistent shape.
+ *
+ * @param db    - Drizzle DB instance wired to the Postgres pool.
+ * @param redis - IORedis connection used by BullMQ.
+ */
+export async function performReadinessCheck(
+  db: DbLike,
+  redis: RedisLike,
+): Promise<ReadinessResult> {
+  const [dbResult, rpcResult, lagResult, queueResult] =
+    await Promise.allSettled([
+      checkDatabase(db),
+      checkSorobanRpc(),
+      checkIndexerLag(db),
+      checkQueue(redis),
+    ]);
+
+  const now = Date.now();
+
+  function unwrap(
+    settled: PromiseSettledResult<ReadinessCheck>,
+    fallbackMessage: string,
+  ): ReadinessCheck {
+    if (settled.status === "fulfilled") return settled.value;
+    return { status: "fail", durationMs: now, message: fallbackMessage };
+  }
+
+  const checks: ReadinessStatus = {
+    db: unwrap(dbResult, "Database check threw unexpectedly"),
+    sorobanRpc: unwrap(rpcResult, "Soroban RPC check threw unexpectedly"),
+    indexerLag: unwrap(lagResult, "Indexer lag check threw unexpectedly"),
+    queue: unwrap(queueResult, "Queue check threw unexpectedly"),
+  };
+
+  const ready = Object.values(checks).every((c) => c.status === "pass");
 
   return {
     status: ready ? "ready" : "unready",
-    checks: results,
+    checks,
   };
 }

--- a/tests/healthReady.test.ts
+++ b/tests/healthReady.test.ts
@@ -1,0 +1,456 @@
+/**
+ * healthReady.test.ts
+ *
+ * Tests for GET /api/health/ready.
+ *
+ * All external I/O is replaced by in-memory stubs — no real DB, Redis, or
+ * Soroban RPC connection is required. The service layer is exercised directly
+ * (unit tests) and the HTTP layer is exercised via supertest (integration tests).
+ *
+ * Coverage targets
+ * ────────────────
+ *  • All four probes: db, sorobanRpc, indexerLag, queue
+ *  • 200 when all pass / 503 when any fail
+ *  • Response shape: status, correlationId, checkedAt, checks
+ *  • correlationId echo + UUID generation
+ *  • Individual probe failure isolation
+ *  • Timeout / unexpected-throw handling
+ *  • No authentication required
+ *  • Structured logging output
+ */
+
+// ── Env stubs (must come before any src/ imports) ────────────────────────────
+
+process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
+process.env.JWT_SECRET = "abcdefghijklmnopqrstuvwxyz123456789012";
+process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "test-contract-id";
+process.env.REDIS_URL = "redis://localhost:6379";
+
+// ── Mocks (must come before createApp / route imports) ───────────────────────
+
+// Prevent real DB pool from being opened.
+jest.mock("../src/db/client", () => ({
+  db: {},
+  pool: {
+    totalCount: 0,
+    idleCount: 0,
+    waitingCount: 0,
+    query: jest.fn().mockResolvedValue({ rows: [] }),
+  },
+  connectWithRetry: jest.fn().mockResolvedValue(undefined),
+  closeDb: jest.fn().mockResolvedValue(undefined),
+  getDb: jest.fn().mockReturnValue({}),
+  getPool: jest.fn().mockReturnValue({
+    query: jest.fn().mockResolvedValue({ rows: [] }),
+  }),
+  setDbForTests: jest.fn(),
+}));
+
+// Prevent real Redis connection from being opened.
+jest.mock("../src/queue", () => ({
+  redisConnection: { ping: jest.fn().mockResolvedValue("PONG") },
+  webhookQueue: { add: jest.fn() },
+  backupVerificationQueue: { add: jest.fn() },
+  reconciliationQueue: { add: jest.fn() },
+  marketResolutionQueue: { add: jest.fn() },
+  webhookQueueName: "webhook-deliveries",
+  backupVerificationQueueName: "backup-verification",
+  reconciliationQueueName: "reconciliation",
+  marketResolutionQueueName: "market-resolution",
+}));
+
+// Prevent real Soroban RPC calls from the route — we mock the service layer.
+jest.mock("../src/services/readinessService");
+
+import request from "supertest";
+import express from "express";
+import { errorHandler } from "../src/middleware/errorHandler";
+import { createReadyRouter } from "../src/routes/health/ready";
+import {
+  performReadinessCheck,
+  type DbLike,
+  type RedisLike,
+  type ReadinessResult,
+} from "../src/services/readinessService";
+
+// ── Stub helpers ──────────────────────────────────────────────────────────────
+
+/** A db stub that resolves immediately. */
+function makeDb(overrides: Partial<DbLike> = {}): DbLike {
+  return {
+    execute: jest.fn().mockResolvedValue({ rows: [] }),
+    ...overrides,
+  };
+}
+
+/** A redis stub that responds PONG. */
+function makeRedis(pongResponse = "PONG"): RedisLike {
+  return {
+    ping: jest.fn().mockResolvedValue(pongResponse),
+  };
+}
+
+/** A fully-passing ReadinessResult fixture. */
+function allPass(): ReadinessResult {
+  return {
+    status: "ready",
+    checks: {
+      db: { status: "pass", durationMs: 5, message: "Database connection healthy" },
+      sorobanRpc: { status: "pass", durationMs: 10, message: "Soroban RPC healthy" },
+      indexerLag: { status: "pass", durationMs: 8, message: "Indexer lag healthy: 50 ≤ 200 ledgers" },
+      queue: { status: "pass", durationMs: 2, message: "Queue (Redis) healthy" },
+    },
+  };
+}
+
+/** A result where one probe has failed. */
+function oneFailure(probe: keyof ReadinessResult["checks"]): ReadinessResult {
+  const result = allPass();
+  result.status = "unready";
+  result.checks[probe] = {
+    status: "fail",
+    durationMs: 1001,
+    message: "Probe timed out",
+  };
+  return result;
+}
+
+// ── Minimal Express app for HTTP tests ───────────────────────────────────────
+
+function makeApp(db = makeDb(), redis = makeRedis()): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/health/ready", createReadyRouter({ db, redis }));
+  app.use(errorHandler);
+  return app;
+}
+
+// Cast the module mock so TypeScript is happy.
+const mockPerform = performReadinessCheck as jest.MockedFunction<
+  typeof performReadinessCheck
+>;
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Service unit tests (probe functions are mocked at module boundary)
+// We test them individually here using real implementations via jest.requireActual
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("readinessService — individual probes (unit)", () => {
+  // Use real implementations for this block.
+  const real = jest.requireActual<typeof import("../src/services/readinessService")>(
+    "../src/services/readinessService",
+  );
+
+  describe("checkDatabase", () => {
+    it("returns pass when execute resolves", async () => {
+      const db = makeDb();
+      const result = await real.checkDatabase(db);
+      expect(result.status).toBe("pass");
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+      expect(result.message).toContain("healthy");
+    });
+
+    it("returns fail when execute rejects", async () => {
+      const db = makeDb({
+        execute: jest.fn().mockRejectedValue(new Error("connection refused")),
+      });
+      const result = await real.checkDatabase(db);
+      expect(result.status).toBe("fail");
+      expect(result.message).toContain("connection refused");
+    });
+
+    it("returns fail on timeout (slow execute)", async () => {
+      // Simulate a probe that never resolves — the 1-second timeout should fire.
+      // We advance fake timers so the test doesn't actually wait 1 s.
+      jest.useFakeTimers();
+
+      const db = makeDb({
+        execute: jest.fn().mockImplementation(
+          () => new Promise(() => { /* never resolves */ }),
+        ),
+      });
+
+      const promise = real.checkDatabase(db);
+      jest.advanceTimersByTime(1100);
+      const result = await promise;
+
+      expect(result.status).toBe("fail");
+      expect(result.message).toContain("timed out");
+
+      jest.useRealTimers();
+    });
+  });
+
+  describe("checkQueue", () => {
+    it("returns pass when Redis responds PONG", async () => {
+      const result = await real.checkQueue(makeRedis("PONG"));
+      expect(result.status).toBe("pass");
+      expect(result.message).toContain("healthy");
+    });
+
+    it("returns fail when Redis responds with unexpected value", async () => {
+      const result = await real.checkQueue(makeRedis("NOPE"));
+      expect(result.status).toBe("fail");
+      expect(result.message).toContain("NOPE");
+    });
+
+    it("returns fail when Redis ping rejects", async () => {
+      const redis: RedisLike = {
+        ping: jest.fn().mockRejectedValue(new Error("ECONNREFUSED")),
+      };
+      const result = await real.checkQueue(redis);
+      expect(result.status).toBe("fail");
+      expect(result.message).toContain("ECONNREFUSED");
+    });
+
+    it("returns fail on timeout", async () => {
+      jest.useFakeTimers();
+
+      const redis: RedisLike = {
+        ping: jest.fn().mockImplementation(
+          () => new Promise(() => { /* never resolves */ }),
+        ),
+      };
+
+      const promise = real.checkQueue(redis);
+      jest.advanceTimersByTime(1100);
+      const result = await promise;
+
+      expect(result.status).toBe("fail");
+      expect(result.message).toContain("timed out");
+
+      jest.useRealTimers();
+    });
+  });
+
+  describe("performReadinessCheck", () => {
+    // For these tests we mock the Soroban SDK at the module level so no real
+    // network call is made, and we control db/redis via injected stubs.
+
+    beforeEach(() => {
+      // Mock the entire Stellar SDK so checkSorobanRpc and checkIndexerLag
+      // don't try to hit the real RPC.
+      jest.doMock("@stellar/stellar-sdk", () => ({
+        SorobanRpc: {
+          Server: jest.fn().mockImplementation(() => ({
+            getLatestLedger: jest.fn().mockResolvedValue({ sequence: 1100 }),
+          })),
+        },
+      }));
+    });
+
+    afterEach(() => {
+      jest.dontMock("@stellar/stellar-sdk");
+    });
+
+    it("returns ready when db and redis pass (rpc/indexer may vary)", async () => {
+      const db = makeDb();
+      const redis = makeRedis("PONG");
+
+      const result = await real.performReadinessCheck(db, redis);
+
+      // db and queue must pass; overall result depends on RPC reachability in CI
+      expect(result.checks.db.status).toBe("pass");
+      expect(result.checks.queue.status).toBe("pass");
+      expect(result).toHaveProperty("status");
+      expect(result).toHaveProperty("checks");
+    });
+
+    it("returns unready when db probe fails", async () => {
+      const db = makeDb({
+        execute: jest.fn().mockRejectedValue(new Error("DB down")),
+      });
+      const redis = makeRedis("PONG");
+
+      const result = await real.performReadinessCheck(db, redis);
+
+      expect(result.status).toBe("unready");
+      expect(result.checks.db.status).toBe("fail");
+    });
+
+    it("returns unready when queue probe fails", async () => {
+      const db = makeDb();
+      const redis: RedisLike = {
+        ping: jest.fn().mockRejectedValue(new Error("Redis down")),
+      };
+
+      const result = await real.performReadinessCheck(db, redis);
+
+      expect(result.status).toBe("unready");
+      expect(result.checks.queue.status).toBe("fail");
+    });
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// HTTP integration tests (service layer fully mocked)
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("GET /api/health/ready — HTTP", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── 200 OK ──────────────────────────────────────────────────────────────────
+
+  it("returns 200 when all probes pass", async () => {
+    mockPerform.mockResolvedValue(allPass());
+
+    const res = await request(makeApp()).get("/api/health/ready");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("ready");
+  });
+
+  it("returns all four checks in the body", async () => {
+    mockPerform.mockResolvedValue(allPass());
+
+    const res = await request(makeApp()).get("/api/health/ready");
+
+    expect(res.body.checks).toHaveProperty("db");
+    expect(res.body.checks).toHaveProperty("sorobanRpc");
+    expect(res.body.checks).toHaveProperty("indexerLag");
+    expect(res.body.checks).toHaveProperty("queue");
+  });
+
+  it("each check has status, durationMs, and message", async () => {
+    mockPerform.mockResolvedValue(allPass());
+
+    const res = await request(makeApp()).get("/api/health/ready");
+
+    for (const check of Object.values(res.body.checks as Record<string, unknown>)) {
+      expect(check).toMatchObject({
+        status: expect.stringMatching(/^(pass|fail)$/),
+        durationMs: expect.any(Number),
+        message: expect.any(String),
+      });
+    }
+  });
+
+  // ── 503 Unavailable ──────────────────────────────────────────────────────────
+
+  it("returns 503 when db probe fails", async () => {
+    mockPerform.mockResolvedValue(oneFailure("db"));
+
+    const res = await request(makeApp()).get("/api/health/ready");
+
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe("unready");
+    expect(res.body.checks.db.status).toBe("fail");
+  });
+
+  it("returns 503 when sorobanRpc probe fails", async () => {
+    mockPerform.mockResolvedValue(oneFailure("sorobanRpc"));
+
+    const res = await request(makeApp()).get("/api/health/ready");
+
+    expect(res.status).toBe(503);
+    expect(res.body.checks.sorobanRpc.status).toBe("fail");
+  });
+
+  it("returns 503 when indexerLag probe fails", async () => {
+    mockPerform.mockResolvedValue(oneFailure("indexerLag"));
+
+    const res = await request(makeApp()).get("/api/health/ready");
+
+    expect(res.status).toBe(503);
+    expect(res.body.checks.indexerLag.status).toBe("fail");
+  });
+
+  it("returns 503 when queue probe fails", async () => {
+    mockPerform.mockResolvedValue(oneFailure("queue"));
+
+    const res = await request(makeApp()).get("/api/health/ready");
+
+    expect(res.status).toBe(503);
+    expect(res.body.checks.queue.status).toBe("fail");
+  });
+
+  it("returns 503 when all probes fail", async () => {
+    mockPerform.mockResolvedValue({
+      status: "unready",
+      checks: {
+        db: { status: "fail", durationMs: 1001, message: "DB down" },
+        sorobanRpc: { status: "fail", durationMs: 1001, message: "RPC down" },
+        indexerLag: { status: "fail", durationMs: 1001, message: "Lag too high" },
+        queue: { status: "fail", durationMs: 1001, message: "Redis down" },
+      },
+    });
+
+    const res = await request(makeApp()).get("/api/health/ready");
+
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe("unready");
+  });
+
+  // ── correlationId ─────────────────────────────────────────────────────────────
+
+  it("echoes x-correlation-id from request header", async () => {
+    mockPerform.mockResolvedValue(allPass());
+    const id = "my-custom-correlation-id";
+
+    const res = await request(makeApp())
+      .get("/api/health/ready")
+      .set("x-correlation-id", id);
+
+    expect(res.body.correlationId).toBe(id);
+  });
+
+  it("generates a UUID correlationId when header is absent", async () => {
+    mockPerform.mockResolvedValue(allPass());
+
+    const res = await request(makeApp()).get("/api/health/ready");
+
+    expect(res.body.correlationId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  // ── checkedAt ─────────────────────────────────────────────────────────────────
+
+  it("includes a valid ISO-8601 checkedAt timestamp", async () => {
+    mockPerform.mockResolvedValue(allPass());
+
+    const before = new Date();
+    const res = await request(makeApp()).get("/api/health/ready");
+    const after = new Date();
+
+    const checkedAt = new Date(res.body.checkedAt);
+    expect(checkedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(checkedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+  });
+
+  // ── No auth required ─────────────────────────────────────────────────────────
+
+  it("does not require authentication — no Authorization header needed", async () => {
+    mockPerform.mockResolvedValue(allPass());
+
+    const res = await request(makeApp()).get("/api/health/ready");
+
+    // Must not be 401 or 403.
+    expect(res.status).toBe(200);
+  });
+
+  // ── Error propagation ─────────────────────────────────────────────────────────
+
+  it("propagates unexpected service errors to the error handler", async () => {
+    mockPerform.mockRejectedValue(new Error("unexpected internal error"));
+
+    const res = await request(makeApp()).get("/api/health/ready");
+
+    // The error handler will turn this into a 500.
+    expect(res.status).toBe(500);
+  });
+
+  // ── Response Content-Type ─────────────────────────────────────────────────────
+
+  it("responds with application/json content type", async () => {
+    mockPerform.mockResolvedValue(allPass());
+
+    const res = await request(makeApp()).get("/api/health/ready");
+
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+  });
+});


### PR DESCRIPTION
closes #296 

Implements GET /api/health/ready with four parallel probes:
- db: Postgres SELECT 1 with 1s timeout
- sorobanRpc: getLatestLedger() with 1s timeout
- indexerLag: cursor vs chain tip, fails when lag > READINESS_MAX_LAG_LEDGERS
- queue: Redis PING via BullMQ connection with 1s timeout

Returns 200 (ready) or 503 (unready). Not cached — intended for Kubernetes/ECS readiness probes that need a fresh signal every poll.

Also fixes pre-existing compile errors:
- src/config/env.ts was a corrupted partial file; restored proper export
- src/config/env-schema.ts was missing SLOW_QUERY_ALERTER_* fields
- src/index.ts was missing devicesRouter import and had dead probeHandle var

Tests: 24/24 pass (src/routes/health/ready.ts + src/services/readinessService.ts)
Docs: docs/health-ready.md runbook + README health endpoints table