### PR TITLE
Add per-endpoint metrics on /api/markets (v7)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -32,6 +32,8 @@ Collected by `prom-client`'s `collectDefaultMetrics`:
 | Metric name | Type | Labels | Description |
 |---|---|---|---|
 | `http_request_duration_seconds` | Histogram | `route`, `status` | HTTP request duration in seconds, bucketed |
+| `markets_request_duration_seconds` | Histogram | `endpoint`, `method`, `status` | `/api/markets` request duration in seconds, bucketed per endpoint (`list`, `search`, `featured`, `upcoming`, `get`, `patch`) |
+| `markets_requests_total` | Counter | `endpoint`, `method`, `status` | Total `/api/markets` requests, segmented per endpoint (`list`, `search`, `featured`, `upcoming`, `get`, `patch`) |
 | `indexer_polls_total` | Counter | — | Total indexer poll cycles completed |
 | `webhook_deliveries_total` | Counter | `status` | Webhook deliveries by outcome |
 | `auth_verifications_total` | Counter | `outcome` | Auth verification attempts by result |

--- a/src/metrics/registry.ts
+++ b/src/metrics/registry.ts
@@ -68,3 +68,18 @@ export const signupAnomalyTopScore = new Gauge({
   help: "Highest modified z-score observed in the most recent signup-rate anomaly scan",
   registers: [register],
 });
+
+export const marketsRequestDuration = new Histogram({
+  name: "markets_request_duration_seconds",
+  help: "Duration of /api/markets requests in seconds, segmented by endpoint, method, and status code",
+  labelNames: ["endpoint", "method", "status"] as const,
+  buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10],
+  registers: [register],
+});
+
+export const marketsRequestsTotal = new Counter({
+  name: "markets_requests_total",
+  help: "Total number of /api/markets requests, segmented by endpoint, method, and status code",
+  labelNames: ["endpoint", "method", "status"] as const,
+  registers: [register],
+});

--- a/src/routes/markets/index.ts
+++ b/src/routes/markets/index.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import type { Request, Response, NextFunction } from "express";
 import {
   listMarkets,
   listUpcomingMarkets,
@@ -13,6 +14,7 @@ import { listFeaturedMarkets } from "../../services/marketFeatureService";
 import { logger } from "../../config/logger";
 import { RouteErrorFactory } from "../../errors";
 import { conditionalGet } from "../../middleware/etag";
+import { marketsRequestDuration, marketsRequestsTotal } from "../../metrics/registry";
 import { recommendationsRouter } from "./recommendations";
 import { trendingRouter } from "./trending";
 import { tagsRouter } from "./tags";
@@ -30,6 +32,21 @@ import {
 
 export const marketsRouter = Router();
 
+function trackMarketsMetrics(endpoint: string) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const start = process.hrtime.bigint();
+
+    res.on("finish", () => {
+      const durationSec = Number(process.hrtime.bigint() - start) / 1e9;
+      const labels = { endpoint, method: req.method, status: res.statusCode };
+      marketsRequestDuration.observe(labels, durationSec);
+      marketsRequestsTotal.inc(labels);
+    });
+
+    next();
+  };
+}
+
 marketsRouter.use(rateLimitAnon);
 marketsRouter.use("/tags", tagsRouter);
 marketsRouter.use("/recommendations", recommendationsRouter);
@@ -39,7 +56,7 @@ marketsRouter.use("/:id/prediction-count", predictionCountRouter);
 marketsRouter.use("/:id/audit", marketAuditRouter);
 marketsRouter.use("/:id/disputes", disputesRouter);
 
-marketsRouter.get("/search", async (req, res, next) => {
+marketsRouter.get("/search", trackMarketsMetrics("search"), async (req, res, next) => {
   const reqId = String((req as { id?: unknown }).id ?? "anon");
   try {
     const parsed = searchMarketsQuerySchema.safeParse(req.query);
@@ -92,7 +109,7 @@ marketsRouter.get("/search", async (req, res, next) => {
   }
 });
 
-marketsRouter.get("/", async (req, res, next) => {
+marketsRouter.get("/", trackMarketsMetrics("list"), async (req, res, next) => {
   const reqId = String((req as { id?: unknown }).id ?? "anon");
   try {
     const parsed = listMarketsQuerySchema.safeParse(req.query);
@@ -129,7 +146,7 @@ marketsRouter.get("/", async (req, res, next) => {
   }
 });
 
-marketsRouter.get("/featured", async (req, res, next) => {
+marketsRouter.get("/featured", trackMarketsMetrics("featured"), async (req, res, next) => {
   const reqId = String((req as { id?: unknown }).id ?? "anon");
   try {
     const parsed = featuredMarketsQuerySchema.safeParse(req.query);
@@ -146,7 +163,7 @@ marketsRouter.get("/featured", async (req, res, next) => {
   }
 });
 
-marketsRouter.get("/upcoming", async (req, res, next) => {
+marketsRouter.get("/upcoming", trackMarketsMetrics("upcoming"), async (req, res, next) => {
   const reqId = String((req as { id?: unknown }).id ?? "anon");
   try {
     const parsed = upcomingMarketsQuerySchema.safeParse(req.query);
@@ -170,7 +187,7 @@ marketsRouter.get("/upcoming", async (req, res, next) => {
   }
 });
 
-marketsRouter.get("/:id", async (req, res, next) => {
+marketsRouter.get("/:id", trackMarketsMetrics("get"), async (req, res, next) => {
   const reqId = String((req as { id?: unknown }).id ?? "anon");
 
   try {
@@ -211,7 +228,7 @@ marketsRouter.get("/:id", async (req, res, next) => {
   }
 });
 
-marketsRouter.patch("/:id", requireAdmin, async (req: AuthenticatedRequest, res, next) => {
+marketsRouter.patch("/:id", trackMarketsMetrics("patch"), requireAdmin, async (req: AuthenticatedRequest, res, next) => {
   const reqId = String((req as { id?: unknown }).id ?? "anon");
   const adminAddress = req.user?.stellarAddress;
 

--- a/tests/marketsMetrics.test.ts
+++ b/tests/marketsMetrics.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Focused tests for the per-endpoint /api/markets Prometheus metrics
+ * (markets_request_duration_seconds, markets_requests_total).
+ *
+ * Mounts marketsRouter + metricsRouter directly rather than going through
+ * createApp(), since createApp() also wires up unrelated routers that are
+ * broken independent of this change (see src/index.ts's webhooksRouter
+ * import, which does not match src/routes/webhooks.ts's actual exports).
+ */
+
+import request from "supertest";
+import express from "express";
+import { marketsRouter } from "../src/routes/markets";
+import { metricsRouter } from "../src/routes/metrics";
+import { errorHandler } from "../src/middleware/errorHandler";
+import * as marketService from "../src/services/marketService";
+
+jest.mock("../src/services/marketService", () => ({
+  ...jest.requireActual("../src/services/marketService"),
+  listMarkets: jest.fn(),
+  listUpcomingMarkets: jest.fn(),
+  getMarketById: jest.fn(),
+}));
+
+const mockListMarkets = marketService.listMarkets as jest.Mock;
+const mockListUpcoming = marketService.listUpcomingMarkets as jest.Mock;
+const mockGetMarketById = marketService.getMarketById as jest.Mock;
+
+const METRICS_PATH = "/api/metrics";
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/markets", marketsRouter);
+  app.use(METRICS_PATH, metricsRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+describe("Per-endpoint /api/markets metrics", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("declares the markets metric names on /api/metrics", async () => {
+    const res = await request(makeApp()).get(METRICS_PATH);
+    expect(res.text).toContain("markets_request_duration_seconds");
+    expect(res.text).toContain("markets_requests_total");
+  });
+
+  it("records list endpoint requests with a 200 status label", async () => {
+    mockListMarkets.mockResolvedValue({ data: [], nextCursor: null });
+
+    const app = makeApp();
+    await request(app).get("/api/markets");
+    const res = await request(app).get(METRICS_PATH);
+
+    expect(res.text).toContain(
+      'markets_requests_total{endpoint="list",method="GET",status="200"}',
+    );
+    expect(res.text).toMatch(
+      /markets_request_duration_seconds_count\{endpoint="list",method="GET",status="200"\}\s+1/,
+    );
+  });
+
+  it("records upcoming endpoint requests with a distinct endpoint label", async () => {
+    mockListUpcoming.mockResolvedValue([]);
+
+    const app = makeApp();
+    await request(app).get("/api/markets/upcoming");
+    const res = await request(app).get(METRICS_PATH);
+
+    expect(res.text).toContain(
+      'markets_requests_total{endpoint="upcoming",method="GET",status="200"}',
+    );
+  });
+
+  it("records get-by-id 404 responses with a 404 status label", async () => {
+    mockGetMarketById.mockResolvedValue(null);
+
+    const app = makeApp();
+    await request(app).get("/api/markets/does-not-exist");
+    const res = await request(app).get(METRICS_PATH);
+
+    expect(res.text).toContain(
+      'markets_requests_total{endpoint="get",method="GET",status="404"}',
+    );
+  });
+
+  it("records patch endpoint auth failures (401) before the handler runs", async () => {
+    const app = makeApp();
+    const patchRes = await request(app)
+      .patch("/api/markets/some-id")
+      .send({ question: "Updated?", expectedVersion: 1 });
+    expect(patchRes.status).toBe(401);
+
+    const res = await request(app).get(METRICS_PATH);
+    expect(res.text).toContain(
+      'markets_requests_total{endpoint="patch",method="PATCH",status="401"}',
+    );
+  });
+
+  it("increments the counter across repeated requests to the same endpoint", async () => {
+    mockListUpcoming.mockResolvedValue([]);
+
+    const app = makeApp();
+    await request(app).get("/api/markets/upcoming");
+    await request(app).get("/api/markets/upcoming");
+    const res = await request(app).get(METRICS_PATH);
+
+    const match = res.text.match(
+      /markets_requests_total\{endpoint="upcoming",method="GET",status="200"\}\s+(\d+)/,
+    );
+    expect(match).toBeTruthy();
+    expect(Number(match![1])).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
Close #394

## Summary

Adds per-endpoint Prometheus metrics for the direct /api/markets routes.

## Changes

- Added a request counter for /api/markets.
- Added a request-duration histogram for /api/markets.
- Instrumented the six direct market routes with endpoint, method, and status labels.
- Added focused tests for successful, not-found, authentication-failure, and repeated-request cases.
- Updated the metrics documentation.

## Validation

- Focused metrics tests: 6/6 passing.
- ESLint passes for the modified files.
- Changed lines are covered by the focused tests.
- Existing API responses, validation, logging, and error handling remain unchanged.

## Note

The broader type-check and createApp() test failures are pre-existing repository issues and are unrelated to this change.