### PR TITLE
test: add predictions integration coverage

### DIFF
--- a/tests/integration/predictions.test.ts
+++ b/tests/integration/predictions.test.ts
@@ -338,6 +338,18 @@ describe("GET /api/predictions integration", () => {
       expect(res.body.error.requestId).toEqual(expect.any(String));
     });
 
+    it("returns 400 validation_error when marketId is empty", async () => {
+      await seedUser("GEMPTYMARKETIDUSER");
+
+      const res = await request(createPredictionsApp())
+        .get("/api/predictions?marketId=")
+        .set("Authorization", `Bearer ${tokenFor("GEMPTYMARKETIDUSER")}`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatchObject({ code: "validation_error" });
+      expect(res.body.error.requestId).toEqual(expect.any(String));
+    });
+
     it("returns 400 validation_error when limit exceeds the maximum", async () => {
       await seedUser("GLIMITUSER");
 


### PR DESCRIPTION
# test: add predictions integration coverage

## Summary
Add focused integration coverage for the predictions listing endpoint by exercising an empty `marketId` validation case.

## What changed

- Added a new integration test in `tests/integration/predictions.test.ts`
- Covered the boundary case where `GET /api/predictions?marketId=` returns a validation error with the expected error envelope
- Kept the change scoped to prediction endpoint coverage and did not modify unrelated behavior

## Verification

- Ran:
  - `npm run test:integration -- --runTestsByPath tests/integration/predictions.test.ts --runInBand`
  - Result: 17/17 tests passed
- Ran:
  - `npx eslint tests/integration/predictions.test.ts`
  - Result: no lint errors
  
  Closes: #347 