### PR TITLE
docs: fix and complete markets ETag/304 caching documentation

### DIFF
--- a/docs/markets-api.md
+++ b/docs/markets-api.md
@@ -48,6 +48,59 @@ This endpoint uses **keyset (cursor) pagination** on `(createdAt DESC, id DESC)`
 
 - `400 validation_error` - invalid query parameters
 
+### Conditional requests and caching
+
+`GET /api/markets` supports strong ETags for conditional revalidation. Every
+response includes an `ETag` header and a `Cache-Control: no-cache` header.
+Clients may send an `If-None-Match` header with the latest ETag to receive a
+`304 Not Modified` response without a body when the market list has not
+changed.
+
+Example:
+
+```http
+GET /api/markets
+If-None-Match: "<etag>"
+```
+
+## `GET /api/markets/:id`
+
+Returns a single market by ID.
+
+### Path Parameters
+
+| Parameter | Type   | Required | Description        |
+|-----------|--------|----------|---------------------|
+| `id`      | string | yes      | The market's ID.    |
+
+### Response
+
+`200 OK`
+
+```json
+{
+  "data": {
+    "id": "market-1",
+    "question": "Will BTC close above $100k this quarter?",
+    "status": "active",
+    "resolutionTime": "2026-07-01T00:00:00.000Z",
+    "version": 1
+  }
+}
+```
+
+### Errors
+
+- `404 not_found` - no market exists with the given ID
+
+### Conditional requests and caching
+
+`GET /api/markets/:id` supports strong ETags for conditional revalidation on
+the same terms as the list endpoint: every `200` response includes an `ETag`
+and `Cache-Control: no-cache` header, and a matching `If-None-Match` header
+returns `304 Not Modified` with no body. A `404` response does not include an
+`ETag` header.
+
 ## `GET /api/markets/recommendations`
 
 Returns personalized market recommendations for the authenticated user.
@@ -81,26 +134,6 @@ The endpoint excludes markets the user has already predicted on, prefers active
 non-archived markets related to terms from the user's prediction history, and
 falls back to recent active non-archived markets when there is no usable history
 or no related market is found.
-
-### ETag support
-
-`GET /api/markets` supports conditional revalidation through `ETag` and `If-None-Match`.
-On a matching revalidation request, the route responds with `304 Not Modified`
-and does not return a response body. Clients should treat the response as a
-cache revalidation success and reuse the previously cached representation.
-
-### Conditional requests and caching
-
-The public market listing endpoint supports strong ETags. Clients may send an
-`If-None-Match` header with the latest ETag to receive a `304 Not Modified`
-response without a body when the market list has not changed.
-
-Example:
-
-```http
-GET /api/markets
-If-None-Match: "<etag>"
-```
 
 ### Errors
 


### PR DESCRIPTION
## Summary
Closes #337.

The ETag/304 caching implementation and its test coverage (`src/middleware/etag.ts`, `tests/etag.test.ts`, `tests/markets.test.ts`) were already in place on `main`, but `docs/markets-api.md` was left inaccurate:

- The `GET /api/markets/:id` endpoint had no documented section at all.
- The ETag/conditional-caching notes were duplicated and misattributed under `GET /api/markets/recommendations`, an endpoint that has no ETag support (it doesn't call `conditionalGet`).

This PR:
- Adds a proper `GET /api/markets/:id` section (path params, response shape, `404` error, conditional-caching behavior).
- Moves the ETag/`If-None-Match`/`304` documentation to the two endpoints that actually implement it: `GET /api/markets` and `GET /api/markets/:id`.
- Removes the incorrect duplicate sections from `GET /api/markets/recommendations`.

No source code changes — the caching behavior itself was already correct and tested; this brings the docs in line with it.

## Test plan
- [x] Reviewed `src/routes/markets/index.ts` to confirm which routes call `conditionalGet` and use that as the source of truth for the doc content.
- [x] Reviewed `tests/etag.test.ts` and `tests/markets.test.ts` to confirm existing coverage for both endpoints' `200`/`304`/`404` ETag behavior.
- [x] Docs-only change; no lint/build impact (`docs/markets-api.md` is outside `eslint`'s `src/**/*.ts` scope).