### PR TITLE
Add strict input validation for predictions queries

### DIFF
--- a/src/routes/predictions.ts
+++ b/src/routes/predictions.ts
@@ -1,7 +1,6 @@
   
   
 import { Router, Request, Response, NextFunction } from "express";
-import { z } from "zod";
 import { requireAuth } from "../middleware/requireAuth";
 import { getPredictionExplanation } from "../services/predictionExplainService";
 import cancelRouter from "./predictions/cancel";
@@ -9,8 +8,9 @@ import { createShareRouter } from "./predictions/share";
 import { listPredictions } from "../repositories/predictionRepo";
 import { logger } from "../config/logger";
 import { getRequestId } from "../lib/requestContext";
-import { clampLimit, DEFAULT_PAGE_SIZE } from "../utils/cursor";
+import { clampLimit } from "../utils/cursor";
 import type { AuthenticatedRequest } from "../middleware/auth";
+import { listPredictionsQuerySchema } from "../validators/predictions";
 
 export const predictionsRouter = Router();
 
@@ -28,23 +28,6 @@ predictionsRouter.use("/", cancelRouter);
 
 // ── Authenticated routes ──────────────────────────────────────────────────
 predictionsRouter.use(requireAuth);
-
-// Zod schema for GET /api/predictions query parameters.
-// Validated at the route boundary before any DB access.
-const listQuerySchema = z.object({
-  /** Filter by market ID (optional). */
-  marketId: z.string().min(1).max(128).optional(),
-  /** Filter by prediction lifecycle status (optional). */
-  status: z
-    .enum(["pending", "confirmed", "won", "lost", "claimed"])
-    .optional(),
-  /** Filter by chosen outcome value (optional). */
-  outcome: z.string().min(1).max(64).optional(),
-  /** Opaque cursor from the previous page (optional). */
-  cursor: z.string().optional(),
-  /** Number of rows to return per page (default 20, max 100). */
-  limit: z.coerce.number().int().min(1).max(100).default(DEFAULT_PAGE_SIZE),
-});
 
 /**
  * GET /api/predictions
@@ -78,7 +61,7 @@ predictionsRouter.get(
 
     try {
       // ── Input validation ─────────────────────────────────────────────────
-      const queryParse = listQuerySchema.safeParse(req.query);
+      const queryParse = listPredictionsQuerySchema.safeParse(req.query);
       if (!queryParse.success) {
         logger.warn(
           { reqId, issues: queryParse.error.issues },

--- a/src/validators/predictions.ts
+++ b/src/validators/predictions.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import { DEFAULT_PAGE_SIZE } from "../utils/cursor";
+
+/**
+ * Schema for GET /api/predictions query parameters.
+ *
+ * Unknown query parameters are rejected to keep the route boundary explicit
+ * and to avoid silently ignoring malformed input.
+ */
+export const listPredictionsQuerySchema = z
+  .object({
+    marketId: z
+      .string({ invalid_type_error: "marketId must be a string" })
+      .trim()
+      .min(1, "marketId must be a non-empty string")
+      .max(128, "marketId must be at most 128 characters")
+      .optional(),
+    status: z
+      .enum(["pending", "confirmed", "won", "lost", "claimed"], {
+        message: "status must be one of: pending, confirmed, won, lost, claimed",
+      })
+      .optional(),
+    outcome: z
+      .string({ invalid_type_error: "outcome must be a string" })
+      .trim()
+      .min(1, "outcome must be a non-empty string")
+      .max(64, "outcome must be at most 64 characters")
+      .optional(),
+    cursor: z.string({ invalid_type_error: "cursor must be a string" }).optional(),
+    limit: z.coerce
+      .number({ invalid_type_error: "limit must be a number" })
+      .int("limit must be an integer")
+      .min(1, "limit must be between 1 and 100")
+      .max(100, "limit must be between 1 and 100")
+      .default(DEFAULT_PAGE_SIZE),
+  })
+  .strict();
+
+export type ListPredictionsQuery = z.infer<typeof listPredictionsQuerySchema>;

--- a/tests/integration/predictions.test.ts
+++ b/tests/integration/predictions.test.ts
@@ -360,6 +360,17 @@ describe("GET /api/predictions integration", () => {
       expect(res.body.error.code).toBe("validation_error");
     });
 
+    it("returns 400 validation_error for unexpected query parameters", async () => {
+      await seedUser("GUNEXPECTEDQUERYUSER");
+
+      const res = await request(createPredictionsApp())
+        .get("/api/predictions?status=won&unexpected=true")
+        .set("Authorization", `Bearer ${tokenFor("GUNEXPECTEDQUERYUSER")}`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
     it("defaults to the standard page size when limit is omitted", async () => {
       const userId = await seedUser("GDEFAULTLIMITUSER");
       await seedMarket({


### PR DESCRIPTION
# Add strict input validation for predictions queries

## PR Description
This change adds route-boundary validation for GET /api/predictions using a dedicated Zod schema.

### What changed
- Introduced a dedicated validator for predictions query parameters in predictions.ts
- Wired the predictions route to reject unexpected query params and enforce the existing validation rules in predictions.ts
- Added a regression integration test covering invalid/unexpected query parameters in predictions.test.ts

### Why
This makes predictions input handling consistent with the project’s other validated routes and ensures malformed requests fail fast with the standard 400 validation error envelope.

### Verification
- Ran ESLint on the touched files
- Ran the predictions integration suite:
  - 1/1 suite passed
  - 17/17 tests passed
  
  Closes: #350