### PR TITLE
feat: prometheus histogram per endpoint

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -38,6 +38,8 @@ Collected by `prom-client`'s `collectDefaultMetrics`:
 | `signup_anomaly_scans_total` | Counter | — | Signup-rate anomaly scans completed ([signup-anomaly.md](signup-anomaly.md)) |
 | `signup_anomalies_detected_total` | Counter | `severity` | Anomalous signup buckets detected (`warning`, `critical`) |
 | `signup_anomaly_top_score` | Gauge | — | Highest modified z-score from the most recent signup scan |
+| `endpoint_requests_total` | Counter | `method`, `route`, `status` | Per-endpoint request count |
+| `endpoint_request_duration_seconds` | Histogram | `method`, `route`, `status` | Per-endpoint request duration in seconds, bucketed |
 
 ## Content type
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from "uuid";
 import { env } from "./config/env";
 import { logger } from "./config/logger";
 import { metricsMiddleware } from "./metrics/httpMetrics";
+import { metricsHistogramMiddleware } from "./middleware/metricsHistogram";
 import { idempotency } from "./middleware/idempotency";
 import { defaultBodySizeLimitMiddleware, webhookBodySizeLimitMiddleware } from "./middleware/bodySize";
 import { healthRouter } from "./routes/health";
@@ -115,6 +116,7 @@ export function createApp(_options: CreateAppOptions = {}): express.Express {
   app.use(defaultBodySizeLimitMiddleware);
 
   app.use(metricsMiddleware);
+  app.use(metricsHistogramMiddleware);
   app.use("/health", healthRouter);
   app.use("/healthz/dependencies", dependenciesRouter);
   app.use("/api/health/ready", createReadyRouter({ db, redis: redisConnection }));

--- a/src/metrics/registry.ts
+++ b/src/metrics/registry.ts
@@ -83,3 +83,18 @@ export const usersEndpointDuration = new Histogram({
   buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10],
   registers: [register],
 });
+
+export const endpointRequestsTotal = new Counter({
+  name: "endpoint_requests_total",
+  help: "Total number of requests per endpoint, segmented by method, route, and status",
+  labelNames: ["method", "route", "status"] as const,
+  registers: [register],
+});
+
+export const endpointRequestDuration = new Histogram({
+  name: "endpoint_request_duration_seconds",
+  help: "Request duration in seconds per endpoint, segmented by method, route, and status",
+  labelNames: ["method", "route", "status"] as const,
+  buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10],
+  registers: [register],
+});

--- a/src/middleware/metricsHistogram.ts
+++ b/src/middleware/metricsHistogram.ts
@@ -1,0 +1,30 @@
+import type { Request, Response, NextFunction } from "express";
+import { endpointRequestsTotal, endpointRequestDuration } from "../metrics/registry";
+
+function sanitizeRoute(route: string): string {
+  return route
+    .replace(/\/[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}/gi, "/:id")
+    .replace(/\/\d+/g, "/:id");
+}
+
+export function metricsHistogramMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const start = process.hrtime.bigint();
+
+  res.on("finish", () => {
+    const durationNs = Number(process.hrtime.bigint() - start);
+    const durationSec = durationNs / 1e9;
+
+    const routeTemplate: string = req.route?.path
+      ? (req.baseUrl || "") + req.route.path
+      : req.path;
+
+    const route = sanitizeRoute(routeTemplate);
+    const method = req.method;
+    const status = String(res.statusCode);
+
+    endpointRequestsTotal.inc({ method, route, status });
+    endpointRequestDuration.observe({ method, route, status }, durationSec);
+  });
+
+  next();
+}

--- a/tests/metricsHistogram.test.ts
+++ b/tests/metricsHistogram.test.ts
@@ -1,0 +1,149 @@
+process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
+process.env.JWT_SECRET = "abcdefghijklmnopqrstuvwxyz123456789012";
+process.env.SOROBAN_RPC_URL = "https://testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "test-contract-id";
+
+import express from "express";
+import request from "supertest";
+import { metricsHistogramMiddleware } from "../src/middleware/metricsHistogram";
+import { endpointRequestsTotal, endpointRequestDuration } from "../src/metrics/registry";
+import { register } from "../src/metrics/registry";
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(metricsHistogramMiddleware);
+  app.get("/test", (_req, res) => res.status(200).json({ ok: true }));
+  app.get("/test/:id", (req, res) => res.status(200).json({ id: req.params.id }));
+  app.post("/test", (_req, res) => res.status(201).json({ ok: true }));
+  app.get("/error", (_req, res) => res.status(500).json({ error: "fail" }));
+  return app;
+}
+
+function counterValue(labels: Record<string, string>): number {
+  const key = Object.keys(labels)
+    .sort()
+    .map((k) => `${k}:${labels[k]}`)
+    .join(",") + ",";
+  const entry = endpointRequestsTotal.hashMap[key] as { value: number } | undefined;
+  return entry?.value ?? 0;
+}
+
+describe("metricsHistogramMiddleware per-endpoint metrics", () => {
+  let app: express.Express;
+
+  beforeAll(() => {
+    app = makeApp();
+  });
+
+  describe("GET /test", () => {
+    it("increments counter with method, route, and status labels", async () => {
+      const before = counterValue({ method: "GET", route: "/test", status: "200" });
+
+      await request(app).get("/test");
+
+      const after = counterValue({ method: "GET", route: "/test", status: "200" });
+      expect(after).toBe(before + 1);
+    });
+
+    it("observes duration in histogram", async () => {
+      await request(app).get("/test");
+
+      const metrics = await endpointRequestDuration.get();
+      const metric = metrics.values.find(
+        (v) => v.labels.route === "/test" && v.labels.method === "GET",
+      );
+      expect(metric).toBeDefined();
+      expect(metric!.labels.status).toBe("200");
+    });
+  });
+
+  describe("POST /test", () => {
+    it("increments counter with method=POST", async () => {
+      const before = counterValue({ method: "POST", route: "/test", status: "201" });
+
+      await request(app).post("/test");
+
+      const after = counterValue({ method: "POST", route: "/test", status: "201" });
+      expect(after).toBe(before + 1);
+    });
+  });
+
+  describe("GET /test/:id", () => {
+    it("normalizes UUID in route", async () => {
+      const before = counterValue({ method: "GET", route: "/test/:id", status: "200" });
+
+      await request(app).get("/test/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+
+      const after = counterValue({ method: "GET", route: "/test/:id", status: "200" });
+      expect(after).toBe(before + 1);
+    });
+
+    it("normalizes numeric ID in route", async () => {
+      const before = counterValue({ method: "GET", route: "/test/:id", status: "200" });
+
+      await request(app).get("/test/12345");
+
+      const after = counterValue({ method: "GET", route: "/test/:id", status: "200" });
+      expect(after).toBe(before + 1);
+    });
+  });
+
+  describe("GET /error", () => {
+    it("records status=500", async () => {
+      const before = counterValue({ method: "GET", route: "/error", status: "500" });
+
+      await request(app).get("/error");
+
+      const after = counterValue({ method: "GET", route: "/error", status: "500" });
+      expect(after).toBe(before + 1);
+    });
+  });
+
+  describe("Prometheus output", () => {
+    it("exposes endpoint_requests_total in /metrics", async () => {
+      await request(app).get("/test");
+
+      const res = await request(createAppWithMetrics()).get("/api/metrics");
+      expect(res.text).toContain("endpoint_requests_total");
+    });
+
+    it("exposes endpoint_request_duration_seconds in /metrics", async () => {
+      await request(app).get("/test");
+
+      const res = await request(createAppWithMetrics()).get("/api/metrics");
+      expect(res.text).toContain("endpoint_request_duration_seconds");
+    });
+  });
+
+  describe("label structure", () => {
+    it("includes method, route, and status labels on histogram", async () => {
+      await request(app).get("/test");
+
+      const metrics = await endpointRequestDuration.get();
+      const metric = metrics.values.find((v) => v.labels.route === "/test");
+      expect(metric).toBeDefined();
+      expect(metric!.labels).toHaveProperty("method", "GET");
+      expect(metric!.labels).toHaveProperty("status", "200");
+    });
+
+    it("includes method, route, and status labels on counter", async () => {
+      await request(app).get("/test");
+
+      const metrics = await endpointRequestsTotal.get();
+      const metric = metrics.values.find((v) => v.labels.route === "/test");
+      expect(metric).toBeDefined();
+      expect(metric!.labels).toHaveProperty("method", "GET");
+      expect(metric!.labels).toHaveProperty("status", "200");
+    });
+  });
+});
+
+function createAppWithMetrics(): express.Express {
+  const app = express();
+  app.get("/api/metrics", async (_req, res) => {
+    res.set("Content-Type", register.contentType);
+    res.send(await register.metrics());
+  });
+  return app;
+}


### PR DESCRIPTION
## Overview

This PR adds per-endpoint Prometheus histogram and counter metrics that record request count and duration segmented by method, route, and status code � providing granular observability for every API endpoint.

## Related Issue

Closes #299

## Changes

- **[ADD]** `src/metrics/registry.ts` � `endpoint_requests_total` Counter and `endpoint_request_duration_seconds` Histogram with `method`, `route`, `status` labels
- **[ADD]** `src/middleware/metricsHistogram.ts` � Generic middleware that hooks into `res.on("finish")` to record counter increment and histogram observation for every request. Route sanitization normalizes UUID and numeric path segments to `/:id`
- **[MODIFY]** `src/index.ts` � Wired `metricsHistogramMiddleware` globally alongside the existing `metricsMiddleware`
- **[ADD]** `tests/metricsHistogram.test.ts` � 10 tests covering counter increment, histogram observation, route normalization (UUID/numeric), error status codes, Prometheus output presence, and label structure verification
- **[MODIFY]** `docs/metrics.md` � Documented both new metrics in the custom metrics table

## Verification Results

```
npm test -- tests/metricsHistogram.test.ts
? 10/10 passed

npm test -- tests/usersMetrics.test.ts
? 13/13 passed (existing tests unaffected)

npm run lint
? Lint passes clean
```

### Acceptance Criteria

| Criteria | Status |
|---|---|
| Implementation matches description | ? Histogram + Counter per endpoint with method, route, status |
| Tests added and passing | ? 10 new tests, 23 total relevant tests pass |
| Docs updated | ? `docs/metrics.md` updated |
| Lint passes | ? Clean |
