### PR TITLE
feat: admin rate-limit inspect

### DIFF
--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -35,6 +35,27 @@ HTTP **429 Too Many Requests** with:
 for the caller's IP. Authenticated callers (Bearer token) receive a
 `bypasses: true` response.
 
+## Admin inspection endpoint
+
+`GET /api/admin/rate-limit/inspect/:address` is an admin-only read-only
+inspection endpoint for a target Stellar address. It returns the current
+sliding-window usage, remaining quota, and reset timestamp for the address.
+
+### Response (200)
+
+```json
+{
+  "data": {
+    "address": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "limit": 60,
+    "used": 3,
+    "remaining": 57,
+    "windowMs": 60000,
+    "resetAt": "2026-07-24T12:00:00.000Z"
+  }
+}
+```
+
 ### Anonymous response (200)
 
 ```json

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import { marketResolverWorker } from "./workers/marketResolver";
 import { backupVerificationWorker } from "./workers/backupVerificationWorker";
 import { reconciliationWorker } from "./workers/reconciliationWorker";
 import { rateLimitStatusRouter } from "./routes/rate-limit/status";
+import { adminRateLimitInspectRouter } from "./routes/admin/rate-limit/inspect";
 import { startSlowQueryAlerter, stopSlowQueryAlerter } from "./workers/slowQueryAlerter";
 
 const docsEnabled = env.NODE_ENV !== "production" || process.env.ENABLE_DOCS === "true";
@@ -120,6 +121,7 @@ export function createApp(deps: AppDeps = {}): express.Express {
   app.use("/api/admin/markets", adminMarketsRouter);
   app.use("/api/admin/db/explain", adminDbExplainRouter);
   app.use("/api/admin/schema-versions", adminSchemaVersionsRouter);
+  app.use("/api/admin/rate-limit", adminRateLimitInspectRouter);
 
   app.get("/metrics", async (req, res) => {
     const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;

--- a/src/openapi/registry.ts
+++ b/src/openapi/registry.ts
@@ -1077,6 +1077,49 @@ registry.registerPath({
   },
 });
 
+// ── /api/admin/rate-limit/inspect/:address ─────────────────────────────────
+
+const AdminRateLimitInspect = z
+  .object({
+    address: z.string().describe("Target Stellar address"),
+    limit: z.number().int().describe("Configured request cap in the window"),
+    used: z.number().int().describe("Requests currently active in the window"),
+    remaining: z.number().int().describe("Requests remaining in the current window"),
+    windowMs: z.number().int().describe("Sliding-window length in milliseconds"),
+    resetAt: z.string().datetime().describe("ISO-8601 timestamp when the window resets"),
+  })
+  .openapi("AdminRateLimitInspect");
+
+registry.registerPath({
+  method: "get",
+  path: "/api/admin/rate-limit/inspect/{address}",
+  operationId: "inspectAdminRateLimit",
+  tags: ["Admin"],
+  summary: "Inspect current rate-limit state for an address (admin only)",
+  description:
+    "Returns the current sliding-window rate-limit usage for a target Stellar address. " +
+    "Admin-only and read-only.",
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: "Current rate-limit state for the requested address",
+      content: { "application/json": { schema: z.object({ data: AdminRateLimitInspect }) } },
+    },
+    400: {
+      description: "Validation error",
+      content: { "application/json": { schema: ValidationErrorBody } },
+    },
+    403: {
+      description: "Forbidden — missing or non-admin JWT",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    429: {
+      description: "Rate limit exceeded",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+  },
+});
+
 // ── /api/admin/health/detail ─────────────────────────────────────────────────
 
 const CheckStatus = z

--- a/src/routes/admin/rate-limit/inspect.ts
+++ b/src/routes/admin/rate-limit/inspect.ts
@@ -1,0 +1,105 @@
+/**
+ * Admin rate-limit inspect router.
+ *
+ * GET /api/admin/rate-limit/inspect/:address
+ *
+ * Returns the current rate-limit usage for a target Stellar address.
+ * The endpoint is admin-only and rate-limited per admin token.
+ */
+
+import { Router } from "express";
+import { rateLimit } from "express-rate-limit";
+import { z } from "zod";
+import { requireAdmin } from "../../../middleware/requireAdmin";
+import { SlidingWindowStore } from "../../../middleware/rateLimitAnon";
+import { getRequestId } from "../../../lib/requestContext";
+import { logger } from "../../../config/logger";
+
+export interface AdminRateLimitInspectRouterOptions {
+  /** Requests per minute per admin token. Default: 60 */
+  rateLimitPerMinute?: number;
+  /** Sliding window length in milliseconds. Default: 60_000 */
+  windowMs?: number;
+  /** Max requests in the window. Default: 60 */
+  max?: number;
+  /** Store used to track per-address usage. */
+  store?: SlidingWindowStore;
+}
+
+const stellarAddressSchema = z
+  .string()
+  .regex(/^G[A-Z2-7]{55}$/, "Invalid Stellar address");
+
+function validationError(res: import("express").Response, message: string): void {
+  res.status(400).json({
+    error: { code: "validation_error", message, requestId: getRequestId() },
+  });
+}
+
+export function createAdminRateLimitInspectRouter(
+  opts: AdminRateLimitInspectRouterOptions = {},
+): Router {
+  const router = Router();
+  const limit = opts.rateLimitPerMinute ?? 60;
+  const windowMs = opts.windowMs ?? 60_000;
+  const max = opts.max ?? 60;
+  const store = opts.store ?? new SlidingWindowStore();
+
+  router.use(
+    rateLimit({
+      windowMs: 60_000,
+      limit,
+      keyGenerator: (req) =>
+        (req.headers.authorization as string | undefined) ?? req.ip ?? "unknown",
+      standardHeaders: "draft-6",
+      legacyHeaders: false,
+      message: { error: { code: "rate_limit_exceeded" } },
+    }),
+  );
+
+  router.use(requireAdmin);
+
+  router.get("/inspect/:address", (req, res) => {
+    const parsed = stellarAddressSchema.safeParse(req.params.address);
+    if (!parsed.success) {
+      return validationError(res, parsed.error.issues[0]?.message ?? "invalid stellar address");
+    }
+
+    const now = Date.now();
+    const active = store.getTimestamps(parsed.data, now, windowMs);
+    const used = active.length;
+    const remaining = Math.max(0, max - used);
+    const resetAt =
+      used > 0 ? new Date(active[0]! + windowMs).toISOString() : new Date(now + windowMs).toISOString();
+
+    logger.info(
+      {
+        reqId: getRequestId(),
+        actor: req.adminAddress,
+        address: parsed.data,
+        used,
+        remaining,
+        windowMs,
+        max,
+      },
+      "admin_rate_limit_inspect",
+    );
+
+    return res.json({
+      data: {
+        address: parsed.data,
+        limit: max,
+        used,
+        remaining,
+        windowMs,
+        resetAt,
+      },
+    });
+  });
+
+  return router;
+}
+
+export const adminRateLimitInspectStore = new SlidingWindowStore();
+
+export const adminRateLimitInspectRouter = createAdminRateLimitInspectRouter();

--- a/tests/adminRateLimitInspect.test.ts
+++ b/tests/adminRateLimitInspect.test.ts
@@ -1,0 +1,96 @@
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { errorHandler } from "../src/middleware/errorHandler";
+import {
+  adminRateLimitInspectStore,
+  createAdminRateLimitInspectRouter,
+} from "../src/routes/admin/rate-limit/inspect";
+import { requestContextStorage } from "../src/lib/requestContext";
+
+const SECRET = process.env.JWT_SECRET!;
+const ISSUER = process.env.JWT_ISSUER ?? "predictify";
+const AUDIENCE = process.env.JWT_AUDIENCE ?? "predictify-app";
+const ADMIN_ADDR = "GADMIN0000000000000000000000000000000000000000000000000000";
+const USER_ADDR = "GUSER00000000000000000000000000000000000000000000000000000";
+const TARGET_ADDR = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+function sign(payload: object): string {
+  return jwt.sign(payload, SECRET, {
+    issuer: ISSUER,
+    audience: AUDIENCE,
+    expiresIn: "1h",
+  });
+}
+
+const adminToken = sign({ sub: ADMIN_ADDR, role: "admin" });
+const userToken = sign({ sub: USER_ADDR, role: "user" });
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((_req, _res, next) => {
+    requestContextStorage.run({ requestId: "test-req-id" }, next);
+  });
+  app.use(
+    "/api/admin/rate-limit",
+    createAdminRateLimitInspectRouter({
+      windowMs: 60_000,
+      max: 5,
+      store: adminRateLimitInspectStore,
+    }),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+describe("GET /api/admin/rate-limit/inspect/:address", () => {
+  beforeEach(() => {
+    adminRateLimitInspectStore.clear();
+  });
+
+  it("returns 403 with no Authorization header", async () => {
+    const res = await request(makeApp()).get(`/api/admin/rate-limit/inspect/${TARGET_ADDR}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 for a non-admin JWT", async () => {
+    const res = await request(makeApp())
+      .get(`/api/admin/rate-limit/inspect/${TARGET_ADDR}`)
+      .set("Authorization", `Bearer ${userToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for an invalid Stellar address", async () => {
+    const res = await request(makeApp())
+      .get("/api/admin/rate-limit/inspect/not-an-address")
+      .set("Authorization", `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("returns the current inspection state for a valid admin request", async () => {
+    const now = Date.now();
+    adminRateLimitInspectStore.record(TARGET_ADDR, now, 60_000);
+    adminRateLimitInspectStore.record(TARGET_ADDR, now + 1000, 60_000);
+
+    const res = await request(makeApp())
+      .get(`/api/admin/rate-limit/inspect/${TARGET_ADDR}`)
+      .set("Authorization", `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      data: {
+        address: TARGET_ADDR,
+        limit: 5,
+        used: 2,
+        remaining: 3,
+        windowMs: 60000,
+      },
+    });
+    expect(typeof res.body.data.resetAt).toBe("string");
+  });
+});


### PR DESCRIPTION
Added the admin-only inspect route in src/routes/admin/rate-limit/inspect.ts
Mounted it in src/index.ts
Recorded the API surface in src/openapi/registry.ts
Added focused regression coverage in tests/adminRateLimitInspect.test.ts
Documented the visible behavior in docs/rate-limiting.md
#322 closed