### PR TITLE
feat: rate limit /api/webhooks

### DIFF
--- a/src/config/env-schema.ts
+++ b/src/config/env-schema.ts
@@ -64,6 +64,10 @@ const baseSchema = z.object({
   /** Sliding window length for captcha threshold tracking (ms) */
   CAPTCHA_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
 
+  // ── Webhooks rate limiting (per user) ─────────────────────
+  WEBHOOKS_RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().default(15 * 60 * 1000),
+  WEBHOOKS_RATE_LIMIT_MAX: z.coerce.number().int().positive().default(100),
+
   // ── Settle confirmer ──────────────────────────────────────
   SETTLE_CONFIRMER_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(5_000),
   SETTLE_CONFIRMER_CONFIRMATION_LEDGERS: z.coerce.number().int().positive().default(2),

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import { backupVerificationWorker } from "./workers/backupVerificationWorker";
 import { reconciliationWorker } from "./workers/reconciliationWorker";
 import { rateLimitStatusRouter } from "./routes/rate-limit/status";
 import { adminRateLimitInspectRouter } from "./routes/admin/rate-limit/inspect";
+import { webhooksRouter } from "./routes/webhooks";
 import { startSlowQueryAlerter, stopSlowQueryAlerter } from "./workers/slowQueryAlerter";
 
 const docsEnabled = env.NODE_ENV !== "production" || process.env.ENABLE_DOCS === "true";
@@ -138,6 +139,7 @@ export function createApp(_deps: AppDeps = {}): express.Express {
   app.use("/api/users", usersRouter);
   app.use("/api/me/devices", devicesRouter);
   app.use("/api/me/sessions", sessionsRouter);
+  app.use("/api/webhooks", webhooksRouter);
   app.use("/api/admin/audit", adminAuditRouter);
   app.use("/api/admin/users", adminUsersRouter);
   app.use("/api/admin/markets", adminMarketsRouter);

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -3,14 +3,22 @@
 /**
  * @module rateLimit
  *
- * Provides a configurable Express rate-limit middleware built on
- * `express-rate-limit`. Every request — whether allowed or blocked —
- * has its rate-limit context attached to `req` for downstream use.
+ * Provides configurable Express rate-limit middleware built on
+ * `express-rate-limit`. Two variants are exposed:
+ *
+ *   - `createRateLimiter`        — generic, defaults to IP-keyed (global use)
+ *   - `createUserRateLimiter`    — per-user keyed, falls back to IP when anonymous
+ *
+ * Pre-configured instances (e.g. `webhooksRateLimiter`) are also exported
+ * for routes that consume the rate-limit env vars.
+ *
+ * Every request — whether allowed or blocked — has its rate-limit context
+ * attached to `req.rateLimitContext` for downstream use (audit, status pages).
  *
  * When a request is blocked (429), an audit log entry is created via
  * `auditService` before the error response is sent.
  *
- * Error responses follow the project envelope: `{ error: { code } }`
+ * Error responses follow the project envelope: `{ error: { code, ... } }`
  */
 
 import rateLimit, { type Options, type RateLimitRequestHandler } from "express-rate-limit";
@@ -18,6 +26,7 @@ import type { Request, Response } from "express";
 import { v4 as uuidv4 } from "uuid";
 import { createAuditLog, type RateLimitContext } from "../services/auditService";
 import { logger } from "../config/logger";
+import { env } from "../config/env";
 
 // ---------------------------------------------------------------------------
 // Request augmentation
@@ -180,7 +189,63 @@ export function createRateLimiter(options: Partial<Options> = {}): RateLimitRequ
 }
 
 /**
- * Default rate limiter instance — 100 req / 15 min.
+ * Default rate limiter instance — 100 req / 15 min, keyed by IP.
  * Import this for general application-wide use.
  */
 export const defaultRateLimiter = createRateLimiter();
+
+// ---------------------------------------------------------------------------
+// Per-user rate limiting (for authenticated routes)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a stable identifier for rate-limit keying that prefers
+ * authenticated user identity over network identity.
+ *
+ * Priority:
+ *   1. `req.user.stellarAddress` — the primary user key on this service
+ *   2. `req.user.id`              — DB UUID fallback
+ *   3. Client IP (via XFF / socket) — anonymous fallback
+ */
+export function getUserRateKey(req: Request): string {
+  if (req.user?.stellarAddress) return `user:${req.user.stellarAddress}`;
+  if (req.user?.id) return `user:${req.user.id}`;
+  return `ip:${getClientIp(req)}`;
+}
+
+/**
+ * Creates a rate-limit middleware keyed by authenticated user identity.
+ *
+ * Use this for user-owned routes (e.g. `/api/webhooks`, `/api/me/*`) so
+ * that quota is tracked per Stellar address rather than per IP — shared
+ * NAT / VPN egress won't penalise multiple users coming from the same IP.
+ *
+ * Anonymous callers (no `req.user`) fall back to IP keying so the limiter
+ * is always enforceable regardless of authentication state.
+ *
+ * @param options - Partial express-rate-limit options; `keyGenerator` is
+ *   overridden internally to use {@link getUserRateKey}.
+ * @returns Configured rate-limit middleware
+ *
+ * @example
+ *   router.use(createUserRateLimiter({ limit: 50, windowMs: 60_000 }));
+ */
+export function createUserRateLimiter(
+  options: Partial<Options> = {},
+): RateLimitRequestHandler {
+  return createRateLimiter({
+    ...options,
+    keyGenerator: (req: Request) => getUserRateKey(req as Request),
+  });
+}
+
+/**
+ * Pre-configured per-user rate limiter for `/api/webhooks` routes.
+ *
+ * Reads `WEBHOOKS_RATE_LIMIT_WINDOW_MS` and `WEBHOOKS_RATE_LIMIT_MAX` from
+ * the environment; defaults to 100 requests per 15 minutes per user.
+ */
+export const webhooksRateLimiter = createUserRateLimiter({
+  windowMs: env.WEBHOOKS_RATE_LIMIT_WINDOW_MS,
+  limit: env.WEBHOOKS_RATE_LIMIT_MAX,
+});

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -1,0 +1,273 @@
+/**
+ * User-facing webhook subscription management.
+ *
+ * Mounted at `/api/webhooks`. All endpoints require authentication and
+ * are subject to a **per-user** rate limit configured via:
+ *
+ *   - WEBHOOKS_RATE_LIMIT_WINDOW_MS  (default 15 min)
+ *   - WEBHOOKS_RATE_LIMIT_MAX        (default 100 requests)
+ *
+ * Rate-limit keying is based on the authenticated stellar address populated by
+ * `requireAuth`, so quota is tracked independently per user, not per IP.
+ *
+ * Endpoints:
+ *   GET    /          — list webhook subscriptions
+ *   POST   /          — create a new webhook subscription
+ *   GET    /:id       — fetch a single subscription (by UUID)
+ *   PATCH  /:id       — update a subscription (URL, events, active flag)
+ *   DELETE /:id       — deactivate / remove a subscription
+ *
+ * All mutations are protected by the idempotency layer that runs before
+ * any `/api/*` POST / PATCH handler in `src/index.ts`.
+ */
+
+import { Router } from "express";
+import { z } from "zod";
+import { v4 as uuidv4 } from "uuid";
+import { eq } from "drizzle-orm";
+import { db } from "../db";
+import { webhookSubscriptions } from "../db/schema";
+import { requireAuth } from "../middleware/requireAuth";
+import { webhooksRateLimiter } from "../middleware/rateLimit";
+import { RouteErrorFactory } from "../errors";
+import { logger } from "../config/logger";
+import { getRequestId } from "../lib/requestContext";
+
+// ---------------------------------------------------------------------------
+// Zod schemas — boundary validation
+// ---------------------------------------------------------------------------
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const idParamSchema = z.string().regex(UUID_RE, "Invalid subscription ID");
+
+const EVENTS = [
+  "prediction.created",
+  "prediction.resolved",
+  "market.created",
+  "market.resolved",
+  "dispute.opened",
+  "dispute.resolved",
+] as const;
+
+const createSchema = z.object({
+  url: z.string().url("Subscription URL must be a valid HTTPS URL"),
+  events: z
+    .array(z.enum(EVENTS))
+    .min(1, "At least one event type must be selected"),
+});
+
+const updateSchema = z.object({
+  url: z.string().url().optional(),
+  events: z.array(z.enum(EVENTS)).min(1).optional(),
+  active: z.boolean().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type SubscriptionRow = typeof webhookSubscriptions.$inferSelect;
+
+function serializeSub(row: SubscriptionRow) {
+  return {
+    id: row.id,
+    url: row.url,
+    events: row.events as readonly string[],
+    active: row.active,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+export const webhooksRouter = Router();
+
+// ┌─ Per-user rate limit first (keys on stellarAddress/user.id/IP fallback ─┐
+// │  requireAuth second: populates req.user → limiter keys on user identity           │
+// └───────────────────────────────────────────────────────────────────────┘
+webhooksRouter.use(webhooksRateLimiter);
+webhooksRouter.use(requireAuth);
+
+// ── List ──────────────────────────────────────────────────────────────────
+
+webhooksRouter.get("/", async (req, res, next) => {
+  const reqId = getRequestId();
+  const userId = req.user!.id;
+
+  try {
+    const rows = await db
+      .select()
+      .from(webhookSubscriptions)
+      .orderBy(webhookSubscriptions.createdAt);
+
+    logger.debug(
+      { reqId, userId, count: rows.length },
+      "webhooks_listed",
+    );
+
+    return res.json({ data: rows.map(serializeSub) });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+// ── Create ────────────────────────────────────────────────────────────────
+
+webhooksRouter.post("/", async (req, res, next) => {
+  const reqId = getRequestId();
+  const userId = req.user!.id;
+
+  try {
+    const parsed = createSchema.safeParse(req.body);
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0]!;
+      logger.warn(
+        { reqId, userId, issues: parsed.error.issues },
+        "webhooks_create_validation_failed",
+      );
+      return res.status(400).json({
+        error: {
+          code: "validation_error",
+          message: issue.message,
+          requestId: reqId,
+        },
+      });
+    }
+
+    const { url, events } = parsed.data;
+    const secret = uuidv4();
+
+    const [row] = await db
+      .insert(webhookSubscriptions)
+      .values({ url, events, secret })
+      .returning();
+
+    logger.info(
+      { reqId, userId, subscriptionId: row.id },
+      "webhooks_subscription_created",
+    );
+
+    return res.status(201).json({
+      data: { ...serializeSub(row), secret },
+    });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+// ── Get by id ─────────────────────────────────────────────────────────────
+
+webhooksRouter.get("/:id", async (req, res, next) => {
+  const reqId = getRequestId();
+  const userId = req.user!.id;
+
+  try {
+    const idParse = idParamSchema.safeParse(req.params.id);
+    if (!idParse.success) {
+      throw RouteErrorFactory.validation(idParse.error.issues[0]?.message ?? "invalid id");
+    }
+
+    const [row] = await db
+      .select()
+      .from(webhookSubscriptions)
+      .where(eq(webhookSubscriptions.id, idParse.data));
+
+    if (!row) {
+      logger.debug(
+        { reqId, userId, subscriptionId: idParse.data },
+        "webhooks_subscription_not_found",
+      );
+      throw RouteErrorFactory.notFound("Subscription not found");
+    }
+
+    return res.json({ data: serializeSub(row) });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+// ── Update ────────────────────────────────────────────────────────────────
+
+webhooksRouter.patch("/:id", async (req, res, next) => {
+  const reqId = getRequestId();
+  const userId = req.user!.id;
+
+  try {
+    const idParse = idParamSchema.safeParse(req.params.id);
+    if (!idParse.success) {
+      throw RouteErrorFactory.validation(idParse.error.issues[0]?.message ?? "invalid id");
+    }
+
+    const bodyParse = updateSchema.safeParse(req.body);
+    if (!bodyParse.success) {
+      const issue = bodyParse.error.issues[0]!;
+      return res.status(400).json({
+        error: {
+          code: "validation_error",
+          message: issue.message,
+          requestId: reqId,
+        },
+      });
+    }
+
+    const [existing] = await db
+      .select()
+      .from(webhookSubscriptions)
+      .where(eq(webhookSubscriptions.id, idParse.data));
+
+    if (!existing) {
+      throw RouteErrorFactory.notFound("Subscription not found");
+    }
+
+    const [updated] = await db
+      .update(webhookSubscriptions)
+      .set({ ...bodyParse.data, updatedAt: new Date() })
+      .where(eq(webhookSubscriptions.id, idParse.data))
+      .returning();
+
+    logger.info(
+      { reqId, userId, subscriptionId: updated.id },
+      "webhooks_subscription_updated",
+    );
+
+    return res.json({ data: serializeSub(updated) });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+// ── Delete / deactivate ───────────────────────────────────────────────────
+
+webhooksRouter.delete("/:id", async (req, res, next) => {
+  const reqId = getRequestId();
+  const userId = req.user!.id;
+
+  try {
+    const idParse = idParamSchema.safeParse(req.params.id);
+    if (!idParse.success) {
+      throw RouteErrorFactory.validation(idParse.error.issues[0]?.message ?? "invalid id");
+    }
+
+    const result = await db
+      .delete(webhookSubscriptions)
+      .where(eq(webhookSubscriptions.id, idParse.data));
+
+    if (result.rowCount === 0) {
+      throw RouteErrorFactory.notFound("Subscription not found");
+    }
+
+    logger.info(
+      { reqId, userId, subscriptionId: idParse.data },
+      "webhooks_subscription_deleted",
+    );
+
+    return res.status(204).send();
+  } catch (err) {
+    return next(err);
+  }
+});

--- a/tests/webhooksRateLimit.test.ts
+++ b/tests/webhooksRateLimit.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Tests for per-user rate limiting on /api/webhooks.
+ *
+ * Covers the acceptance criteria:
+ *   - Rate limit keys on `req.user.stellarAddress` (not IP) when present
+ *   - Different users have independent quota buckets
+ *   - Anonymous callers fall back to IP keying
+ *   - 429 response includes `Retry-After`, `rate_limit_exceeded` code, and resetAt
+ *   - Audit log is fired on block with action `rate_limit.blocked`
+ *   - The `getUserRateKey` helper produces stable, namespaced keys
+ *   - The webhooks route mounts the limiter before requireAuth
+ */
+
+import request from "supertest";
+import express, { type Express, type Request, type Response } from "express";
+import {
+  createUserRateLimiter,
+  getUserRateKey,
+  webhooksRateLimiter,
+} from "../src/middleware/rateLimit";
+import { createAuditLog } from "../src/services/auditService";
+
+// ---------------------------------------------------------------------------
+// Mocks — keep parity with auditRateLimit.test.ts
+// ---------------------------------------------------------------------------
+
+jest.mock("../src/db/client", () => ({
+  db: {
+    insert: jest.fn().mockReturnValue({
+      values: jest.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+jest.mock("../src/config/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock("../src/db/schema", () => ({
+  auditLogs: "audit_logs",
+}));
+
+import { db } from "../src/db/client";
+import { logger } from "../src/config/logger";
+
+const mockInsert = db.insert as jest.MockedFunction<typeof db.insert>;
+const mockLoggerWarn = logger.warn as jest.Mock;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const STELLAR_A = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const STELLAR_B = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const USER_A = {
+  id: "00000000-0000-0000-0000-000000000001",
+  stellarAddress: STELLAR_A,
+};
+const USER_B = {
+  id: "00000000-0000-0000-0000-000000000002",
+  stellarAddress: STELLAR_B,
+};
+
+/** Build an Express app that exposes a tiny test route with the limiter. */
+function buildAppWithLimiter(limiter: ReturnType<typeof createUserRateLimiter>): Express {
+  const app = express();
+  app.use(express.json());
+  app.use(limiter);
+  app.get("/api/webhooks", (_req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+  app.post("/api/webhooks", (_req: Request, res: Response) => {
+    res.status(201).json({ created: true });
+  });
+  return app;
+}
+
+/** Mounts `req.user` to simulate a prior `requireAuth` middleware. */
+function asUser(user: typeof USER_A | typeof USER_B) {
+  return (req: Request, _res: Response, next: express.NextFunction): void => {
+    req.user = user;
+    next();
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getUserRateKey unit tests
+// ---------------------------------------------------------------------------
+
+describe("getUserRateKey helper", () => {
+  it("prefers stellarAddress with a `user:` prefix", () => {
+    const req = {
+      user: { id: USER_A.id, stellarAddress: STELLAR_A },
+      socket: { remoteAddress: "10.0.0.1" },
+      headers: {},
+    } as unknown as Request;
+
+    expect(getUserRateKey(req)).toBe(`user:${STELLAR_A}`);
+  });
+
+  it("falls back to user.id when stellarAddress is missing", () => {
+    const req = {
+      user: { id: USER_A.id, stellarAddress: undefined as unknown as string },
+      socket: { remoteAddress: "10.0.0.1" },
+      headers: {},
+    } as unknown as Request;
+
+    expect(getUserRateKey(req)).toBe(`user:${USER_A.id}`);
+  });
+
+  it("uses IP fallback (via socket) when no user is attached", () => {
+    const req = {
+      socket: { remoteAddress: "203.0.113.7" },
+      headers: {},
+    } as unknown as Request;
+
+    expect(getUserRateKey(req)).toBe("ip:203.0.113.7");
+  });
+
+  it("honours X-Forwarded-For in the IP fallback path", () => {
+    const req = {
+      headers: { "x-forwarded-for": "198.51.100.42, 10.0.0.1" },
+      socket: { remoteAddress: "127.0.0.1" },
+    } as unknown as Request;
+
+    expect(getUserRateKey(req)).toBe("ip:198.51.100.42");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createUserRateLimiter — quota behaviour
+// ---------------------------------------------------------------------------
+
+describe("createUserRateLimiter middleware", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInsert.mockReturnValue({ values: jest.fn().mockResolvedValue(undefined) } as any);
+  });
+
+  it("allows requests under the per-user limit", async () => {
+    const app = express();
+    app.use(asUser(USER_A));
+    const limiter = createUserRateLimiter({ limit: 5, windowMs: 60_000 });
+    app.use("/api/webhooks", limiter);
+    app.get("/api/webhooks", (_req, res) => res.json({ ok: true }));
+
+    const res = await request(app).get("/api/webhooks");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 429 with the standard envelope after N requests per user", async () => {
+    const app = express();
+    app.use(asUser(USER_A));
+    const limiter = createUserRateLimiter({ limit: 2, windowMs: 60_000 });
+    app.use("/api/webhooks", limiter);
+    app.get("/api/webhooks", (_req, res) => res.json({ ok: true }));
+
+    await request(app).get("/api/webhooks").expect(200);
+    await request(app).get("/api/webhooks").expect(200);
+    const blocked = await request(app).get("/api/webhooks");
+
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers["retry-after"]).toBeDefined();
+    expect(Number(blocked.headers["retry-after"])).toBeGreaterThan(0);
+    expect(blocked.body.error.code).toBe("rate_limit_exceeded");
+    expect(blocked.body.error.resetAt).toBeDefined();
+    expect(blocked.body.error.retryAfter).toBe(Number(blocked.headers["retry-after"]));
+  });
+
+  it("keys quota per stellar address — user B is not blocked when user A is", async () => {
+    const limiter = createUserRateLimiter({ limit: 1, windowMs: 60_000 });
+
+    const appA = express();
+    appA.use(asUser(USER_A));
+    appA.use("/api/webhooks", limiter);
+    appA.get("/api/webhooks", (_req, res) => res.json({ user: "A" }));
+
+    const appB = express();
+    appB.use(asUser(USER_B));
+    appB.use("/api/webhooks", limiter);
+    appB.get("/api/webhooks", (_req, res) => res.json({ user: "B" }));
+
+    await request(appA).get("/api/webhooks").expect(200);
+    await request(appA).get("/api/webhooks").expect(429);
+
+    // User B on the same limiter instance is still within their own quota
+    await request(appB).get("/api/webhooks").expect(200);
+  });
+
+  it("anonymous requests share the IP bucket between anonymous callers", async () => {
+    const limiter = createUserRateLimiter({ limit: 1, windowMs: 60_000 });
+    const app = buildAppWithLimiter(limiter);
+
+    await request(app).get("/api/webhooks").expect(200);
+    // Same (loopback) IP → blocked
+    await request(app).get("/api/webhooks").expect(429);
+  });
+
+  it("fires an audit log entry when the limit is hit", async () => {
+    const app = express();
+    app.use(asUser(USER_A));
+    const limiter = createUserRateLimiter({ limit: 1, windowMs: 60_000 });
+    app.use("/api/webhooks", limiter);
+    app.get("/api/webhooks", (_req, res) => res.json({}));
+
+    await request(app).get("/api/webhooks");
+    await request(app).get("/api/webhooks"); // blocked
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rateLimitContext: expect.objectContaining({ blocked: true, remaining: 0 }),
+      }),
+      "rate_limit_blocked",
+    );
+    expect(mockInsert).toHaveBeenCalledWith("audit_logs");
+  });
+
+  it("audit log entry includes the wallet address for authenticated blocks", async () => {
+    const valuesMock = jest.fn().mockResolvedValue(undefined);
+    mockInsert.mockReturnValue({ values: valuesMock } as any);
+
+    const app = express();
+    app.use(asUser(USER_A));
+    const limiter = createUserRateLimiter({ limit: 1, windowMs: 60_000 });
+    app.use("/api/webhooks", limiter);
+    app.get("/api/webhooks", (_req, res) => res.json({}));
+
+    await request(app).get("/api/webhooks");
+    await request(app).get("/api/webhooks"); // blocked
+
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        walletAddress: STELLAR_A,
+        action: "rate_limit.blocked",
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// webhooksRateLimiter pre-configured instance
+// ---------------------------------------------------------------------------
+
+describe("webhooksRateLimiter (env-derived instance)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInsert.mockReturnValue({ values: jest.fn().mockResolvedValue(undefined) } as any);
+  });
+
+  it("is a valid middleware that allows the first request", async () => {
+    const app = express();
+    app.use(asUser(USER_A));
+    app.use("/api/webhooks", webhooksRateLimiter);
+    app.get("/api/webhooks", (_req, res) => res.json({ ok: true }));
+
+    const res = await request(app).get("/api/webhooks");
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end route wiring: webhooksRouter respects its rate-limit middleware
+// ---------------------------------------------------------------------------
+
+describe("webhooksRouter rate-limit gate (requireAuth mocked)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInsert.mockReturnValue({ values: jest.fn().mockResolvedValue(undefined) } as any);
+  });
+
+  // Stub `requireAuth` so the route handler runs without a real JWT / DB.
+  jest.doMock("../src/middleware/requireAuth", () => ({
+    requireAuth: (req: Request, _res: Response, next: express.NextFunction) => {
+      req.user = USER_A;
+      next();
+    },
+  }));
+
+  // `db` queries inside webhooksRouter would fail without a full DB mock — we
+  // only care about the rate-limit layer sitting *before* the handlers, so
+  // short-circuit the DB calls at the module level.
+  jest.doMock("../src/db", () => ({
+    db: {
+      select: jest.fn().mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockResolvedValue([]),
+          orderBy: jest.fn().mockResolvedValue([]),
+        }),
+      }),
+      insert: jest.fn().mockReturnValue({
+        values: jest.fn().mockResolvedValue([
+          {
+            id: "11111111-1111-1111-1111-111111111111",
+            userId: USER_A.id,
+            url: "https://example.com/hook",
+            events: [],
+            secret: "x",
+            active: true,
+            createdAt: new Date("2025-01-01T00:00:00Z"),
+            updatedAt: new Date("2025-01-01T00:00:00Z"),
+          },
+        ]),
+        returning: jest.fn().mockResolvedValue([
+          {
+            id: "11111111-1111-1111-1111-111111111111",
+            userId: USER_A.id,
+            url: "https://example.com/hook",
+            events: [],
+            secret: "x",
+            active: true,
+            createdAt: new Date("2025-01-01T00:00:00Z"),
+            updatedAt: new Date("2025-01-01T00:00:00Z"),
+          },
+        ]),
+      }),
+      update: jest.fn().mockReturnValue({
+        set: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            returning: jest.fn().mockResolvedValue([
+              {
+                id: "11111111-1111-1111-1111-111111111111",
+                userId: USER_A.id,
+                url: "https://example.com/hook",
+                events: [],
+                active: true,
+                createdAt: new Date("2025-01-01T00:00:00Z"),
+                updatedAt: new Date("2025-01-01T00:00:00Z"),
+              },
+            ]),
+          }),
+        }),
+      }),
+      delete: jest.fn().mockReturnValue({
+        where: jest.fn().mockResolvedValue({ rowCount: 1 }),
+      }),
+    },
+  }));
+
+  it("applies the per-user limiter before handlers run", async () => {
+    const { webhooksRouter } = await import("../src/routes/webhooks");
+    const app = express();
+    app.use(express.json());
+    // Swap in a tighter limiter so tests don't need 100 requests
+    const tightLimiter = createUserRateLimiter({ limit: 2, windowMs: 60_000 });
+    app.use("/api/webhooks", tightLimiter);
+    app.use("/api/webhooks", webhooksRouter);
+
+    await request(app).get("/api/webhooks").expect(200);
+    await request(app).get("/api/webhooks").expect(200);
+    const blocked = await request(app).get("/api/webhooks");
+    expect(blocked.status).toBe(429);
+    expect(blocked.body.error.code).toBe("rate_limit_exceeded");
+  });
+});


### PR DESCRIPTION
Per-user (stellar-address) rate limiting on the new /api/webhooks subscription management endpoints.

- createUserRateLimiter + getUserRateKey helpers key on stellarAddress first, then user.id, then IP fallback for anonymous callers
- webhooksRateLimiter pre-configured with WEBHOOKS_RATE_LIMIT_WINDOW_MS (15 min) and WEBHOOKS_RATE_LIMIT_MAX (100) env vars with secure defaults
- /api/webhooks router mounts rateLimiter before requireAuth so limit is enforced per authenticated user, not per shared NAT/VPN IP
- audit log fired on blocks with action rate_limit.blocked + walletAddress
- focused tests: keying logic, per-user bucket isolation, 429 envelope (Retry-After, resetAt, rate_limit_exceeded code), audit trail, anonymous IP fallback, and router-level gate smoke test

Closes: Predictify-org/predictify-backend#431