### PR TITLE
feat: rate limit predictions

### DIFF
--- a/docs/predictions-api.md
+++ b/docs/predictions-api.md
@@ -11,6 +11,8 @@ Returns a cursor-paginated list of predictions belonging to the **authenticated 
 Requires a valid JWT in the `Authorization: Bearer <token>` header.
 Returns `401 unauthenticated` when the token is absent, expired, or invalid.
 
+The authenticated predictions listing endpoint is also protected by a per-user rate limit of `60` requests per minute. Once that quota is exceeded, the endpoint returns `429 rate_limit_exceeded` with `Retry-After` and `resetAt` metadata.
+
 ---
 
 ### Query Parameters
@@ -98,6 +100,19 @@ GET /api/predictions?limit=20&cursor=djF8MjR8...
 }
 ```
 
+**429 rate_limit_exceeded** — per-user quota exceeded
+
+```json
+{
+  "error": {
+    "code": "rate_limit_exceeded",
+    "message": "Too many requests",
+    "retryAfter": 60,
+    "resetAt": "2026-07-25T12:34:56.000Z"
+  }
+}
+```
+
 ---
 
 ### Implementation Details
@@ -118,6 +133,7 @@ GET /api/predictions?limit=20&cursor=djF8MjR8...
 
 - Input validated with Zod at the route boundary before any DB access.
 - `requireAuth` middleware enforces authentication; `req.user.id` is always populated when the handler executes.
+- A per-user `createPerUserRateLimiter` protects the authenticated predictions routes at `60` requests/minute per user, returning a standard `429` error envelope with retry metadata.
 - Structured logging via `pino` with `reqId` (from `x-request-id`) and `userId` on every log entry.
 - Errors bubble to the global `errorHandler` middleware for standardised envelopes.
 

--- a/src/routes/predictions.ts
+++ b/src/routes/predictions.ts
@@ -3,6 +3,7 @@
 import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { requireAuth } from "../middleware/requireAuth";
+import { createPerUserRateLimiter } from "../middleware/rateLimit";
 import { getPredictionExplanation } from "../services/predictionExplainService";
 import cancelRouter from "./predictions/cancel";
 import { createShareRouter } from "./predictions/share";
@@ -28,6 +29,20 @@ predictionsRouter.use("/", cancelRouter);
 
 // ── Authenticated routes ──────────────────────────────────────────────────
 predictionsRouter.use(requireAuth);
+predictionsRouter.use(
+  createPerUserRateLimiter({
+    windowMs: 60 * 1000,
+    limit: 60,
+    keyGenerator: (req) => {
+      const userId = (req as AuthenticatedRequest).user?.id;
+      if (typeof userId === "string" && userId.trim().length > 0) {
+        return `predictions:${userId}`;
+      }
+
+      return `predictions:unknown`;
+    },
+  }),
+);
 
 // Zod schema for GET /api/predictions query parameters.
 // Validated at the route boundary before any DB access.

--- a/tests/integration/predictions.test.ts
+++ b/tests/integration/predictions.test.ts
@@ -338,6 +338,29 @@ describe("GET /api/predictions integration", () => {
       expect(res.body.error.requestId).toEqual(expect.any(String));
     });
 
+    it("returns 429 once the per-user limit is exceeded", async () => {
+      await seedUser("GRATELIMITUSER");
+      const token = tokenFor("GRATELIMITUSER");
+
+      for (let index = 0; index < 60; index += 1) {
+        const res = await request(createPredictionsApp())
+          .get("/api/predictions")
+          .set("Authorization", `Bearer ${token}`);
+
+        expect(res.status).toBe(200);
+      }
+
+      const blocked = await request(createPredictionsApp())
+        .get("/api/predictions")
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(blocked.status).toBe(429);
+      expect(blocked.body.error).toMatchObject({
+        code: "rate_limit_exceeded",
+        retryAfter: expect.any(Number),
+      });
+    });
+
     it("returns 400 validation_error when limit exceeds the maximum", async () => {
       await seedUser("GLIMITUSER");
 


### PR DESCRIPTION
## Summary

Add a per-user rate limit to the authenticated predictions listing endpoint so repeated requests are throttled with a standard 429 response.

## What changed

- Applied a per-user limiter to the predictions router at 60 requests per minute
- Added integration coverage for the 429 response once the limit is exceeded
- Documented the new rate-limit behavior and error response in the predictions API docs

## Verification

- Ran:
  - `npm run test:integration -- --runTestsByPath tests/integration/predictions.test.ts --runInBand`
  - Result: 17/17 tests passed
- Ran:
  - `npx eslint src/routes/predictions.ts tests/integration/predictions.test.ts`
  - Result: no lint errors
  
  Closes: #348