### PR TITLE
feat: cursor pagination predictions

### DIFF
--- a/docs/predictions-api.md
+++ b/docs/predictions-api.md
@@ -1,0 +1,139 @@
+# Predictions Listing API
+
+## `GET /api/predictions`
+
+Returns a cursor-paginated list of predictions belonging to the **authenticated user**.
+
+---
+
+### Authentication
+
+Requires a valid JWT in the `Authorization: Bearer <token>` header.
+Returns `401 unauthenticated` when the token is absent, expired, or invalid.
+
+---
+
+### Query Parameters
+
+| Parameter  | Type   | Required | Default | Constraints       | Description                                                   |
+|------------|--------|----------|---------|-------------------|---------------------------------------------------------------|
+| `limit`    | number | no       | `20`    | 1–100             | Number of rows to return per page.                            |
+| `cursor`   | string | no       | —       | opaque token      | Cursor from the previous page's `nextCursor`. Absent = page 1.|
+| `marketId` | string | no       | —       | 1–128 chars       | Filter to a specific market.                                  |
+| `status`   | string | no       | —       | enum (see below)  | Filter by prediction lifecycle status.                        |
+| `outcome`  | string | no       | —       | 1–64 chars        | Filter by chosen outcome (e.g. `"yes"` / `"no"`).            |
+
+**Status enum values:** `pending` · `confirmed` · `won` · `lost` · `claimed`
+
+---
+
+### Pagination
+
+This endpoint uses **keyset (cursor) pagination** on `(createdAt DESC, id DESC)`.
+
+- Pass the returned `nextCursor` verbatim as `?cursor=` to fetch the next page.
+- `nextCursor` is `null` on the last page.
+- Cursors are versioned. A stale or tampered cursor is safely ignored (the
+  response restarts from page 1) rather than causing a 500 or a wrong offset.
+
+```
+GET /api/predictions?limit=20
+
+{
+  "data": [ ... ],
+  "nextCursor": "djF8MjR8..."
+}
+
+GET /api/predictions?limit=20&cursor=djF8MjR8...
+
+{
+  "data": [ ... ],
+  "nextCursor": null     ← last page
+}
+```
+
+---
+
+### Response Shape
+
+**200 OK**
+
+```json
+{
+  "data": [
+    {
+      "id": "11111111-1111-1111-1111-111111111111",
+      "marketId": "market-abc",
+      "question": "Will ETH reach $10k by end of 2026?",
+      "outcome": "yes",
+      "amount": "100",
+      "txHash": "abc123...",
+      "status": "pending",
+      "result": null,
+      "createdAt": "2026-06-27T12:00:00.000Z",
+      "resolutionTime": "2027-01-01T00:00:00.000Z"
+    }
+  ],
+  "nextCursor": "djF8MjR8..."
+}
+```
+
+**400 validation_error** — invalid query parameters
+
+```json
+{
+  "error": {
+    "code": "validation_error",
+    "message": "Invalid enum value. Expected 'pending' | 'confirmed' | ...",
+    "requestId": "req-uuid"
+  }
+}
+```
+
+**401 unauthenticated** — missing or invalid JWT
+
+```json
+{
+  "error": { "code": "unauthenticated" }
+}
+```
+
+---
+
+### Implementation Details
+
+#### Repository (`src/repositories/predictionRepo.ts`)
+
+- Executes a single `SELECT … INNER JOIN markets … WHERE … ORDER BY createdAt DESC, id DESC LIMIT limit+1` query.
+- The `limit + 1` probe determines whether a next page exists without a separate `COUNT(*)` round-trip.
+- All filter conditions (`userId`, `marketId`, `status`, `outcome`) are injected as parameterised Drizzle column expressions — no string interpolation, so SQL injection is structurally impossible.
+- The cursor keyset predicate is:
+  ```sql
+  (createdAt < cursorTime)
+  OR (createdAt = cursorTime AND id < cursorId)
+  ```
+  This is the standard two-column keyset predicate for `DESC (createdAt, id)` ordering.
+
+#### Route (`src/routes/predictions.ts`)
+
+- Input validated with Zod at the route boundary before any DB access.
+- `requireAuth` middleware enforces authentication; `req.user.id` is always populated when the handler executes.
+- Structured logging via `pino` with `reqId` (from `x-request-id`) and `userId` on every log entry.
+- Errors bubble to the global `errorHandler` middleware for standardised envelopes.
+
+#### Cursor Encoding (`src/utils/cursor.ts`)
+
+Cursors are versioned base64url tokens encoding `{ sortValue: ISO-string, id: UUID }`.
+Version mismatches (e.g. after a schema migration) cause the cursor to be silently
+discarded rather than mis-paginating.
+
+---
+
+### Differences from `GET /api/users/:address/predictions`
+
+| Feature               | `/api/predictions`              | `/api/users/:address/predictions` |
+|-----------------------|---------------------------------|-----------------------------------|
+| Auth                  | Required (caller's own data)    | None (public, by Stellar address) |
+| Scope                 | Authenticated user only         | Any Stellar address               |
+| Filters               | marketId, status, outcome       | status only                       |
+| Data source           | `predictionRepo.listPredictions`| `userService.getUserPredictions`  |

--- a/src/openapi/registry.ts
+++ b/src/openapi/registry.ts
@@ -1178,6 +1178,91 @@ registry.registerPath({
   },
 });
 
+// ── /api/predictions ──────────────────────────────────────────────────────────
+
+/**
+ * PredictionRow — the shape returned by GET /api/predictions.
+ * Includes the joined market question and resolution time for display.
+ */
+const PredictionRow = z
+  .object({
+    id: z.string().uuid(),
+    marketId: z.string(),
+    question: z.string(),
+    outcome: z.string(),
+    amount: z.string(),
+    txHash: z.string(),
+    status: PredictionStatus,
+    result: z.string().nullable(),
+    createdAt: z.string().datetime(),
+    resolutionTime: z.string().datetime(),
+  })
+  .openapi("PredictionRow");
+
+const PredictionsListResponse = z
+  .object({
+    data: z.array(PredictionRow),
+    /** Opaque cursor for the next page, or null if this is the last page. */
+    nextCursor: z.string().nullable(),
+  })
+  .openapi("PredictionsListResponse");
+
+/**
+ * GET /api/predictions
+ *
+ * Returns a cursor-paginated list of predictions belonging to the
+ * authenticated user.
+ *
+ * Keyset pagination on (createdAt DESC, id DESC) — stable and efficient
+ * even as new rows are inserted between page loads.
+ *
+ * Filters: marketId, status, outcome (all optional).
+ * Pagination: cursor + limit (default 20, max 100).
+ */
+registry.registerPath({
+  method: "get",
+  path: "/api/predictions",
+  operationId: "listPredictions",
+  tags: ["Predictions"],
+  summary: "List the authenticated user\u2019s predictions",
+  description:
+    "Returns a cursor-paginated list of predictions placed by the caller. " +
+    "Sort order is `createdAt DESC, id DESC`. " +
+    "Pass the returned `nextCursor` as `?cursor=` to fetch the next page. " +
+    "`nextCursor` is `null` when no further pages exist.",
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: z.object({
+      /** Filter to a specific market. */
+      marketId: z.string().min(1).max(128).optional(),
+      /** Filter by prediction lifecycle status. */
+      status: PredictionStatus.optional(),
+      /** Filter by chosen outcome value (e.g. "yes" / "no"). */
+      outcome: z.string().min(1).max(64).optional(),
+      /** Opaque cursor from the previous page\u2019s `nextCursor`. */
+      cursor: z.string().optional(),
+      /** Page size — default 20, max 100. */
+      limit: z.coerce.number().int().min(1).max(100).default(20).optional(),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Paginated list of predictions",
+      content: {
+        "application/json": { schema: PredictionsListResponse },
+      },
+    },
+    400: {
+      description: "Validation error — invalid query parameters",
+      content: { "application/json": { schema: ValidationErrorBody } },
+    },
+    401: {
+      description: "Unauthorized — missing or invalid JWT",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+  },
+});
+
 registry.registerPath({
   method: "post",
   path: "/api/users/{addr}/follow",

--- a/src/repositories/predictionRepo.ts
+++ b/src/repositories/predictionRepo.ts
@@ -1,0 +1,178 @@
+/**
+ * predictionRepo.ts
+ *
+ * Data-access layer for the authenticated user's predictions.
+ *
+ * Design notes
+ * ------------
+ * - Keyset (cursor) pagination on `(createdAt DESC, id DESC)` is preferred
+ *   over OFFSET/LIMIT because the result set stays stable and fast even as new
+ *   predictions are written between page loads.
+ * - The cursor encodes `{ sortValue: createdAt ISO-string, id: UUID }` via the
+ *   shared `encodeCursor` / `decodeCursor` helpers in `src/utils/cursor.ts`.
+ *   Cursors are versioned; a stale or tampered cursor token is silently treated
+ *   as absent (restart from page 1) rather than 500-ing.
+ * - Optional filters (marketId, status, outcome) are injected as additional
+ *   `WHERE` conditions using parameterised Drizzle column expressions — no
+ *   string interpolation, so injection is structurally impossible.
+ * - One extra row is fetched (`limit + 1`) to determine whether a subsequent
+ *   page exists without a separate COUNT query.
+ */
+
+import { and, desc, eq, lt, or } from "drizzle-orm";
+import { db } from "../db/client";
+import { markets, predictions } from "../db/schema";
+import { decodeCursor, encodeCursor, type Page } from "../utils/cursor";
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+/**
+ * A single prediction row as returned to the API layer.
+ * Dates are serialised to ISO-8601 strings for a stable JSON wire format.
+ */
+export interface PredictionRow {
+  id: string;
+  marketId: string;
+  /** Human-readable question text from the joined markets row. */
+  question: string;
+  outcome: string;
+  amount: string;
+  txHash: string;
+  status: string;
+  result: string | null;
+  createdAt: string;
+  resolutionTime: string;
+}
+
+/**
+ * Filter options accepted by `listPredictions`.
+ */
+export interface ListPredictionsFilter {
+  /** Scope results to a single market. */
+  marketId?: string;
+  /** Filter by prediction lifecycle status (pending, confirmed, won, lost, claimed). */
+  status?: string;
+  /** Filter by the chosen outcome value (e.g. "yes" / "no"). */
+  outcome?: string;
+}
+
+/**
+ * Pagination options accepted by `listPredictions`.
+ */
+export interface ListPredictionsOptions extends ListPredictionsFilter {
+  /** Number of rows to return per page (already clamped by the caller). */
+  limit: number;
+  /** Opaque cursor token from the previous page's `nextCursor`. */
+  cursor?: string;
+}
+
+// ── Repository function ───────────────────────────────────────────────────────
+
+/**
+ * Fetch one page of predictions for `userId` using keyset pagination.
+ *
+ * Sort order: `(createdAt DESC, id DESC)` — stable even when multiple
+ * predictions share the same timestamp because the UUID tie-breaker is unique.
+ *
+ * Keyset WHERE predicate for DESC ordering:
+ *   `(createdAt < cursorTime)
+ *    OR (createdAt = cursorTime AND id < cursorId)`
+ *
+ * @param userId  - UUID of the authenticated user (scopes the query).
+ * @param options - Pagination + filter options.
+ * @returns       - `{ data, nextCursor }` — `nextCursor` is null on the last page.
+ */
+export async function listPredictions(
+  userId: string,
+  options: ListPredictionsOptions,
+): Promise<Page<PredictionRow>> {
+  const { limit, cursor, marketId, status, outcome } = options;
+
+  // ------------------------------------------------------------------
+  // Build WHERE conditions.  All conditions use parameterised Drizzle
+  // column expressions — never string-interpolated values.
+  // ------------------------------------------------------------------
+
+  // Always scope to the authenticated user.
+  const conditions = [eq(predictions.userId, userId)];
+
+  if (marketId) {
+    conditions.push(eq(predictions.marketId, marketId));
+  }
+
+  if (status) {
+    conditions.push(eq(predictions.status, status));
+  }
+
+  if (outcome) {
+    conditions.push(eq(predictions.outcome, outcome));
+  }
+
+  // Decode the opaque cursor.  An invalid / version-mismatched token returns
+  // null, which is safe — we just start from the beginning of the ordered set.
+  const cursorKey = decodeCursor(cursor);
+
+  if (cursorKey) {
+    const cursorTime = new Date(cursorKey.sortValue);
+    // Standard two-column keyset predicate for DESC (createdAt, id):
+    //   rows that are strictly "earlier" in the sort order than the last
+    //   row on the previous page.
+    conditions.push(
+      or(
+        lt(predictions.createdAt, cursorTime),
+        and(
+          eq(predictions.createdAt, cursorTime),
+          lt(predictions.id, cursorKey.id),
+        ),
+      )!,
+    );
+  }
+
+  // ------------------------------------------------------------------
+  // Execute the paginated query.  Fetch limit+1 rows so we can detect
+  // whether another page follows without a separate COUNT(*) round-trip.
+  // ------------------------------------------------------------------
+  const rows = await db
+    .select({
+      id: predictions.id,
+      marketId: predictions.marketId,
+      question: markets.question,
+      outcome: predictions.outcome,
+      amount: predictions.amount,
+      txHash: predictions.txHash,
+      status: predictions.status,
+      result: predictions.result,
+      createdAt: predictions.createdAt,
+      resolutionTime: markets.resolutionTime,
+    })
+    .from(predictions)
+    .innerJoin(markets, eq(predictions.marketId, markets.id))
+    .where(and(...conditions))
+    .orderBy(desc(predictions.createdAt), desc(predictions.id))
+    .limit(limit + 1);
+
+  const hasMore = rows.length > limit;
+  const data = rows.slice(0, limit);
+
+  // Mint the next-page cursor from the last row on this page.  The shared
+  // `encodeCursor` helper stamps the current CURSOR_VERSION into the token so
+  // old cursors are rejected after a schema migration rather than silently
+  // mis-paginating.
+  const last = data[data.length - 1];
+  const nextCursor =
+    hasMore && last
+      ? encodeCursor({
+          sortValue: last.createdAt.toISOString(),
+          id: last.id,
+        })
+      : null;
+
+  return {
+    data: data.map((r) => ({
+      ...r,
+      createdAt: r.createdAt.toISOString(),
+      resolutionTime: r.resolutionTime.toISOString(),
+    })),
+    nextCursor,
+  };
+}

--- a/src/routes/predictions.ts
+++ b/src/routes/predictions.ts
@@ -1,11 +1,16 @@
   
   
-/* eslint-disable @typescript-eslint/no-explicit-any */ 
-import { Router } from "express";
+import { Router, Request, Response, NextFunction } from "express";
+import { z } from "zod";
 import { requireAuth } from "../middleware/requireAuth";
 import { getPredictionExplanation } from "../services/predictionExplainService";
 import cancelRouter from "./predictions/cancel";
 import { createShareRouter } from "./predictions/share";
+import { listPredictions } from "../repositories/predictionRepo";
+import { logger } from "../config/logger";
+import { getRequestId } from "../lib/requestContext";
+import { clampLimit, DEFAULT_PAGE_SIZE } from "../utils/cursor";
+import type { AuthenticatedRequest } from "../middleware/auth";
 
 export const predictionsRouter = Router();
 
@@ -24,13 +29,110 @@ predictionsRouter.use("/", cancelRouter);
 // ── Authenticated routes ──────────────────────────────────────────────────
 predictionsRouter.use(requireAuth);
 
+// Zod schema for GET /api/predictions query parameters.
+// Validated at the route boundary before any DB access.
+const listQuerySchema = z.object({
+  /** Filter by market ID (optional). */
+  marketId: z.string().min(1).max(128).optional(),
+  /** Filter by prediction lifecycle status (optional). */
+  status: z
+    .enum(["pending", "confirmed", "won", "lost", "claimed"])
+    .optional(),
+  /** Filter by chosen outcome value (optional). */
+  outcome: z.string().min(1).max(64).optional(),
+  /** Opaque cursor from the previous page (optional). */
+  cursor: z.string().optional(),
+  /** Number of rows to return per page (default 20, max 100). */
+  limit: z.coerce.number().int().min(1).max(100).default(DEFAULT_PAGE_SIZE),
+});
+
 /**
  * GET /api/predictions
- * Returns predictions belonging to the authenticated user.
+ *
+ * Returns a cursor-paginated list of predictions belonging to the authenticated
+ * user.
+ *
+ * Query parameters:
+ *   - marketId (optional) — filter to a single market
+ *   - status   (optional) — one of: pending, confirmed, won, lost, claimed
+ *   - outcome  (optional) — e.g. "yes" / "no"
+ *   - cursor   (optional) — opaque token from the previous page's `nextCursor`
+ *   - limit    (optional, default 20, max 100) — page size
+ *
+ * Response:
+ *   200 { data: PredictionRow[], nextCursor: string | null }
+ *
+ * Pagination:
+ *   `nextCursor` is null on the last page.  Pass it verbatim as `?cursor=` to
+ *   fetch the next page.  Cursors are versioned; a stale or tampered cursor
+ *   safely restarts from page 1 rather than returning a wrong offset.
+ *
+ * Errors:
+ *   400 validation_error — query params fail the zod schema
+ *   401 unauthorized     — missing or invalid JWT (enforced by requireAuth)
  */
-predictionsRouter.get("/", (req, res) => {
-  res.json({ data: [], user: (req as any).user });
-});
+predictionsRouter.get(
+  "/",
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const reqId = getRequestId();
+
+    try {
+      // ── Input validation ─────────────────────────────────────────────────
+      const queryParse = listQuerySchema.safeParse(req.query);
+      if (!queryParse.success) {
+        logger.warn(
+          { reqId, issues: queryParse.error.issues },
+          "predictions_list_invalid_query",
+        );
+        res.status(400).json({
+          error: {
+            code: "validation_error",
+            message:
+              queryParse.error.issues[0]?.message ?? "invalid query parameters",
+            requestId: reqId,
+          },
+        });
+        return;
+      }
+
+      const { marketId, status, outcome, cursor, limit: rawLimit } =
+        queryParse.data;
+
+      // clampLimit is a belt-and-suspenders guard; zod already enforces 1–100.
+      const limit = clampLimit(rawLimit);
+
+      const userId = (req as AuthenticatedRequest).user!.id;
+
+      logger.debug(
+        { reqId, userId, marketId, status, outcome, limit, hasCursor: !!cursor },
+        "predictions_list_request",
+      );
+
+      // ── Data access ──────────────────────────────────────────────────────
+      const page = await listPredictions(userId, {
+        marketId,
+        status,
+        outcome,
+        limit,
+        cursor,
+      });
+
+      logger.info(
+        {
+          reqId,
+          userId,
+          count: page.data.length,
+          hasNext: !!page.nextCursor,
+        },
+        "predictions_list_served",
+      );
+
+      res.json({ data: page.data, nextCursor: page.nextCursor });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
 
 /**
  * GET /api/predictions/:id/explain

--- a/tests/predictionsList.test.ts
+++ b/tests/predictionsList.test.ts
@@ -1,0 +1,681 @@
+/**
+ * tests/predictionsList.test.ts
+ *
+ * Focused unit tests for the cursor-paginated
+ *   GET /api/predictions
+ * endpoint and the underlying `listPredictions` repository function.
+ *
+ * Strategy
+ * --------
+ * Two layers of tests:
+ *
+ *   1. Route-level (supertest) — mounts `predictionsRouter` on a minimal
+ *      Express app, mocks the `predictionRepo` module, and exercises the HTTP
+ *      interface (auth, input validation, response shape, logging).
+ *
+ *   2. Repository-level — mocks `../src/db/client` and verifies that
+ *      `listPredictions` wires the correct query (conditions, ordering,
+ *      limit+1 probe, cursor encoding).
+ *
+ * No real DB socket is ever opened. The pg / drizzle mocks follow the same
+ * pattern used by tests/usersMe.test.ts and tests/usersPredictions.test.ts.
+ *
+ * Coverage targets
+ * ----------------
+ *   Route
+ *     - 401 when Authorization header is absent
+ *     - 400 validation_error for bad status / limit values
+ *     - 400 validation_error for empty marketId
+ *     - 200 happy-path: first page with nextCursor
+ *     - 200 happy-path: last page with nextCursor = null
+ *     - 200 empty data array when no predictions
+ *     - 200 default limit = 20 forwarded to repo
+ *     - 200 all optional filters forwarded to repo
+ *     - 200 tampered cursor forwarded to repo and handled gracefully
+ *     - 500 when repo throws unexpectedly
+ *
+ *   Repository
+ *     - returns empty data with nextCursor = null when DB returns zero rows
+ *     - serialises Date fields to ISO strings
+ *     - sets nextCursor when there are more rows than the limit (hasMore)
+ *     - sets nextCursor = null on the last page
+ *     - does not leak the extra probe row into the data array
+ *     - encodes the correct cursor from the last row on the page
+ *     - accepts an invalid cursor without throwing
+ */
+
+// ---------------------------------------------------------------------------
+// 1. Env vars — must be set before ANY project import.
+// ---------------------------------------------------------------------------
+process.env.NODE_ENV = "test";
+process.env.PORT = "3001";
+process.env.LOG_LEVEL = "fatal";
+process.env.DATABASE_URL = "postgres://localhost/test";
+process.env.JWT_SECRET = "predictions-list-test-secret-at-least-32-bytes!!";
+process.env.JWT_ISSUER = "predictify";
+process.env.JWT_AUDIENCE = "predictify-app";
+process.env.JWT_TTL_SECONDS = "3600";
+process.env.STELLAR_NETWORK = "testnet";
+process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "CABCDEF";
+
+// ---------------------------------------------------------------------------
+// 2. Mock pg so no real socket is opened during module load.
+// ---------------------------------------------------------------------------
+jest.mock("pg", () => {
+  const Pool = jest.fn().mockImplementation(() => ({
+    connect: jest.fn(),
+    query: jest.fn(),
+    end: jest.fn(),
+    on: jest.fn(),
+  }));
+  return { Pool };
+});
+
+// ---------------------------------------------------------------------------
+// 3. Mock drizzle-orm/node-postgres.
+//    requireAuth builds its own drizzle instance with this factory.
+//    We expose authLimit so individual tests can control whether the user
+//    lookup resolves to a user row (authenticated) or empty (unauthenticated).
+//    The intermediate chain methods use closures so they survive resetAllMocks.
+// ---------------------------------------------------------------------------
+const authLimit = jest.fn();
+const authWhere = jest.fn(() => ({ limit: authLimit }));
+const authFrom = jest.fn(() => ({ where: authWhere }));
+const authSelect = jest.fn(() => ({ from: authFrom }));
+
+jest.mock("drizzle-orm/node-postgres", () => ({
+  drizzle: jest.fn(() => ({ select: authSelect })),
+}));
+
+// ---------------------------------------------------------------------------
+// 4. Mock src/db/client so pool.on() does not throw during module init.
+// ---------------------------------------------------------------------------
+jest.mock("../src/db/client", () => ({
+  db: {
+    select: jest.fn(),
+    query: { users: { findFirst: jest.fn() } },
+  },
+  pool: { on: jest.fn(), end: jest.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// 5. Mock sub-routers that have problematic imports (broken logging path in
+//    cancel.ts, and share.ts which requires extra deps not needed here).
+//    These sub-routers are NOT under test — we only care about GET /.
+// ---------------------------------------------------------------------------
+jest.mock("../src/routes/predictions/cancel", () => {
+  const { Router } = jest.requireActual("express") as typeof import("express");
+  const router = Router();
+  return { __esModule: true, default: router };
+});
+
+jest.mock("../src/routes/predictions/share", () => ({
+  createShareRouter: () => {
+    const { Router } = jest.requireActual("express") as typeof import("express");
+    return Router();
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// 6. Mock the predictionRepo so route tests stay in-process.
+// ---------------------------------------------------------------------------
+jest.mock("../src/repositories/predictionRepo");
+
+// ---------------------------------------------------------------------------
+// 7. Project imports — safe after mocks are in place.
+// ---------------------------------------------------------------------------
+import express from "express";
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { predictionsRouter } from "../src/routes/predictions";
+import { errorHandler } from "../src/middleware/errorHandler";
+import { listPredictions } from "../src/repositories/predictionRepo";
+import { encodeCursor } from "../src/utils/cursor";
+import { env } from "../src/config/env";
+
+const mockListPredictions = listPredictions as jest.MockedFunction<
+  typeof listPredictions
+>;
+
+// ---------------------------------------------------------------------------
+// App factory
+// ---------------------------------------------------------------------------
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/predictions", predictionsRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+const TEST_USER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const STELLAR_ADDRESS = "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW";
+const PREDICTION_ID_1 = "11111111-1111-1111-1111-111111111111";
+const PREDICTION_ID_2 = "22222222-2222-2222-2222-222222222222";
+const MARKET_ID = "market-abc-123";
+const SORT_TS = "2026-06-27T12:00:00.000Z";
+
+/** The user row that requireAuth's DB lookup returns after JWT verification. */
+const MOCK_USER_ROW = { id: TEST_USER_ID, stellarAddress: STELLAR_ADDRESS };
+
+function validToken(userId = TEST_USER_ID): string {
+  return jwt.sign(
+    { sub: STELLAR_ADDRESS, userId },
+    env.JWT_SECRET,
+    {
+      issuer: env.JWT_ISSUER,
+      audience: env.JWT_AUDIENCE,
+      expiresIn: env.JWT_TTL_SECONDS,
+    },
+  );
+}
+
+function makePredictionRow(id: string) {
+  return {
+    id,
+    marketId: MARKET_ID,
+    question: "Will ETH reach $10k?",
+    outcome: "yes",
+    amount: "100",
+    txHash: "abc123",
+    status: "pending",
+    result: null,
+    createdAt: SORT_TS,
+    resolutionTime: "2027-01-01T00:00:00.000Z",
+  };
+}
+
+function predictionsUrl(params: Record<string, string> = {}) {
+  const qs = Object.keys(params).length
+    ? "?" + new URLSearchParams(params).toString()
+    : "";
+  return `/api/predictions${qs}`;
+}
+
+const app = makeApp();
+
+// ---------------------------------------------------------------------------
+// Route-level tests
+// ---------------------------------------------------------------------------
+describe("GET /api/predictions — route", () => {
+  beforeEach(() => {
+    // clearAllMocks clears call history but preserves mock implementations
+    // set via jest.fn(() => ...) — so the drizzle chain (authWhere, authFrom,
+    // authSelect) remains wired after each test.  Only authLimit (which has no
+    // default implementation) and mockListPredictions need to be re-primed
+    // per test.
+    jest.clearAllMocks();
+    // Restore the closure implementations that resetAllMocks would erase.
+    authWhere.mockReturnValue({ limit: authLimit });
+    authFrom.mockReturnValue({ where: authWhere });
+    authSelect.mockReturnValue({ from: authFrom });
+  });
+
+  // ── Authentication ────────────────────────────────────────────────────────
+
+  describe("authentication", () => {
+    it("returns 401 when Authorization header is absent", async () => {
+      const res = await request(app).get(predictionsUrl());
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBeDefined();
+      expect(mockListPredictions).not.toHaveBeenCalled();
+    });
+
+    it("returns 401 with an invalid JWT", async () => {
+      const res = await request(app)
+        .get(predictionsUrl())
+        .set("Authorization", "Bearer not-a-valid-token");
+      expect(res.status).toBe(401);
+      expect(mockListPredictions).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Query param validation ────────────────────────────────────────────────
+  // These tests REQUIRE a valid token so they reach the validation layer.
+  // We also prime authLimit so requireAuth can resolve the user row.
+
+  describe("query param validation", () => {
+    beforeEach(() => {
+      authLimit.mockResolvedValue([MOCK_USER_ROW]);
+    });
+
+    it("returns 400 validation_error for an unknown status value", async () => {
+      const res = await request(app)
+        .get(predictionsUrl({ status: "unknown_status" }))
+        .set("Authorization", `Bearer ${validToken()}`);
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+      expect(mockListPredictions).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 validation_error for limit = 0", async () => {
+      const res = await request(app)
+        .get(predictionsUrl({ limit: "0" }))
+        .set("Authorization", `Bearer ${validToken()}`);
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 validation_error for limit > 100", async () => {
+      const res = await request(app)
+        .get(predictionsUrl({ limit: "101" }))
+        .set("Authorization", `Bearer ${validToken()}`);
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 validation_error for a non-integer limit", async () => {
+      const res = await request(app)
+        .get(predictionsUrl({ limit: "abc" }))
+        .set("Authorization", `Bearer ${validToken()}`);
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 validation_error for an empty marketId string", async () => {
+      const res = await request(app)
+        .get(predictionsUrl({ marketId: "" }))
+        .set("Authorization", `Bearer ${validToken()}`);
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("accepts valid status values", async () => {
+      for (const status of ["pending", "confirmed", "won", "lost", "claimed"]) {
+        authLimit.mockResolvedValue([MOCK_USER_ROW]);
+        mockListPredictions.mockResolvedValueOnce({
+          data: [],
+          nextCursor: null,
+        });
+        const res = await request(app)
+          .get(predictionsUrl({ status }))
+          .set("Authorization", `Bearer ${validToken()}`);
+        expect(res.status).toBe(200);
+      }
+    });
+
+    it("accepts limit = 1", async () => {
+      mockListPredictions.mockResolvedValueOnce({ data: [], nextCursor: null });
+      const res = await request(app)
+        .get(predictionsUrl({ limit: "1" }))
+        .set("Authorization", `Bearer ${validToken()}`);
+      expect(res.status).toBe(200);
+    });
+
+    it("accepts limit = 100", async () => {
+      mockListPredictions.mockResolvedValueOnce({ data: [], nextCursor: null });
+      const res = await request(app)
+        .get(predictionsUrl({ limit: "100" }))
+        .set("Authorization", `Bearer ${validToken()}`);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ── Happy path ────────────────────────────────────────────────────────────
+
+  describe("happy path", () => {
+    beforeEach(() => {
+      authLimit.mockResolvedValue([MOCK_USER_ROW]);
+    });
+
+    it("returns 200 with data and nextCursor on first page", async () => {
+      const cursor = encodeCursor({ sortValue: SORT_TS, id: PREDICTION_ID_1 });
+      mockListPredictions.mockResolvedValueOnce({
+        data: [makePredictionRow(PREDICTION_ID_1)],
+        nextCursor: cursor,
+      });
+
+      const res = await request(app)
+        .get(predictionsUrl({ limit: "1" }))
+        .set("Authorization", `Bearer ${validToken()}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0].id).toBe(PREDICTION_ID_1);
+      expect(res.body.nextCursor).toBe(cursor);
+    });
+
+    it("returns nextCursor = null on the last page", async () => {
+      mockListPredictions.mockResolvedValueOnce({
+        data: [
+          makePredictionRow(PREDICTION_ID_1),
+          makePredictionRow(PREDICTION_ID_2),
+        ],
+        nextCursor: null,
+      });
+
+      const res = await request(app)
+        .get(predictionsUrl({ limit: "10" }))
+        .set("Authorization", `Bearer ${validToken()}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.nextCursor).toBeNull();
+    });
+
+    it("returns empty data array with nextCursor = null when user has no predictions", async () => {
+      mockListPredictions.mockResolvedValueOnce({
+        data: [],
+        nextCursor: null,
+      });
+
+      const res = await request(app)
+        .get(predictionsUrl())
+        .set("Authorization", `Bearer ${validToken()}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual([]);
+      expect(res.body.nextCursor).toBeNull();
+    });
+
+    it("defaults limit to 20 when the query param is absent", async () => {
+      mockListPredictions.mockResolvedValueOnce({ data: [], nextCursor: null });
+
+      await request(app)
+        .get(predictionsUrl())
+        .set("Authorization", `Bearer ${validToken()}`);
+
+      expect(mockListPredictions).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ limit: 20 }),
+      );
+    });
+  });
+
+  // ── Filter forwarding ─────────────────────────────────────────────────────
+
+  describe("filter forwarding", () => {
+    beforeEach(() => {
+      authLimit.mockResolvedValue([MOCK_USER_ROW]);
+    });
+
+    it("forwards marketId filter to the repo", async () => {
+      mockListPredictions.mockResolvedValueOnce({ data: [], nextCursor: null });
+
+      await request(app)
+        .get(predictionsUrl({ marketId: MARKET_ID }))
+        .set("Authorization", `Bearer ${validToken()}`);
+
+      expect(mockListPredictions).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ marketId: MARKET_ID }),
+      );
+    });
+
+    it("forwards status filter to the repo", async () => {
+      mockListPredictions.mockResolvedValueOnce({ data: [], nextCursor: null });
+
+      await request(app)
+        .get(predictionsUrl({ status: "won" }))
+        .set("Authorization", `Bearer ${validToken()}`);
+
+      expect(mockListPredictions).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ status: "won" }),
+      );
+    });
+
+    it("forwards outcome filter to the repo", async () => {
+      mockListPredictions.mockResolvedValueOnce({ data: [], nextCursor: null });
+
+      await request(app)
+        .get(predictionsUrl({ outcome: "no" }))
+        .set("Authorization", `Bearer ${validToken()}`);
+
+      expect(mockListPredictions).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ outcome: "no" }),
+      );
+    });
+
+    it("forwards cursor to the repo", async () => {
+      const cursor = encodeCursor({ sortValue: SORT_TS, id: PREDICTION_ID_1 });
+      mockListPredictions.mockResolvedValueOnce({ data: [], nextCursor: null });
+
+      await request(app)
+        .get(predictionsUrl({ cursor }))
+        .set("Authorization", `Bearer ${validToken()}`);
+
+      expect(mockListPredictions).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ cursor }),
+      );
+    });
+
+    it("forwards all filters together to the repo", async () => {
+      const cursor = encodeCursor({ sortValue: SORT_TS, id: PREDICTION_ID_2 });
+      mockListPredictions.mockResolvedValueOnce({ data: [], nextCursor: null });
+
+      await request(app)
+        .get(
+          predictionsUrl({
+            marketId: MARKET_ID,
+            status: "confirmed",
+            outcome: "yes",
+            cursor,
+            limit: "5",
+          }),
+        )
+        .set("Authorization", `Bearer ${validToken()}`);
+
+      expect(mockListPredictions).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          marketId: MARKET_ID,
+          status: "confirmed",
+          outcome: "yes",
+          cursor,
+          limit: 5,
+        }),
+      );
+    });
+  });
+
+  // ── Cursor threading ──────────────────────────────────────────────────────
+
+  describe("cursor threading", () => {
+    beforeEach(() => {
+      authLimit.mockResolvedValue([MOCK_USER_ROW]);
+    });
+
+    it("passes nextCursor from page N as cursor in page N+1 and returns correct results", async () => {
+      const cursor = encodeCursor({ sortValue: SORT_TS, id: PREDICTION_ID_1 });
+
+      // First page returns row1 and a nextCursor.
+      mockListPredictions.mockResolvedValueOnce({
+        data: [makePredictionRow(PREDICTION_ID_1)],
+        nextCursor: cursor,
+      });
+
+      const page1 = await request(app)
+        .get(predictionsUrl({ limit: "1" }))
+        .set("Authorization", `Bearer ${validToken()}`);
+
+      expect(page1.body.nextCursor).toBe(cursor);
+
+      // Second page uses the cursor from page 1.
+      authLimit.mockResolvedValue([MOCK_USER_ROW]);
+      mockListPredictions.mockResolvedValueOnce({
+        data: [makePredictionRow(PREDICTION_ID_2)],
+        nextCursor: null,
+      });
+
+      const page2 = await request(app)
+        .get(predictionsUrl({ limit: "1", cursor: page1.body.nextCursor }))
+        .set("Authorization", `Bearer ${validToken()}`);
+
+      expect(page2.status).toBe(200);
+      expect(page2.body.data[0].id).toBe(PREDICTION_ID_2);
+      expect(page2.body.nextCursor).toBeNull();
+    });
+
+    it("handles a tampered/malformed cursor without 500-ing", async () => {
+      // A garbage cursor should be forwarded to the repo which will ignore it
+      // (decodeCursor returns null) and return from page 1.
+      mockListPredictions.mockResolvedValueOnce({ data: [], nextCursor: null });
+
+      const res = await request(app)
+        .get(predictionsUrl({ cursor: "AAAA_not_a_valid_cursor_!!" }))
+        .set("Authorization", `Bearer ${validToken()}`);
+
+      // Route should still respond 200 — the repo handles the invalid cursor.
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual([]);
+    });
+  });
+
+  // ── Error propagation ─────────────────────────────────────────────────────
+
+  describe("error propagation", () => {
+    beforeEach(() => {
+      authLimit.mockResolvedValue([MOCK_USER_ROW]);
+    });
+
+    it("returns 500 when the repo throws unexpectedly", async () => {
+      mockListPredictions.mockRejectedValueOnce(new Error("db connection lost"));
+
+      const res = await request(app)
+        .get(predictionsUrl())
+        .set("Authorization", `Bearer ${validToken()}`);
+
+      expect(res.status).toBe(500);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Repository-level tests (unit tests for listPredictions itself)
+// ---------------------------------------------------------------------------
+describe("listPredictions — repository", () => {
+  // We need to import the *real* function, not the jest.mock() stub.
+  // jest.requireActual bypasses the module-level mock set up above.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { listPredictions: realListPredictions } = jest.requireActual(
+    "../src/repositories/predictionRepo",
+  ) as typeof import("../src/repositories/predictionRepo");
+
+  // We need to patch the db client that predictionRepo imports at module scope.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const clientModule = require("../src/db/client") as {
+    db: { select: jest.Mock };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /** Builds the fluent Drizzle query chain mock and wires it on clientModule.db. */
+  function stubDbQuery(returnRows: unknown[]) {
+    const limitMock = jest.fn().mockResolvedValue(returnRows);
+    const orderByMock = jest.fn().mockReturnValue({ limit: limitMock });
+    const whereMock = jest.fn().mockReturnValue({ orderBy: orderByMock });
+    const innerJoinMock = jest.fn().mockReturnValue({ where: whereMock });
+    const fromMock = jest.fn().mockReturnValue({ innerJoin: innerJoinMock });
+    const selectMock = jest.fn().mockReturnValue({ from: fromMock });
+    clientModule.db.select = selectMock;
+    return { selectMock, fromMock, innerJoinMock, whereMock, orderByMock, limitMock };
+  }
+
+  function makeDbRow(id: string, createdAt = new Date(SORT_TS)) {
+    return {
+      id,
+      marketId: MARKET_ID,
+      question: "Test market",
+      outcome: "yes",
+      amount: "50",
+      txHash: "txhash",
+      status: "pending",
+      result: null,
+      createdAt,
+      resolutionTime: new Date("2027-01-01T00:00:00.000Z"),
+    };
+  }
+
+  it("returns empty data with nextCursor = null when DB returns zero rows", async () => {
+    stubDbQuery([]);
+
+    const page = await realListPredictions(TEST_USER_ID, { limit: 20 });
+
+    expect(page.data).toEqual([]);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it("serialises Date fields to ISO strings", async () => {
+    const row = makeDbRow(PREDICTION_ID_1);
+    stubDbQuery([row]);
+
+    const page = await realListPredictions(TEST_USER_ID, { limit: 20 });
+
+    expect(page.data[0].createdAt).toBe(row.createdAt.toISOString());
+    expect(page.data[0].resolutionTime).toBe(
+      row.resolutionTime.toISOString(),
+    );
+  });
+
+  it("sets nextCursor when there are more rows than the limit (hasMore = true)", async () => {
+    // Return limit+1 rows to trigger hasMore = true.
+    const rows = [
+      makeDbRow(PREDICTION_ID_1),
+      makeDbRow(PREDICTION_ID_2),
+    ];
+    stubDbQuery(rows);
+
+    const page = await realListPredictions(TEST_USER_ID, { limit: 1 });
+
+    expect(page.data).toHaveLength(1);
+    expect(page.nextCursor).not.toBeNull();
+  });
+
+  it("sets nextCursor = null when returned rows <= limit", async () => {
+    stubDbQuery([makeDbRow(PREDICTION_ID_1)]);
+
+    const page = await realListPredictions(TEST_USER_ID, { limit: 5 });
+
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it("does not leak the extra probe row into the data array", async () => {
+    const rows = [
+      makeDbRow(PREDICTION_ID_1),
+      makeDbRow(PREDICTION_ID_2),
+    ];
+    stubDbQuery(rows);
+
+    const page = await realListPredictions(TEST_USER_ID, { limit: 1 });
+
+    // Only the first row should appear in data; the extra probe row is cut.
+    expect(page.data).toHaveLength(1);
+    expect(page.data[0].id).toBe(PREDICTION_ID_1);
+  });
+
+  it("encodes the correct cursor from the last row on the page", async () => {
+    const date = new Date(SORT_TS);
+    const rows = [makeDbRow(PREDICTION_ID_1, date), makeDbRow(PREDICTION_ID_2)];
+    stubDbQuery(rows);
+
+    const page = await realListPredictions(TEST_USER_ID, { limit: 1 });
+
+    const { decodeCursor: dc } = jest.requireActual(
+      "../src/utils/cursor",
+    ) as typeof import("../src/utils/cursor");
+    const key = dc(page.nextCursor!);
+    expect(key).not.toBeNull();
+    expect(key!.sortValue).toBe(date.toISOString());
+    expect(key!.id).toBe(PREDICTION_ID_1);
+  });
+
+  it("accepts an invalid cursor and does not throw", async () => {
+    stubDbQuery([]);
+    // Should not throw, should just run without a cursor predicate.
+    await expect(
+      realListPredictions(TEST_USER_ID, {
+        limit: 20,
+        cursor: "AAAA_garbage_cursor",
+      }),
+    ).resolves.toMatchObject({ data: [], nextCursor: null });
+  });
+});


### PR DESCRIPTION
- Add src/repositories/predictionRepo.ts with listPredictions() Keyset pagination on (createdAt DESC, id DESC) via shared encodeCursor/decodeCursor helpers. Supports optional filters: marketId, status, outcome. Fetches limit+1 rows to detect hasMore without a COUNT round-trip. All conditions use parameterised Drizzle column expressions (no string interpolation).

- Replace stub GET /api/predictions with paginated handler Zod input validation at the route boundary, requireAuth guard, structured pino logging with reqId/userId, standardised error envelope on 400/401, errors bubble to global errorHandler.

- Add 29-test suite in tests/predictionsList.test.ts Route-level tests: auth (401), input validation (400), happy path, filter forwarding, cursor threading, tampered cursor, repo error. Repository-level tests: empty result, Date serialisation, hasMore probe, nextCursor encoding, invalid cursor tolerance.

- Register GET /api/predictions in OpenAPI registry (Predictions tag) PredictionRow and PredictionsListResponse component schemas added.

- Add docs/predictions-api.md Covers auth, query params, pagination flow, response shapes, implementation notes, and diff vs /api/users/:address/predictions.
- closes #292