### PR TITLE
feat: add GET /api/stats with strong ETag + 304 support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ import { adminRateLimitInspectRouter } from "./routes/admin/rate-limit/inspect";
 import { quotaRequestsRouter } from "./routes/quota/requests";
 import { startSlowQueryAlerter, stopSlowQueryAlerter } from "./workers/slowQueryAlerter";
 import { scheduledReportsRouter } from "./routes/reports/scheduled";
+import { statsRouter } from "./routes/stats";
 
 const docsEnabled = env.NODE_ENV !== "production" || process.env.ENABLE_DOCS === "true";
 
@@ -151,6 +152,7 @@ export function createApp(_options: CreateAppOptions = {}): express.Express {
   app.use("/api/admin/schema-versions", adminSchemaVersionsRouter);
   app.use("/api/admin/rate-limit", adminRateLimitInspectRouter);
   app.use("/api/reports/scheduled", scheduledReportsRouter);
+  app.use("/api/stats", statsRouter);
 
   app.get("/metrics", async (req, res) => {
     const metricsAuthToken = process.env.METRICS_AUTH_TOKEN;

--- a/src/openapi/registry.ts
+++ b/src/openapi/registry.ts
@@ -2187,6 +2187,67 @@ registry.registerPath({
   },
 });
 
+// ── /api/stats ───────────────────────────────────────────────────────────────
+
+const MarketBreakdown = z
+  .object({
+    total: z.number().int(),
+    active: z.number().int(),
+    resolved: z.number().int(),
+  })
+  .openapi("MarketBreakdown");
+
+const GlobalStats = z
+  .object({
+    users: z.number().int(),
+    markets: MarketBreakdown,
+    predictions: z.number().int(),
+    claims: z.number().int(),
+  })
+  .openapi("GlobalStats");
+
+registry.registerPath({
+  method: "get",
+  path: "/api/stats",
+  operationId: "getGlobalStats",
+  tags: ["Stats"],
+  summary: "Get global platform statistics",
+  description:
+    "Returns aggregate platform-level statistics including total users, markets " +
+    "(total / active / resolved), predictions, and claims. " +
+    "Responses include a strong ETag and Cache-Control: no-cache header for " +
+    "efficient conditional GET (304 Not Modified) support.\n" +
+    "\n" +
+    "**Caching**: Responses include a strong `ETag` (SHA-256 of the JSON body) and " +
+    "`Cache-Control: no-cache`. Clients should store the ETag and send it back as " +
+    "`If-None-Match` on subsequent requests. A matching ETag returns 304 with no body.",
+  responses: {
+    200: {
+      description: "Global platform statistics",
+      content: {
+        "application/json": {
+          schema: z.object({ data: GlobalStats }),
+          examples: {
+            default: {
+              value: {
+                data: {
+                  users: 1234,
+                  markets: { total: 56, active: 34, resolved: 22 },
+                  predictions: 9876,
+                  claims: 432,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    304: {
+      description: "Not Modified — client already has the latest stats (ETag match)",
+    },
+  },
+});
+
 // ── /api/quota/requests ──────────────────────────────────────────────────
 
 const QuotaType = z.enum(["prediction_limit", "daily_prediction_limit", "claim_limit"]).openapi("QuotaType");

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,0 +1,77 @@
+/**
+ * stats.ts
+ *
+ * GET /api/stats
+ *
+ * Returns global platform statistics (user count, market breakdown,
+ * prediction/claim totals) with strong ETag support.
+ *
+ * ## ETag / conditional GET
+ *
+ * Every 200 response includes:
+ *   - `ETag`           — SHA-256 strong ETag derived from the JSON payload
+ *   - `Cache-Control: no-cache`  — clients may cache but must revalidate
+ *
+ * When the client sends `If-None-Match` whose value matches the current
+ * ETag, the server responds with **304 Not Modified** (no body), saving
+ * bandwidth on repeated reads.
+ *
+ * ## Security
+ *
+ * - Deterministic ETags use sorted-key JSON serialisation (see
+ *   middleware/etag.ts).
+ * - The `If-None-Match` header is stripped of quotes before comparison.
+ * - No authentication is required — this is a public read-only endpoint.
+ */
+
+import { Router } from "express";
+import { conditionalGet } from "../middleware/etag";
+import { getGlobalStats } from "../services/statsService";
+import { logger } from "../config/logger";
+import { getRequestId } from "../lib/requestContext";
+import { rateLimitAnon } from "../middleware/rateLimitAnon";
+
+export const statsRouter = Router();
+
+// Anonymous rate limiting — public endpoint that issues multiple DB queries.
+// A conservative cap prevents abuse while being generous enough for dashboards.
+statsRouter.use(rateLimitAnon);
+
+/**
+ * GET /api/stats
+ *
+ * Returns platform-level aggregate statistics.
+ *
+ * Response (200):
+ * ```json
+ * {
+ *   "data": {
+ *     "users": 1234,
+ *     "markets": { "total": 56, "active": 34, "resolved": 22 },
+ *     "predictions": 9876,
+ *     "claims": 432
+ *   }
+ * }
+ * ```
+ */
+statsRouter.get("/", async (req, res, next) => {
+  const reqId = getRequestId();
+
+  try {
+    const stats = await getGlobalStats();
+
+    logger.debug(
+      { reqId, users: stats.users, markets: stats.markets.total, predictions: stats.predictions },
+      "stats_served",
+    );
+
+    // Conditional GET — respond 304 if the client already has the current
+    // representation, saving both bandwidth and server CPU on serialisation.
+    const done = conditionalGet({ data: stats }, req, res);
+    if (done) return;
+
+    res.json({ data: stats });
+  } catch (err) {
+    next(err);
+  }
+});

--- a/src/services/statsService.ts
+++ b/src/services/statsService.ts
@@ -1,0 +1,72 @@
+/**
+ * statsService.ts
+ *
+ * Global platform statistics aggregator.
+ *
+ * Returns lightweight counts suitable for a public landing page or dashboard.
+ * The result is intentionally small and stable — ideal for strong ETag caching
+ * on the GET /api/stats endpoint.
+ */
+
+import { db } from "../db";
+import { users, markets, predictions, claims } from "../db/schema";
+import { eq, count } from "drizzle-orm";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MarketBreakdown {
+  total: number;
+  active: number;
+  resolved: number;
+}
+
+export interface GlobalStats {
+  users: number;
+  markets: MarketBreakdown;
+  predictions: number;
+  claims: number;
+}
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns global platform statistics.
+ *
+ * Runs five lightweight SELECT COUNT(*) queries against the users,
+ * markets, predictions, and claims tables. The result is not cached
+ * in-memory — the caller (route handler) is responsible for ETag /
+ * conditional GET to avoid redundant transfers.
+ */
+export async function getGlobalStats(): Promise<GlobalStats> {
+  // Run all COUNT queries in parallel for efficiency — the result set is
+  // tiny and each query is independent, so concurrency is a free win.
+  const [userCount, marketTotal, activeCount, predictionCount, claimCount] =
+    await Promise.all([
+      db.select({ value: count() }).from(users),
+      db.select({ value: count() }).from(markets),
+      db
+        .select({ value: count() })
+        .from(markets)
+        .where(eq(markets.status, "active")),
+      db.select({ value: count() }).from(predictions),
+      db.select({ value: count() }).from(claims),
+    ]);
+
+  const totalMarkets = Number(marketTotal[0]?.value ?? 0);
+  const activeMarkets = Number(activeCount[0]?.value ?? 0);
+
+  return {
+    users: Number(userCount[0]?.value ?? 0),
+    markets: {
+      total: totalMarkets,
+      active: activeMarkets,
+      resolved: totalMarkets - activeMarkets,
+    },
+    predictions: Number(predictionCount[0]?.value ?? 0),
+    claims: Number(claimCount[0]?.value ?? 0),
+  };
+}

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -1,0 +1,219 @@
+/**
+ * tests/stats.test.ts
+ *
+ * Focused tests for ETag support on GET /api/stats.
+ *
+ * Coverage matrix
+ * ─────────────────────────────────────────────────────────
+ * Unit – generateETag (imported from middleware)
+ *   ✓ returns a quoted SHA-256 hex string
+ *
+ * Integration – GET /api/stats via supertest
+ *   ✓ 200 response includes ETag header
+ *   ✓ 200 response includes Cache-Control: no-cache
+ *   ✓ 200 response has correct data shape
+ *   ✓ 304 when If-None-Match matches current ETag
+ *   ✓ 304 has no body
+ *   ✓ 304 still includes ETag header
+ *   ✓ 304 with unquoted (bare hash) If-None-Match
+ *   ✓ 200 when If-None-Match is stale
+ *   ✓ 200 when If-None-Match header is absent
+ *   ✓ ETag is stable across repeated requests
+ *   ✓ ETag changes when data changes
+ *   ✓ sending old ETag after data change returns 200
+ *   ✓ 500 with error envelope when service throws
+ */
+
+import request from "supertest";
+import { generateETag } from "../src/middleware/etag";
+import { createApp } from "../src/index";
+import * as statsService from "../src/services/statsService";
+
+jest.mock("../src/services/statsService");
+
+const mockGetGlobalStats =
+  statsService.getGlobalStats as jest.MockedFunction<
+    typeof statsService.getGlobalStats
+  >;
+
+const app = createApp();
+
+const baseStats = {
+  users: 100,
+  markets: { total: 10, active: 5, resolved: 5 },
+  predictions: 1000,
+  claims: 50,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetGlobalStats.mockResolvedValue(baseStats);
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests – ETag generation on the stats payload shape
+// ---------------------------------------------------------------------------
+
+describe("generateETag (unit, stats payload)", () => {
+  it("returns a quoted SHA-256 hex string for a stats payload", () => {
+    const etag = generateETag({ data: baseStats });
+    expect(etag).toMatch(/^"[0-9a-f]{64}"$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests – GET /api/stats
+// ---------------------------------------------------------------------------
+
+describe("GET /api/stats – ETag integration", () => {
+  // ── 200 happy path ────────────────────────────────────────────────────────
+
+  it("200 response includes an ETag header", async () => {
+    const res = await request(app).get("/api/stats");
+    expect(res.status).toBe(200);
+    expect(res.headers["etag"]).toMatch(/^"[0-9a-f]{64}"$/);
+  });
+
+  it("200 response includes Cache-Control: no-cache", async () => {
+    const res = await request(app).get("/api/stats");
+    expect(res.status).toBe(200);
+    expect(res.headers["cache-control"]).toBe("no-cache");
+  });
+
+  it("200 response has the correct data shape", async () => {
+    const res = await request(app).get("/api/stats");
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      users: 100,
+      markets: { total: 10, active: 5, resolved: 5 },
+      predictions: 1000,
+      claims: 50,
+    });
+  });
+
+  // ── Conditional GET: 304 ─────────────────────────────────────────────────
+
+  it("returns 304 when If-None-Match matches current ETag", async () => {
+    const first = await request(app).get("/api/stats");
+    const etag = first.headers["etag"];
+    expect(etag).toBeDefined();
+
+    const second = await request(app)
+      .get("/api/stats")
+      .set("If-None-Match", etag);
+
+    expect(second.status).toBe(304);
+  });
+
+  it("304 response has no body", async () => {
+    const first = await request(app).get("/api/stats");
+    const etag = first.headers["etag"];
+
+    const second = await request(app)
+      .get("/api/stats")
+      .set("If-None-Match", etag);
+
+    expect(second.status).toBe(304);
+    const bodyText = second.text;
+    expect(bodyText).toBeFalsy();
+  });
+
+  it("304 response still includes ETag header", async () => {
+    const first = await request(app).get("/api/stats");
+    const etag = first.headers["etag"];
+
+    const second = await request(app)
+      .get("/api/stats")
+      .set("If-None-Match", etag);
+
+    expect(second.status).toBe(304);
+    expect(second.headers["etag"]).toBe(etag);
+  });
+
+  it("304 with unquoted (bare hash) If-None-Match", async () => {
+    const first = await request(app).get("/api/stats");
+    const quotedEtag = first.headers["etag"];
+    const bareHash = quotedEtag.replace(/"/g, "");
+
+    const second = await request(app)
+      .get("/api/stats")
+      .set("If-None-Match", bareHash);
+
+    expect(second.status).toBe(304);
+  });
+
+  // ── Conditional GET: stale / absent ──────────────────────────────────────
+
+  it("returns 200 when If-None-Match is stale", async () => {
+    const res = await request(app)
+      .get("/api/stats")
+      .set(
+        "If-None-Match",
+        '"000000000000000000000000000000000000000000000000000000000000dead"',
+      );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toBeDefined();
+  });
+
+  it("returns 200 when If-None-Match header is absent", async () => {
+    const res = await request(app).get("/api/stats");
+    expect(res.status).toBe(200);
+  });
+
+  // ── ETag correctness ─────────────────────────────────────────────────────
+
+  it("ETag is stable across repeated requests for the same data", async () => {
+    const r1 = await request(app).get("/api/stats");
+    const r2 = await request(app).get("/api/stats");
+
+    expect(r1.headers["etag"]).toBe(r2.headers["etag"]);
+  });
+
+  it("ETag changes when the stats data changes", async () => {
+    const r1 = await request(app).get("/api/stats");
+    const etag1 = r1.headers["etag"];
+
+    // Change the mocked stats
+    mockGetGlobalStats.mockResolvedValue({
+      ...baseStats,
+      users: 200,
+      predictions: 2000,
+    });
+
+    const r2 = await request(app).get("/api/stats");
+    const etag2 = r2.headers["etag"];
+
+    expect(etag1).not.toBe(etag2);
+  });
+
+  it("sending old ETag after data change returns 200 (not 304)", async () => {
+    const first = await request(app).get("/api/stats");
+    const staleEtag = first.headers["etag"];
+
+    // Change the mocked stats
+    mockGetGlobalStats.mockResolvedValue({
+      ...baseStats,
+      users: 999,
+    });
+
+    const second = await request(app)
+      .get("/api/stats")
+      .set("If-None-Match", staleEtag);
+
+    expect(second.status).toBe(200);
+    expect(second.body.data.users).toBe(999);
+  });
+
+  // ── Error propagation ────────────────────────────────────────────────────
+
+  it("returns 500 with error envelope when service throws", async () => {
+    mockGetGlobalStats.mockRejectedValue(new Error("DB connection lost"));
+
+    const res = await request(app).get("/api/stats");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBeDefined();
+    expect(res.body.error.code).toBeDefined();
+  });
+});


### PR DESCRIPTION
- New statsService: parallel COUNT(*) queries for users, markets, predictions, claims
- New /api/stats route with conditionalGet() middleware for ETag/304
- Anonymous rate limiting via rateLimitAnon
- OpenAPI spec for /api/stats with ETag caching documentation
- 14 test cases: 200/304/ETag stability/error propagation

Closes #480