### PR TITLE
Add cursor pagination on /api/rate-limit

### DIFF
--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -61,6 +61,46 @@ sliding-window usage, remaining quota, and reset timestamp for the address.
 }
 ```
 
+## Rate-limit event list
+
+`GET /api/rate-limit` is an admin-only, cursor-paginated listing of blocked
+rate-limit audit events. Results are ordered newest-first by `(created_at, id)`
+so pagination stays stable when new blocked requests are written while a client
+is paging through the list.
+
+### Query parameters
+
+- `cursor` - optional opaque token returned by the previous page
+- `limit` - optional positive integer page size
+
+### Response (200)
+
+```json
+{
+  "data": [
+    {
+      "id": "11111111-1111-1111-1111-111111111111",
+      "action": "rate_limit.blocked",
+      "walletAddress": null,
+      "ip": "127.0.0.1",
+      "correlationId": "req-123",
+      "rateLimitContext": {
+        "limit": 60,
+        "remaining": 0,
+        "resetAt": "2026-07-24T12:00:00.000Z",
+        "blocked": true
+      },
+      "createdAt": "2026-07-24T12:00:00.000Z"
+    }
+  ],
+  "nextCursor": "djF8MjR8..."
+}
+```
+
+The endpoint uses the same standard error envelope as the rest of the API and
+returns `400` for malformed query parameters, `401` for missing auth, and `403`
+for non-admin callers.
+
 ### Anonymous response (200)
 
 ```json

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ import { WebhookWorker } from "./workers/webhookWorker";
 import { marketResolverWorker } from "./workers/marketResolver";
 import { backupVerificationWorker } from "./workers/backupVerificationWorker";
 import { reconciliationWorker } from "./workers/reconciliationWorker";
-import { rateLimitStatusRouter } from "./routes/rate-limit/status";
+import { rateLimitRouter } from "./routes/rate-limit";
 import { adminRateLimitInspectRouter } from "./routes/admin/rate-limit/inspect";
 import { quotaRequestsRouter } from "./routes/quota/requests";
 import { startSlowQueryAlerter, stopSlowQueryAlerter } from "./workers/slowQueryAlerter";
@@ -132,7 +132,7 @@ export function createApp(_options: CreateAppOptions = {}): express.Express {
   app.use("/api/predictions", predictionsRouter);
   app.use("/api/leaderboard", leaderboardRouter);
   app.use("/api/leaderboard/global", globalLeaderboardRouter);
-  app.use("/api/rate-limit", rateLimitStatusRouter);
+  app.use("/api/rate-limit", rateLimitRouter);
   app.use("/api/quota/requests", quotaRequestsRouter);
   app.use("/api/notifications", notificationsRouter);
   app.use("/api/webhooks", webhooksRouter);

--- a/src/openapi/registry.ts
+++ b/src/openapi/registry.ts
@@ -799,6 +799,58 @@ registry.registerPath({
   },
 });
 
+const RateLimitAuditEntry = z
+  .object({
+    id: z.string().uuid(),
+    action: z.literal("rate_limit.blocked"),
+    walletAddress: z.string().nullable(),
+    ip: z.string(),
+    correlationId: z.string(),
+    rateLimitContext: z.unknown().nullable(),
+    createdAt: z.string().datetime(),
+  })
+  .openapi("RateLimitAuditEntry");
+
+registry.registerPath({
+  method: "get",
+  path: "/api/rate-limit",
+  operationId: "listRateLimitEvents",
+  tags: ["Rate Limiting"],
+  summary: "List rate-limit audit events (admin only)",
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: z.object({
+      cursor: z.string().optional(),
+      limit: z.coerce.number().int().positive().optional(),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Paginated rate-limit audit log",
+      content: {
+        "application/json": {
+          schema: z.object({
+            data: z.array(RateLimitAuditEntry),
+            nextCursor: z.string().nullable(),
+          }),
+        },
+      },
+    },
+    400: {
+      description: "Invalid query parameters",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    403: {
+      description: "Forbidden",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+  },
+});
+
 // ── /api/markets/featured ────────────────────────────────────────────────────
 
 registry.registerPath({

--- a/src/routes/rate-limit.ts
+++ b/src/routes/rate-limit.ts
@@ -1,0 +1,69 @@
+import { Router, type NextFunction, type Request, type Response } from "express";
+import { z } from "zod";
+import { requireAdmin } from "../middleware/requireAdmin";
+import { getAuditLogs } from "../repositories/auditLogRepo";
+import { getRequestId } from "../lib/requestContext";
+import { logger } from "../config/logger";
+import { rateLimitStatusRouter } from "./rate-limit/status";
+
+export const rateLimitRouter = Router();
+
+const rateLimitQuerySchema = z.object({
+  cursor: z.string().min(1, { message: "cursor must not be empty when provided" }).optional(),
+  limit: z
+    .string()
+    .regex(/^\d+$/, { message: "limit must be a positive integer" })
+    .optional(),
+});
+
+rateLimitRouter.use(rateLimitStatusRouter);
+
+rateLimitRouter.get("/", requireAdmin, async (req: Request, res: Response, next: NextFunction) => {
+  const reqId = getRequestId();
+
+  try {
+    const parsed = rateLimitQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      logger.warn(
+        {
+          reqId,
+          adminAddress: req.adminAddress,
+          issues: parsed.error.issues,
+        },
+        "rate_limit_list_validation_failed",
+      );
+
+      return res.status(400).json({
+        error: {
+          code: "validation_error",
+          message: parsed.error.issues[0]?.message ?? "invalid query parameters",
+          requestId: reqId,
+        },
+      });
+    }
+
+    const limit = parsed.data.limit ? Number.parseInt(parsed.data.limit, 10) : undefined;
+    const page = await getAuditLogs({
+      action: "rate_limit.blocked",
+      cursor: parsed.data.cursor,
+      limit,
+    });
+
+    logger.info(
+      {
+        reqId,
+        adminAddress: req.adminAddress,
+        count: page.data.length,
+        hasNext: page.nextCursor !== null,
+      },
+      "rate_limit_listed",
+    );
+
+    return res.json({
+      data: page.data,
+      nextCursor: page.nextCursor,
+    });
+  } catch (err) {
+    return next(err);
+  }
+});

--- a/tests/rateLimit.test.ts
+++ b/tests/rateLimit.test.ts
@@ -1,0 +1,117 @@
+import express from "express";
+import jwt from "jsonwebtoken";
+import request from "supertest";
+import { rateLimitRouter } from "../src/routes/rate-limit";
+import { requestContextStorage } from "../src/lib/requestContext";
+
+jest.mock("../src/repositories/auditLogRepo");
+
+jest.mock("../src/config/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { getAuditLogs } from "../src/repositories/auditLogRepo";
+
+const mockGetAuditLogs = getAuditLogs as jest.MockedFunction<typeof getAuditLogs>;
+
+const SECRET = process.env.JWT_SECRET || "test-jwt-secret-at-least-32-bytes-long-000000";
+const ISSUER = process.env.JWT_ISSUER || "predictify";
+const AUDIENCE = process.env.JWT_AUDIENCE || "predictify-app";
+const ADMIN_ADDRESS = "GADMIN7777777777777777777777777777777777777777777777777777";
+const USER_ADDRESS = "GUSER88888888888888888888888888888888888888888888888888888";
+
+function signJwt(payload: object): string {
+  return jwt.sign(payload, SECRET, { issuer: ISSUER, audience: AUDIENCE, expiresIn: "1h" });
+}
+
+const adminJwt = signJwt({ sub: ADMIN_ADDRESS, role: "admin" });
+const userJwt = signJwt({ sub: USER_ADDRESS, role: "user" });
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use((_req, _res, next) => {
+    requestContextStorage.run({ requestId: "test-req-id" }, next);
+  });
+  app.use("/api/rate-limit", rateLimitRouter);
+  return app;
+}
+
+describe("GET /api/rate-limit", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 403 for non-admin callers", async () => {
+    const res = await request(makeApp())
+      .get("/api/rate-limit")
+      .set("Authorization", `Bearer ${userJwt}`);
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: { code: "forbidden" } });
+  });
+
+  it("returns 400 for malformed pagination input", async () => {
+    const res = await request(makeApp())
+      .get("/api/rate-limit?cursor=&limit=-5")
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+    expect(res.body.error.message).toContain("cursor must not be empty when provided");
+  });
+
+  it("returns cursor-paginated rate-limit events for admin callers", async () => {
+    const mockResult = {
+      data: [
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          action: "rate_limit.blocked",
+          walletAddress: null,
+          ip: "127.0.0.1",
+          correlationId: "req-1",
+          rateLimitContext: {
+            limit: 60,
+            remaining: 0,
+            resetAt: "2026-07-24T12:00:00.000Z",
+            blocked: true,
+          },
+          createdAt: new Date("2026-07-24T12:00:00.000Z"),
+        },
+      ],
+      nextCursor: "next-cursor-token",
+    };
+
+    mockGetAuditLogs.mockResolvedValue(mockResult);
+
+    const res = await request(makeApp())
+      .get("/api/rate-limit?cursor=abc&limit=2")
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(res.status).toBe(200);
+    expect(mockGetAuditLogs).toHaveBeenCalledWith({
+      action: "rate_limit.blocked",
+      cursor: "abc",
+      limit: 2,
+    });
+    expect(res.body).toEqual({
+      data: [
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          action: "rate_limit.blocked",
+          walletAddress: null,
+          ip: "127.0.0.1",
+          correlationId: "req-1",
+          rateLimitContext: {
+            limit: 60,
+            remaining: 0,
+            resetAt: "2026-07-24T12:00:00.000Z",
+            blocked: true,
+          },
+          createdAt: "2026-07-24T12:00:00.000Z",
+        },
+      ],
+      nextCursor: "next-cursor-token",
+    });
+  });
+});


### PR DESCRIPTION
Closes #496

Summary:
- Adds an admin-only cursor-paginated `GET /api/rate-limit` endpoint backed by audit logs, ordered by `(created_at, id)` for stable paging under concurrent writes.
- Keeps `GET /api/rate-limit/status` working through a parent router mount.
- Adds OpenAPI docs, rate-limiting docs, and focused tests for auth, validation, and paging wiring.