### PR TITLE
feat: CSRF middleware

### DIFF
--- a/docs/csrf.md
+++ b/docs/csrf.md
@@ -1,0 +1,148 @@
+# CSRF Protection
+
+## Status: forward-looking, not an active fix
+
+**Read this before assuming this middleware closes a live vulnerability.**
+
+CSRF is a risk specifically for browser-managed, ambient credentials —
+cookies, which the browser attaches to cross-site requests automatically.
+A bearer token in an `Authorization` header, or a token round-tripped in
+a request body, does not have this property.
+
+As confirmed against this codebase's actual routes and services
+(`src/routes/auth.ts`, `src/services/authVerifyService.ts`,
+`src/middleware/auth.ts`), **every current auth flow issues and reads
+tokens via response/request bodies and the `Authorization` header. No
+route sets a session cookie.** `POST /api/auth/verify` returns
+`{ accessToken, expiresIn }` in the JSON body; `POST /api/auth/refresh`
+and `POST /api/auth/logout` take `refreshToken` in the request body.
+None of this is CSRF-exploitable.
+
+This middleware is added as groundwork per issue #310, and is designed
+to activate automatically — with no further code changes — if a
+cookie-based session is introduced later (e.g. by future wallet-auth
+work). Until then, it is a deliberate no-op on every real request this
+service handles.
+
+## How it works — double-submit cookie pattern
+
+1. `issueCsrfToken` middleware sets a random token in a cookie
+   (`CSRF_COOKIE_NAME`, default `csrf_token`). Intentionally **not**
+   `httpOnly`, so client-side JS can read its value.
+2. The client echoes that value back in a request header
+   (`CSRF_HEADER_NAME`, default `X-CSRF-Token`) on state-changing
+   requests.
+3. `verifyCsrfToken`, mounted on mutating routes, checks the cookie and
+   header match (constant-time comparison) before allowing the request
+   through.
+4. A cross-site attacker's page can trigger the cookie to be sent
+   automatically, but cannot read its value or set the custom header
+   for the victim — so a forged request fails the check.
+
+Stateless: no server-side token store required.
+
+### When the middleware no-ops
+
+- **Safe methods** (`GET`, `HEAD`, `OPTIONS`) always pass through.
+- **Requests with no `SESSION_COOKIE_NAME` cookie present** always pass
+  through — which, per the status note above, is every request this
+  service currently handles.
+
+## Integration requirements (read before wiring this in)
+
+Confirmed against the real `src/index.ts`:
+
+1. **`cookie-parser` is not currently mounted in `createApp()`.** Nothing
+   needs it today, since no route reads or sets cookies. If/when a
+   cookie-based session is introduced, add
+   `app.use(cookieParser())` in `createApp()` **before** any route using
+   `issueCsrfToken`/`verifyCsrfToken` — otherwise `req.cookies` is
+   `undefined` and this middleware silently no-ops on every request.
+2. **Correlation IDs come from `requestContextStorage`** (`src/lib/requestContext.ts`),
+   which `createApp()` populates with `{ requestId }` for every request,
+   derived from `pino-http`'s `genReqId`. `csrf.ts` reads
+   `requestContextStorage.getStore()?.requestId` directly, so CSRF
+   rejections carry the same correlation ID as every other log line and
+   error response for that request — no separate ID-derivation logic.
+
+## Usage
+
+```ts
+import cookieParser from "cookie-parser"; // add this if not already present
+import { issueCsrfToken, verifyCsrfToken } from "./middleware/csrf";
+
+app.use(cookieParser());
+
+// If/when a cookie-based session is introduced:
+app.post("/login", issueCsrfToken, loginHandler);
+app.get("/csrf-token", issueCsrfToken, (req, res) => res.sendStatus(204));
+
+app.post("/predictions", verifyCsrfToken, createPredictionHandler);
+app.delete("/predictions/:id", verifyCsrfToken, deletePredictionHandler);
+```
+
+Requires `cookie-parser` mounted upstream so `req.cookies` is populated.
+
+## Configuration
+
+All new env vars are validated via the existing zod env schema and have
+defaults — no `.env` change is required.
+
+| Variable                | Default        | Description                                                      |
+|-------------------------|-----------------|--------------------------------------------------------------------|
+| `CSRF_COOKIE_NAME`       | `csrf_token`    | Name of the CSRF token cookie (non-`httpOnly`).                     |
+| `CSRF_HEADER_NAME`       | `x-csrf-token`  | Header clients must echo the token back in.                        |
+| `CSRF_TOKEN_TTL_SECONDS` | `7200`          | Lifetime of an issued CSRF token cookie, in seconds.                |
+| `SESSION_COOKIE_NAME`    | `session`       | Cookie name whose presence triggers enforcement. Not currently set by any route — see status note above. |
+
+## Error response
+
+Rejections use the existing `RouteError`/error-handling conventions
+(`kind: "Forbidden"`, HTTP 403). Confirmed against the real
+`errorHandler`, the response body is:
+
+```json
+{
+  "error": {
+    "code": "Forbidden",
+    "message": "CSRF token missing or invalid",
+    "correlationId": "e92d11fd-5c90-442c-97c8-d137873d9f6e",
+    "requestId": "e92d11fd-5c90-442c-97c8-d137873d9f6e"
+  }
+}
+```
+
+Rejections are logged (pino, `warn` level) with the correlation ID,
+request path/method, and a machine-readable `reason`
+(`missing_csrf_cookie` | `missing_csrf_header` | `csrf_token_mismatch`).
+
+## Deployment notes (for whenever a session cookie is introduced)
+
+- `NODE_ENV=production` marks the CSRF cookie `Secure` (HTTPS only).
+- The session cookie itself should use `SameSite=Lax`/`Strict` and
+  `httpOnly: true`. This middleware only checks for the session
+  cookie's *presence*; the session cookie's own security configuration
+  is what determines real-world exposure.
+
+## Testing
+
+`tests/security/csrf.test.ts` tests the middleware in isolation, mounted
+on a minimal router — following this repo's `tests/security/` convention
+(see `sqli.test.ts`) but self-contained, since no route in
+`src/index.ts`'s `createApp()` currently exercises cookie-based auth.
+The test app wires up `requestContextStorage` the same way `createApp()`
+does, so correlation-ID behavior is verified against the real mechanism,
+not a stand-in. Covers token issuance, safe-method exemption (including
+when the middleware is mounted directly on a safe-method route), no-op
+behavior for both Bearer-header and body-token requests (matching
+today's real auth patterns), all missing/mismatched/malformed token
+combinations, duplicate-header handling, correlation ID propagation
+(context-stored, `req.id` fallback, and fresh-uuid fallback), and an
+end-to-end login → mutate flow. 100% statement/branch/function/line
+coverage on `src/middleware/csrf.ts`.
+
+**Follow-up suggestion:** once a route sets a real session cookie, add
+a route-level regression test here (or in that route's own test file)
+verifying `verifyCsrfToken` is actually mounted and enforced on it —
+this suite only proves the middleware works correctly in isolation, not
+that any current route uses it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@testcontainers/postgresql": "^12.0.3",
+        "@types/cookie-parser": "^1.4.10",
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.13",
         "@types/js-yaml": "^4.0.9",
@@ -39,6 +40,7 @@
         "@types/supertest": "^6.0.2",
         "@types/swagger-ui-express": "^4.1.7",
         "@types/uuid": "^10.0.0",
+        "cookie-parser": "^1.4.7",
         "drizzle-kit": "^0.31.10",
         "eslint": "^9.12.0",
         "jest": "^29.7.0",
@@ -2721,6 +2723,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
@@ -4681,6 +4693,27 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@testcontainers/postgresql": "^12.0.3",
+    "@types/cookie-parser": "^1.4.10",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.13",
     "@types/js-yaml": "^4.0.9",
@@ -61,6 +62,7 @@
     "@types/supertest": "^6.0.2",
     "@types/swagger-ui-express": "^4.1.7",
     "@types/uuid": "^10.0.0",
+    "cookie-parser": "^1.4.7",
     "drizzle-kit": "^0.31.10",
     "eslint": "^9.12.0",
     "jest": "^29.7.0",

--- a/src/config/env-schema.ts
+++ b/src/config/env-schema.ts
@@ -71,6 +71,15 @@ const baseSchema = z.object({
   // ── Metrics ───────────────────────────────────────────────
   /** Bearer token required to access /api/metrics. Empty string (default) means no auth. */
   METRICS_AUTH_TOKEN: z.string().default(""),
+  // ── CSRF (double-submit cookie) ───────────────────────────
+  /** Name of the CSRF token cookie. Not httpOnly — the client must be able to read it. */
+  CSRF_COOKIE_NAME: z.string().default("csrf_token"),
+  /** Name of the header clients must echo the CSRF token back in. */
+  CSRF_HEADER_NAME: z.string().default("x-csrf-token"),
+  /** Lifetime of an issued CSRF token, in seconds. */
+  CSRF_TOKEN_TTL_SECONDS: z.coerce.number().int().positive().default(7200),
+  /** Name of the session/auth cookie whose presence triggers CSRF enforcement. */
+  SESSION_COOKIE_NAME: z.string().default("session"),
 });
 
 export const envSchema = baseSchema.refine(

--- a/src/middleware/csrf.ts
+++ b/src/middleware/csrf.ts
@@ -1,0 +1,109 @@
+
+import crypto from "node:crypto";
+import type { NextFunction, Request, Response } from "express";
+import { env } from "../config/env";
+import type { RouteError } from "../errors/RouteError";
+import { logger } from "../config/logger";
+import { requestContextStorage } from "../lib/requestContext";
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+const TOKEN_BYTES = 32;
+
+function isUnsafeMethod(method: string): boolean {
+  return !SAFE_METHODS.has(method.toUpperCase());
+}
+
+/** Generates a cryptographically random CSRF token. */
+export function generateCsrfToken(): string {
+  return crypto.randomBytes(TOKEN_BYTES).toString("hex");
+}
+
+
+function safeCompare(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    
+    crypto.timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return crypto.timingSafeEqual(bufA, bufB);
+}
+
+function getCorrelationId(req: Request): string {
+  const ctxRequestId = requestContextStorage.getStore()?.requestId;
+  if (ctxRequestId) {
+    return ctxRequestId;
+  }
+ 
+  const existing = (req as Request & { id?: string }).id;
+  if (typeof existing === "string" && existing.length > 0) {
+    return existing;
+  }
+  return crypto.randomUUID();
+}
+
+function forbidden(req: Request, _res: Response, next: NextFunction, reason: string): void {
+  const correlationId = getCorrelationId(req);
+  logger.warn(
+    { correlationId, path: req.path, method: req.method, reason },
+    "CSRF verification failed",
+  );
+  const routeError: RouteError = {
+    kind: "Forbidden",
+    message: "CSRF token missing or invalid",
+    reason,
+  };
+ 
+  next(routeError);
+}
+
+
+export function issueCsrfToken(req: Request, res: Response, next: NextFunction): void {
+  const existing = req.cookies?.[env.CSRF_COOKIE_NAME];
+  if (!existing) {
+    const token = generateCsrfToken();
+    res.cookie(env.CSRF_COOKIE_NAME, token, {
+      httpOnly: false, // must be readable by client JS to echo back in the header
+      secure: env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: env.CSRF_TOKEN_TTL_SECONDS * 1000,
+      path: "/",
+    });
+  }
+  next();
+}
+
+
+export function verifyCsrfToken(req: Request, res: Response, next: NextFunction): void {
+  if (!isUnsafeMethod(req.method)) {
+    next();
+    return;
+  }
+
+  const hasSessionCookie = Boolean(req.cookies?.[env.SESSION_COOKIE_NAME]);
+  if (!hasSessionCookie) {
+    next();
+    return;
+  }
+
+  const cookieToken = req.cookies?.[env.CSRF_COOKIE_NAME];
+  const headerToken = req.headers[env.CSRF_HEADER_NAME];
+
+  if (!cookieToken || typeof cookieToken !== "string") {
+    forbidden(req, res, next, "missing_csrf_cookie");
+    return;
+  }
+
+  if (!headerToken || Array.isArray(headerToken)) {
+    forbidden(req, res, next, "missing_csrf_header");
+    return;
+  }
+
+  if (!safeCompare(cookieToken, headerToken)) {
+    forbidden(req, res, next, "csrf_token_mismatch");
+    return;
+  }
+
+  next();
+}

--- a/tests/security/csrf.test.ts
+++ b/tests/security/csrf.test.ts
@@ -1,0 +1,279 @@
+
+process.env.NODE_ENV = "test";
+process.env.JWT_SECRET = "security-test-secret-at-least-32-bytes!!";
+process.env.JWT_ISSUER = "predictify";
+process.env.JWT_AUDIENCE = "predictify-app";
+process.env.ADMIN_ALLOWLIST = "GADMIN7777777777777777777777777777777777777777777777777777";
+
+import request from "supertest";
+import express from "express";
+import cookieParser from "cookie-parser";
+import { issueCsrfToken, verifyCsrfToken, generateCsrfToken } from "../../src/middleware/csrf";
+import { errorHandler } from "../../src/middleware/errorHandler";
+import { requestContextStorage } from "../../src/lib/requestContext";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(cookieParser());
+
+  
+  app.use((req, _res, next) => {
+    const requestId = (req.headers["x-request-id"] as string) || "test-generated-id";
+    (req as express.Request & { id?: string }).id = requestId;
+    requestContextStorage.run({ requestId }, next);
+  });
+
+  app.post("/login", issueCsrfToken, (_req, res) => {
+    res.cookie("session", "fake-session-value", { httpOnly: true, path: "/" });
+    res.status(200).json({ ok: true });
+  });
+
+  app.get("/csrf-token", issueCsrfToken, (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+
+  app.get("/public-resource", (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+
+  
+  app.get("/mutate-guarded-get", verifyCsrfToken, (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+
+  app.post("/mutate", verifyCsrfToken, (_req, res) => {
+    res.status(200).json({ ok: true, mutated: true });
+  });
+
+  app.delete("/mutate", verifyCsrfToken, (_req, res) => {
+    res.status(200).json({ ok: true, deleted: true });
+  });
+
+  app.use(errorHandler);
+
+  return app;
+}
+
+describe("CSRF Protection Middleware", () => {
+  const app = buildApp();
+
+  describe("issueCsrfToken", () => {
+    it("sets a csrf_token cookie on first request", async () => {
+      const res = await request(app).get("/csrf-token");
+      expect(res.status).toBe(200);
+      const setCookie = res.headers["set-cookie"] as unknown as string[];
+      expect(setCookie.some((c) => c.startsWith("csrf_token="))).toBe(true);
+    });
+
+    it("does not reissue a cookie if one is already present", async () => {
+      const res = await request(app)
+        .get("/csrf-token")
+        .set("Cookie", ["csrf_token=existing-token-value"]);
+      expect(res.status).toBe(200);
+      const setCookie = (res.headers["set-cookie"] as unknown as string[]) ?? [];
+      expect(setCookie.some((c) => c.startsWith("csrf_token="))).toBe(false);
+    });
+
+    it("issues the cookie as non-httpOnly so client JS can read it", async () => {
+      const res = await request(app).get("/csrf-token");
+      const setCookie = res.headers["set-cookie"] as unknown as string[];
+      const csrfCookie = setCookie.find((c) => c.startsWith("csrf_token="));
+      expect(csrfCookie?.toLowerCase()).not.toContain("httponly");
+    });
+  });
+
+  describe("verifyCsrfToken — safe methods", () => {
+    it("allows GET requests through without any token", async () => {
+      const res = await request(app).get("/public-resource");
+      expect(res.status).toBe(200);
+    });
+
+    it("no-ops for GET even when the middleware is mounted directly on the route", async () => {
+      const res = await request(app)
+        .get("/mutate-guarded-get")
+        .set("Cookie", ["session=fake-session-value"]);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("verifyCsrfToken — no session cookie present (today's actual auth model)", () => {
+    it("allows a mutating request through with only a Bearer token, no cookie", async () => {
+      const res = await request(app)
+        .post("/mutate")
+        .set("Authorization", "Bearer some.jwt.token");
+      expect(res.status).toBe(200);
+      expect(res.body.mutated).toBe(true);
+    });
+
+    it("allows a mutating request through with a body-carried token and no cookie", async () => {
+     
+      const res = await request(app)
+        .post("/mutate")
+        .send({ refreshToken: "some-refresh-token-value" });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("verifyCsrfToken — session cookie present", () => {
+    it("rejects a mutating request with a session cookie but no CSRF cookie or header", async () => {
+      const res = await request(app)
+        .post("/mutate")
+        .set("Cookie", ["session=fake-session-value"]);
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe("Forbidden");
+      expect(res.body.error.correlationId).toBeDefined();
+    });
+
+    it("uses the request's context-stored correlation id (matching src/index.ts's requestContextStorage wiring)", async () => {
+      const res = await request(app)
+        .post("/mutate")
+        .set("Cookie", ["session=fake-session-value"])
+        .set("x-request-id", "upstream-req-id-123");
+      expect(res.status).toBe(403);
+      expect(res.body.error.correlationId).toBe("upstream-req-id-123");
+    });
+
+    it("falls back to a generated id when no x-request-id is set on the request context", async () => {
+      const res = await request(app)
+        .post("/mutate")
+        .set("Cookie", ["session=fake-session-value"]);
+      expect(res.status).toBe(403);
+      expect(res.body.error.correlationId).toBe("test-generated-id");
+    });
+
+    it("rejects when the CSRF cookie is present but the header is missing", async () => {
+      const res = await request(app)
+        .post("/mutate")
+        .set("Cookie", ["session=fake-session-value", "csrf_token=abc123"]);
+      expect(res.status).toBe(403);
+    });
+
+    it("rejects when the header is present but the CSRF cookie is missing", async () => {
+      const res = await request(app)
+        .post("/mutate")
+        .set("Cookie", ["session=fake-session-value"])
+        .set("X-CSRF-Token", "abc123");
+      expect(res.status).toBe(403);
+    });
+
+    it("rejects when the cookie and header values do not match", async () => {
+      const res = await request(app)
+        .post("/mutate")
+        .set("Cookie", ["session=fake-session-value", "csrf_token=abc123"])
+        .set("X-CSRF-Token", "def456");
+      expect(res.status).toBe(403);
+    });
+
+    it("rejects when the header value differs only in length from the cookie", async () => {
+      const res = await request(app)
+        .post("/mutate")
+        .set("Cookie", ["session=fake-session-value", "csrf_token=abc123"])
+        .set("X-CSRF-Token", "abc123extra");
+      expect(res.status).toBe(403);
+    });
+
+    it("rejects when the header is sent as a duplicate (array) value", async () => {
+      const token = generateCsrfToken();
+      const res = await request(app)
+        .post("/mutate")
+        .set("Cookie", ["session=fake-session-value", `csrf_token=${token}`])
+        .set("X-CSRF-Token" as string, [token, token] as unknown as string);
+      expect(res.status).toBe(403);
+    });
+
+    it("accepts when the cookie and header values match", async () => {
+      const token = generateCsrfToken();
+      const res = await request(app)
+        .post("/mutate")
+        .set("Cookie", ["session=fake-session-value", `csrf_token=${token}`])
+        .set("X-CSRF-Token", token);
+      expect(res.status).toBe(200);
+      expect(res.body.mutated).toBe(true);
+    });
+
+    it("enforces the same check on DELETE requests", async () => {
+      const res = await request(app)
+        .delete("/mutate")
+        .set("Cookie", ["session=fake-session-value"]);
+      expect(res.status).toBe(403);
+    });
+
+    it("accepts a matching token on DELETE", async () => {
+      const token = generateCsrfToken();
+      const res = await request(app)
+        .delete("/mutate")
+        .set("Cookie", ["session=fake-session-value", `csrf_token=${token}`])
+        .set("X-CSRF-Token", token);
+      expect(res.status).toBe(200);
+      expect(res.body.deleted).toBe(true);
+    });
+  });
+
+  describe("verifyCsrfToken — outside requestContextStorage scope", () => {
+    it("falls back to req.id or a generated uuid when no context store is active", async () => {
+     
+      const bareApp = express();
+      bareApp.use(cookieParser());
+      bareApp.post("/mutate", verifyCsrfToken, (_req, res) => {
+        res.status(200).json({ ok: true });
+      });
+      bareApp.use(errorHandler);
+
+      const res = await request(bareApp)
+        .post("/mutate")
+        .set("Cookie", ["session=fake-session-value"]);
+      expect(res.status).toBe(403);
+      
+      expect(typeof res.body.error.correlationId).toBe("string");
+      expect(res.body.error.correlationId.length).toBeGreaterThan(0);
+    });
+
+    it("falls back to req.id specifically when it is set but no context store is active", async () => {
+      const bareAppWithReqId = express();
+      bareAppWithReqId.use(cookieParser());
+      bareAppWithReqId.use((req, _res, next) => {
+        (req as express.Request & { id?: string }).id = "manually-set-req-id";
+        next();
+      });
+      bareAppWithReqId.post("/mutate", verifyCsrfToken, (_req, res) => {
+        res.status(200).json({ ok: true });
+      });
+      bareAppWithReqId.use(errorHandler);
+
+      const res = await request(bareAppWithReqId)
+        .post("/mutate")
+        .set("Cookie", ["session=fake-session-value"]);
+      expect(res.status).toBe(403);
+      expect(res.body.error.correlationId).toBe("manually-set-req-id");
+    });
+  });
+
+  describe("end-to-end login → mutate flow", () => {
+    it("allows a mutating request after login issues a matching CSRF cookie", async () => {
+      const agent = request.agent(app);
+      const loginRes = await agent.post("/login");
+      expect(loginRes.status).toBe(200);
+
+      const setCookie = loginRes.headers["set-cookie"] as unknown as string[];
+      const csrfCookie = setCookie
+        .find((c) => c.startsWith("csrf_token="))
+        ?.split(";")[0]
+        .split("=")[1];
+      expect(csrfCookie).toBeDefined();
+
+      const mutateRes = await agent.post("/mutate").set("X-CSRF-Token", csrfCookie as string);
+      expect(mutateRes.status).toBe(200);
+    });
+  });
+
+  describe("generateCsrfToken", () => {
+    it("produces distinct, sufficiently long hex tokens", () => {
+      const a = generateCsrfToken();
+      const b = generateCsrfToken();
+      expect(a).not.toEqual(b);
+      expect(a.length).toBeGreaterThanOrEqual(32);
+      expect(/^[0-9a-f]+$/.test(a)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `src/middleware/csrf.ts`: CSRF protection using the double-submit cookie pattern. `issueCsrfToken` sets a random, non-`httpOnly` token cookie; `verifyCsrfToken` requires a matching `X-CSRF-Token` header on state-changing requests (`POST`/`PUT`/`PATCH`/`DELETE`) whenever a session cookie is present.

Resolves #310

## ⚠️ Read this before reviewing

**This does not close an active vulnerability in this codebase today.** CSRF is a risk specific to browser-managed cookies. As confirmed against `src/routes/auth.ts`, `src/services/authVerifyService.ts`, `src/middleware/auth.ts`, and `src/index.ts`, every current auth flow issues and reads tokens via response/request bodies and the `Authorization` header — no route sets a session cookie, and `cookie-parser` isn't even mounted in `createApp()` yet.

This middleware is added as forward-looking groundwork per #310: it's designed to activate automatically, with no further code changes, if a cookie-based session is introduced later (e.g. future wallet-auth work). Until then it's a deliberate no-op on every real request this service handles — it exits early whenever no `SESSION_COOKIE_NAME` cookie is present. Full explanation in `docs/csrf.md`.

## What's included

- **`src/middleware/csrf.ts`** — `issueCsrfToken`, `verifyCsrfToken`, `generateCsrfToken`. Constant-time comparison on token match. Correlation IDs pulled from the existing `requestContextStorage` (same source as the rest of the app's logging), not re-derived.
- **`tests/security/csrf.test.ts`** — 22 tests, 100% statement/branch/function/line coverage on `csrf.ts`. Covers token issuance, safe-method exemption, no-op behavior for both bearer-header and body-token requests (today's real auth patterns), every missing/mismatched/malformed token combination, duplicate-header handling, and correlation-ID propagation across all three sources (context store, `req.id` fallback, fresh UUID fallback).
- **`docs/csrf.md`** — usage, config, the threat-model note above in full, and integration requirements for whenever cookie-based sessions land.
- Four new env vars in `env-schema.ts`, all defaulted — **no `.env` changes required**: `CSRF_COOKIE_NAME`, `CSRF_HEADER_NAME`, `CSRF_TOKEN_TTL_SECONDS`, `SESSION_COOKIE_NAME`.

## Integration note for whenever this goes live

`cookie-parser` is not currently mounted in `createApp()`. When a cookie-based session is introduced, add `app.use(cookieParser())` before any route using this middleware — otherwise `req.cookies` is `undefined` and `verifyCsrfToken` will silently no-op on every request. Called out in both the code comments and `docs/csrf.md`.

## Testing

```bash
npx tsc --noEmit
# clean

npx eslint src/middleware/csrf.ts tests/security/csrf.test.ts
# clean

npx jest tests/security/csrf.test.ts --coverage --collectCoverageFrom=src/middleware/csrf.ts
# 22/22 passing, 100% coverage
```

## Follow-up (not in this PR)

Once a route actually sets a session cookie, add a route-level regression test proving `verifyCsrfToken` is mounted and enforced there — this PR only proves the middleware works correctly in isolation, not that any current route uses it.

## Checklist

- [x] Implementation matches the issue description
- [x] Tests added and passing (22/22, 100% coverage on changed lines)
- [x] Docs updated (`docs/csrf.md`)
- [x] Lint clean
- [x] Type-check clean