### PR TITLE
Task/markets etag v7

### DIFF
--- a/docs/markets-api.md
+++ b/docs/markets-api.md
@@ -41,6 +41,19 @@ On a matching revalidation request, the route responds with `304 Not Modified`
 and does not return a response body. Clients should treat the response as a
 cache revalidation success and reuse the previously cached representation.
 
+### Conditional requests and caching
+
+The public market listing endpoint supports strong ETags. Clients may send an
+`If-None-Match` header with the latest ETag to receive a `304 Not Modified`
+response without a body when the market list has not changed.
+
+Example:
+
+```http
+GET /api/markets
+If-None-Match: "<etag>"
+```
+
 ### Errors
 
 - `401 Unauthorized` when the bearer token is missing, malformed, invalid, or

--- a/docs/markets-api.md
+++ b/docs/markets-api.md
@@ -34,6 +34,13 @@ non-archived markets related to terms from the user's prediction history, and
 falls back to recent active non-archived markets when there is no usable history
 or no related market is found.
 
+### ETag support
+
+`GET /api/markets` supports conditional revalidation through `ETag` and `If-None-Match`.
+On a matching revalidation request, the route responds with `304 Not Modified`
+and does not return a response body. Clients should treat the response as a
+cache revalidation success and reuse the previously cached representation.
+
 ### Errors
 
 - `401 Unauthorized` when the bearer token is missing, malformed, invalid, or

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,19 +1,14 @@
 import { envSchema, formatEnvErrors } from "./env-schema";
-import { formatEnvErrors } from "./env-schema";
 
 const parsed = envSchema.safeParse(process.env);
 
 if (!parsed.success) {
-  // In test environments we tolerate missing env values; elsewhere we crash fast.
   if (process.env.NODE_ENV !== "test") {
     console.error("❌ Invalid environment configuration:\n" + formatEnvErrors(parsed.error));
     process.exit(1);
   }
 }
 
-export const env = parsed.success ? parsed.data : ({} as ReturnType<typeof envSchema.parse>);
-  console.error("❌ Invalid environment variables:\n" + formatEnvErrors(parsed.error));
-  process.exit(1);
-}
-
-export const env = parsed.data;
+export const env = parsed.success
+  ? parsed.data
+  : ({} as ReturnType<typeof envSchema.parse>);

--- a/src/middleware/etag.ts
+++ b/src/middleware/etag.ts
@@ -8,8 +8,9 @@
  * `generateETag(payload)` – deterministically hashes any serialisable value
  * using SHA-256 and returns a quoted strong ETag string, e.g. `"a3f2..."`.
  *
- * `conditionalGet(payload)` – Express middleware factory.  Call it with the
- * freshly-loaded resource payload after the database read:
+ * `conditionalGet(payload)` – Express middleware helper. Call it with the
+ * freshly-loaded resource payload after the database read (single object or
+ * collection response payloads such as `{ data: [...] }`):
  *
  *   1. Computes the strong ETag for `payload`.
  *   2. Sets `ETag` and `Cache-Control: no-cache` response headers so the
@@ -133,15 +134,22 @@ export function conditionalGet(
   res.setHeader("Cache-Control", "no-cache");
 
   const ifNoneMatch = req.headers["if-none-match"];
+  const ifNoneMatchValues = Array.isArray(ifNoneMatch)
+    ? ifNoneMatch.filter((value): value is string => typeof value === "string")
+    : typeof ifNoneMatch === "string"
+      ? [ifNoneMatch]
+      : [];
 
-  if (ifNoneMatch) {
+  if (ifNoneMatchValues.length > 0) {
     // Strip surrounding quotes from the client-sent header value so both
     // `"abc123"` (quoted, as sent by compliant clients) and the raw hash
     // are compared correctly against our quoted ETag.
-    const normalised = ifNoneMatch.replace(/^"|"$/g, "");
+    const normalisedValues = ifNoneMatchValues.map((value) =>
+      value.replace(/^"|"$/g, ""),
+    );
     const currentHash = etag.replace(/^"|"$/g, "");
 
-    if (normalised === currentHash) {
+    if (normalisedValues.includes(currentHash)) {
       logger.debug(
         { reqId, etag, path: req.path },
         "etag_not_modified",

--- a/src/routes/markets/index.ts
+++ b/src/routes/markets/index.ts
@@ -12,6 +12,7 @@ import { rateLimitAnon } from "../../middleware/rateLimitAnon";
 import { listFeaturedMarkets } from "../../services/marketFeatureService";
 import { logger } from "../../config/logger";
 import { RouteErrorFactory } from "../../errors";
+import { conditionalGet } from "../../middleware/etag";
 import { recommendationsRouter } from "./recommendations";
 import { trendingRouter } from "./trending";
 import { tagsRouter } from "./tags";
@@ -108,12 +109,18 @@ marketsRouter.get("/", async (req, res, next) => {
 
     const data = await listMarkets();
     const slicedData = limit !== undefined ? data.slice(0, limit) : data;
+    const payload = { data: slicedData };
+
+    const etagHandled = conditionalGet(payload, req, res);
+    if (etagHandled) {
+      return;
+    }
 
     logger.info(
       { reqId, correlationId: reqId, count: slicedData.length },
       "markets_list_success",
     );
-    return res.json({ data: slicedData });
+    return res.status(200).json(payload);
   } catch (e) {
     logger.error(
       { reqId, correlationId: reqId, err: e },

--- a/src/routes/markets/index.ts
+++ b/src/routes/markets/index.ts
@@ -196,7 +196,13 @@ marketsRouter.get("/:id", async (req, res, next) => {
       { reqId, correlationId: reqId, marketId },
       "markets_get_success",
     );
-    return res.json({ data: market });
+
+    const responsePayload = { data: market };
+    if (conditionalGet(responsePayload, req, res)) {
+      return;
+    }
+
+    return res.json(responsePayload);
   } catch (e) {
     logger.error(
       { reqId, correlationId: reqId, marketId: req.params.id, err: e },

--- a/tests/markets.test.ts
+++ b/tests/markets.test.ts
@@ -89,6 +89,50 @@ describe("GET /api/markets", () => {
     });
   });
 
+  it("returns an ETag header and supports conditional revalidation", async () => {
+    setDbForTests(createMarketDb([
+      {
+        id: "market-1",
+        question: "Will Predictify ship real market reads?",
+        status: "active",
+        resolutionTime: new Date("2026-07-01T00:00:00.000Z"),
+        version: 1,
+      },
+    ]));
+
+    const first = await request(createApp()).get("/api/markets");
+
+    expect(first.status).toBe(200);
+    expect(first.headers["etag"]).toMatch(/^"[0-9a-f]{64}"$/);
+    expect(first.headers["cache-control"]).toBe("no-cache");
+
+    const second = await request(createApp())
+      .get("/api/markets")
+      .set("If-None-Match", first.headers["etag"] as string);
+
+    expect(second.status).toBe(304);
+    expect(second.text).toBe("");
+  });
+
+  it("returns 200 for a stale If-None-Match value", async () => {
+    setDbForTests(createMarketDb([
+      {
+        id: "market-1",
+        question: "Will Predictify ship real market reads?",
+        status: "active",
+        resolutionTime: new Date("2026-07-01T00:00:00.000Z"),
+        version: 1,
+      },
+    ]));
+
+    const res = await request(createApp())
+      .get("/api/markets")
+      .set("If-None-Match", '"000000000000000000000000000000000000000000000000000000000000dead"');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("data");
+  });
+
   it("returns empty array when no markets exist", async () => {
     setDbForTests(createMarketDb([]));
 


### PR DESCRIPTION
# feat: add ETag support for /api/markets

## Summary

This PR adds ETag support for the public markets endpoints so clients can perform conditional GET requests and receive `304 Not Modified` responses when the response payload has not changed.

### What changed
- Added strong ETag generation and conditional revalidation handling for the public markets list and market detail responses.
- Returned `ETag` and `Cache-Control: no-cache` headers for the relevant GET responses.
- Added focused regression tests covering ETag headers and conditional revalidation behavior for the markets listing endpoint.
- Documented the new caching/conditional request behavior in the markets API docs.

Closes: #387 