### PR TITLE
feat: ETag on predictions

### DIFF
--- a/src/routes/predictions.ts
+++ b/src/routes/predictions.ts
@@ -3,6 +3,7 @@
 import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { requireAuth } from "../middleware/requireAuth";
+import { conditionalGet } from "../middleware/etag";
 import { getPredictionExplanation } from "../services/predictionExplainService";
 import cancelRouter from "./predictions/cancel";
 import { createShareRouter } from "./predictions/share";
@@ -117,6 +118,9 @@ predictionsRouter.get(
         cursor,
       });
 
+      const payload = { data: page.data, nextCursor: page.nextCursor };
+      if (conditionalGet(payload, req, res)) return;
+
       logger.info(
         {
           reqId,
@@ -127,7 +131,7 @@ predictionsRouter.get(
         "predictions_list_served",
       );
 
-      res.json({ data: page.data, nextCursor: page.nextCursor });
+      res.json(payload);
     } catch (err) {
       next(err);
     }
@@ -143,6 +147,7 @@ predictionsRouter.get("/:id/explain", async (req, res, next) => {
   try {
     const { id } = req.params;
     const explanation = await getPredictionExplanation(id);
+    if (conditionalGet(explanation, req, res)) return;
     res.json(explanation);
   } catch (error) {
     next(error);

--- a/tests/predictionExplain.test.ts
+++ b/tests/predictionExplain.test.ts
@@ -1,0 +1,52 @@
+import request from "supertest";
+import { createApp } from "../src/index";
+import { getPredictionExplanation } from "../src/services/predictionExplainService";
+import { generateETag } from "../src/middleware/etag";
+
+jest.mock("../src/services/predictionExplainService");
+
+const mockGetPredictionExplanation = getPredictionExplanation as jest.MockedFunction<
+  typeof getPredictionExplanation
+>;
+
+const app = createApp();
+
+describe("GET /api/predictions/:id/explain", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 200 with the explanation and ETag", async () => {
+    const mockExplanation = { steps: ["step 1", "step 2"] };
+    // @ts-expect-error - Mocking a subset of the actual response
+    mockGetPredictionExplanation.mockResolvedValueOnce(mockExplanation);
+
+    const res = await request(app).get("/api/predictions/123/explain");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockExplanation);
+    expect(res.headers.etag).toBe(generateETag(mockExplanation));
+  });
+
+  it("returns 304 Not Modified when If-None-Match matches ETag", async () => {
+    const mockExplanation = { steps: ["step 1", "step 2"] };
+    // @ts-expect-error - Mocking a subset of the actual response
+    mockGetPredictionExplanation.mockResolvedValueOnce(mockExplanation);
+    const etag = generateETag(mockExplanation);
+
+    const res = await request(app)
+      .get("/api/predictions/123/explain")
+      .set("If-None-Match", etag);
+
+    expect(res.status).toBe(304);
+    expect(res.body).toEqual({});
+  });
+
+  it("returns 500 when service throws an error", async () => {
+    mockGetPredictionExplanation.mockRejectedValueOnce(new Error("Service error"));
+
+    const res = await request(app).get("/api/predictions/123/explain");
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/tests/predictionsList.test.ts
+++ b/tests/predictionsList.test.ts
@@ -133,6 +133,7 @@ import { predictionsRouter } from "../src/routes/predictions";
 import { errorHandler } from "../src/middleware/errorHandler";
 import { listPredictions } from "../src/repositories/predictionRepo";
 import { encodeCursor } from "../src/utils/cursor";
+import { generateETag } from "../src/middleware/etag";
 import { env } from "../src/config/env";
 
 const mockListPredictions = listPredictions as jest.MockedFunction<
@@ -383,6 +384,48 @@ describe("GET /api/predictions — route", () => {
         expect.any(String),
         expect.objectContaining({ limit: 20 }),
       );
+    });
+  });
+
+  // ── ETag caching ──────────────────────────────────────────────────────────
+
+  describe("ETag caching", () => {
+    beforeEach(() => {
+      authLimit.mockResolvedValue([MOCK_USER_ROW]);
+    });
+
+    it("returns 304 Not Modified when If-None-Match matches payload", async () => {
+      const cursor = encodeCursor({ sortValue: SORT_TS, id: PREDICTION_ID_1 });
+      const mockPayload = {
+        data: [makePredictionRow(PREDICTION_ID_1)],
+        nextCursor: cursor,
+      };
+      
+      mockListPredictions.mockResolvedValueOnce(mockPayload);
+
+      const etag = generateETag(mockPayload);
+
+      const res = await request(app)
+        .get(predictionsUrl({ limit: "1" }))
+        .set("Authorization", `Bearer ${validToken()}`)
+        .set("If-None-Match", etag);
+
+      expect(res.status).toBe(304);
+      expect(res.body).toEqual({});
+    });
+
+    it("returns 200 with ETag header on initial request", async () => {
+      const mockPayload = { data: [], nextCursor: null };
+      mockListPredictions.mockResolvedValueOnce(mockPayload);
+      
+      const expectedEtag = generateETag(mockPayload);
+
+      const res = await request(app)
+        .get(predictionsUrl())
+        .set("Authorization", `Bearer ${validToken()}`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers.etag).toBe(expectedEtag);
     });
   });
 


### PR DESCRIPTION
Closes #344 
This PR implements ETag caching with strong validators on predictions per the GrantFox FWC26 campaign requirements (resolves buffer #8).

Changes
src/routes/predictions.ts: Applied the conditionalGet middleware to GET /api/predictions and GET /api/predictions/:id/explain to handle ETags and 304 Not Modified responses on cache hits.
tests/predictionsList.test.ts: Added dedicated tests verifying ETag caching behavior, including correct handling of the If-None-Match header.
tests/predictionExplain.test.ts: Created a new test suite exclusively for the explain route to provide 100% test coverage for the new ETag caching behavior.
Acceptance Criteria Verified
 Implementation matches the ETag requirements.
 Focused tests added and passing.
 High test coverage maintained on all changed lines.
 Follows repository code style and returns the appropriate HTTP status codes (200 / 304).
