### PR TITLE
docs: OpenAPI examples for /api/users (FWC26 - Stellar Wave)

### DIFF
--- a/docs/openapi-users-examples.md
+++ b/docs/openapi-users-examples.md
@@ -1,0 +1,23 @@
+OpenAPI: Examples for /api/users
+================================
+
+Summary
+-------
+
+This change adds concrete `examples` to the OpenAPI spec (`openapi.yaml`) for the user-facing endpoints under `/api/users`:
+
+- `GET /api/users/me` — example authenticated profile
+- `GET /api/users/{address}/predictions` — example paginated predictions page
+- `GET /api/users/{stellarAddress}/profile` — example public profile
+- `POST /api/users/{addr}/follow` and `DELETE /api/users/{addr}/follow` — example follow/unfollow responses
+
+Why
+---
+
+Examples improve the developer experience for API consumers and make the Swagger UI more useful by showing realistic response payloads.
+
+Notes for reviewers
+------------------
+
+- The examples are purely documentation — no behaviour or validation logic was changed.
+- Tests were added at `tests/openapi.users.examples.test.ts` to assert the YAML contains these examples.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1650,13 +1650,23 @@ paths:
           description: Current user profile
           content:
             application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    $ref: '#/components/schemas/CurrentUserProfile'
-                required:
-                  - data
+                schema:
+                  type: object
+                  properties:
+                    data:
+                      $ref: '#/components/schemas/CurrentUserProfile'
+                  required:
+                    - data
+                examples:
+                  currentUser:
+                    summary: Example authenticated user profile
+                    value:
+                      data:
+                        stellarAddress: GCFXExampleUser1111111111111111111111111111
+                        createdAt: '2026-07-01T12:34:56.000Z'
+                        totals:
+                          prediction_count: 42
+                          claim_count: 3
         '401':
           description: Unauthorized
           content:
@@ -1740,6 +1750,16 @@ paths:
                 required:
                   - data
                   - nextCursor
+              examples:
+                samplePage:
+                  summary: Example predictions page
+                  value:
+                    data:
+                      - id: '11111111-1111-4111-8111-111111111111'
+                        marketId: 'market-abc-123'
+                        status: pending
+                        createdAt: '2026-07-01T12:00:00.000Z'
+                    nextCursor: null
         '400':
           description: Invalid address or query parameters
           content:
@@ -1776,6 +1796,22 @@ paths:
                     $ref: '#/components/schemas/UserProfile'
                 required:
                   - data
+                examples:
+                  publicProfile:
+                    summary: Example public user profile
+                    value:
+                      data:
+                        id: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa'
+                        stellarAddress: GCFXExampleUser2222222222222222222222
+                        joinedAt: '2025-12-15T09:00:00.000Z'
+                        predictions:
+                          - id: '22222222-2222-4222-8222-222222222222'
+                            marketId: 'market-def-456'
+                            status: confirmed
+                            createdAt: '2026-01-02T10:00:00.000Z'
+                        totals:
+                          prediction_count: 7
+                          claim_count: 1
         '400':
           description: Invalid Stellar address
           content:
@@ -1814,6 +1850,14 @@ paths:
                     $ref: '#/components/schemas/FollowResult'
                 required:
                   - data
+                examples:
+                  followCreated:
+                    summary: Example follow creation result
+                    value:
+                      data:
+                        follower: GCFXExampleUser3333333333333333333333
+                        followee: GCFXExampleUser4444444444444444444444
+                        followedAt: '2026-07-10T08:00:00.000Z'
         '400':
           description: Validation error
           content:
@@ -1851,6 +1895,14 @@ paths:
                     $ref: '#/components/schemas/FollowResult'
                 required:
                   - data
+                examples:
+                  followRemoved:
+                    summary: Example follow removal result
+                    value:
+                      data:
+                        follower: GCFXExampleUser3333333333333333333333
+                        followee: GCFXExampleUser4444444444444444444444
+                        followedAt: '2026-07-10T08:00:00.000Z'
         '400':
           description: Validation error
           content:

--- a/tests/openapi.users.examples.test.ts
+++ b/tests/openapi.users.examples.test.ts
@@ -1,0 +1,44 @@
+import * as fs from "fs";
+import * as yaml from "js-yaml";
+
+describe("OpenAPI user endpoints include examples", () => {
+  const yamlPath = process.cwd() + "/openapi.yaml";
+  let parsed: Record<string, any>;
+
+  beforeAll(() => {
+    expect(fs.existsSync(yamlPath)).toBe(true);
+    parsed = yaml.load(fs.readFileSync(yamlPath, "utf-8")) as Record<string, any>;
+  });
+
+  test("GET /api/users/me has a 200 example", () => {
+    const ex = parsed.paths?.["/api/users/me"]?.get?.responses?.["200"]?.content?.["application/json"]?.examples;
+    expect(ex).toBeDefined();
+    expect(ex.currentUser).toBeDefined();
+    expect(ex.currentUser.value.data.stellarAddress).toMatch(/^G/);
+  });
+
+  test("GET /api/users/{address}/predictions has a 200 example", () => {
+    const ex = parsed.paths?.["/api/users/{address}/predictions"]?.get?.responses?.["200"]?.content?.["application/json"]?.examples;
+    expect(ex).toBeDefined();
+    expect(ex.samplePage).toBeDefined();
+    expect(Array.isArray(ex.samplePage.value.data)).toBe(true);
+  });
+
+  test("GET /api/users/{stellarAddress}/profile has a 200 example", () => {
+    const ex = parsed.paths?.["/api/users/{stellarAddress}/profile"]?.get?.responses?.["200"]?.content?.["application/json"]?.examples;
+    expect(ex).toBeDefined();
+    expect(ex.publicProfile).toBeDefined();
+    expect(ex.publicProfile.value.data.id).toBeTruthy();
+    expect(ex.publicProfile.value.data.stellarAddress).toMatch(/^G/);
+  });
+
+  test("POST/DELETE /api/users/{addr}/follow have 200 examples", () => {
+    const postEx = parsed.paths?.["/api/users/{addr}/follow"]?.post?.responses?.["200"]?.content?.["application/json"]?.examples;
+    const delEx = parsed.paths?.["/api/users/{addr}/follow"]?.delete?.responses?.["200"]?.content?.["application/json"]?.examples;
+    expect(postEx).toBeDefined();
+    expect(postEx.followCreated).toBeDefined();
+    expect(postEx.followCreated.value.data.follower).toMatch(/^G/);
+    expect(delEx).toBeDefined();
+    expect(delEx.followRemoved).toBeDefined();
+  });
+});


### PR DESCRIPTION
Added concrete OpenAPI examples for the /api/users endpoints (GET /api/users/me, GET /api/users/{address}/predictions, GET /api/users/{stellarAddress}/profile, POST/DELETE /api/users/{addr}/follow), plus focused tests validating those examples and documentation updates in src/openapi.yaml and docs.

Closes #412