### PR TITLE
feat: add /api/audit/counts summary endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Once running:
 - **Swagger UI** → http://localhost:3001/docs *(non-production only; set `ENABLE_DOCS=true` to enable in production)*
 - **OpenAPI JSON** → http://localhost:3001/openapi.json *(always available)*
 - **Audit export** → `GET /api/admin/audit/export` streams admin audit logs as `application/x-ndjson`
+- **Audit counts** → `GET /api/audit/counts` returns a per-action counts summary of audit log entries for admin dashboards
 
 
 ## Health Endpoints

--- a/scripts/check-openapi.ts
+++ b/scripts/check-openapi.ts
@@ -29,6 +29,7 @@ const EXPECTED_ROUTES: RouteEntry[] = [
   { method: "post", path: "/api/users/{addr}/follow" },
   { method: "delete", path: "/api/users/{addr}/follow" },
   { method: "get", path: "/api/admin/audit" },
+  { method: "get", path: "/api/audit/counts" },
   { method: "get", path: "/api/admin/users/{address}" },
   { method: "get", path: "/api/admin/feature-flags" },
   { method: "post", path: "/api/admin/feature-flags" },

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { socialRouter } from "./routes/social";
 import { webhooksRouter } from "./routes/webhooks";
 import { adminAuditRouter } from "./routes/admin/audit";
 import { adminAuditExportRouter } from "./routes/admin/audit/export";
+import { auditCountsRouter } from "./routes/audit/counts";
 import { adminMarketsRouter } from "./routes/admin/markets";
 import { adminSchemaVersionsRouter } from "./routes/admin/schema-versions";
 import { errorHandler } from "./middleware/errorHandler";
@@ -144,6 +145,7 @@ export function createApp(_options: CreateAppOptions = {}): express.Express {
   app.use("/api/me/sessions", sessionsRouter);
   app.use("/api/admin/audit", adminAuditRouter);
   app.use("/api/admin/audit", adminAuditExportRouter);
+  app.use("/api/audit/counts", auditCountsRouter);
   app.use("/api/admin/users", adminUsersRouter);
   app.use("/api/admin/users", adminNotesRouter);
   app.use("/api/admin/feature-flags", adminFeatureFlagsRouter);

--- a/src/openapi/registry.ts
+++ b/src/openapi/registry.ts
@@ -1832,6 +1832,63 @@ registry.registerPath({
   },
 });
 
+// ── /api/audit/counts ───────────────────────────────────────────────────────
+
+const AuditActionCount = z
+  .object({
+    action: z.string(),
+    count: z.number().int(),
+  })
+  .openapi("AuditActionCount");
+
+const AuditCountsSummary = z
+  .object({
+    totalCount: z.number().int(),
+    byAction: z.array(AuditActionCount),
+  })
+  .openapi("AuditCountsSummary");
+
+registry.registerPath({
+  method: "get",
+  path: "/api/audit/counts",
+  operationId: "getAuditCounts",
+  tags: ["Admin"],
+  summary: "Per-action audit log counts summary for dashboards (admin only)",
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: z.object({
+      startDate: z.string().datetime().optional(),
+      endDate: z.string().datetime().optional(),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Audit log counts summary",
+      content: {
+        "application/json": {
+          schema: z.object({ data: AuditCountsSummary }),
+        },
+      },
+    },
+    400: {
+      description: "Invalid query parameters",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    403: {
+      description: "Forbidden",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    429: {
+      description: "Rate limit exceeded",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+  },
+});
+
 // ── /api/admin/plugins ─────────────────────────────────────────────────────
 
 const PluginView = z

--- a/src/repositories/auditLogRepo.ts
+++ b/src/repositories/auditLogRepo.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, lt, or, gte, lte } from "drizzle-orm";
+import { and, count, desc, eq, lt, or, gte, lte } from "drizzle-orm";
 import { db } from "../db";
 import { auditLogs } from "../db/schema";
 import { clampLimit, decodeCursor, encodeCursor, type Page } from "../utils/cursor";
@@ -120,4 +120,48 @@ export async function* getAuditLogsStream(
   for (const row of rows) {
     yield row as AuditLogItem;
   }
+}
+
+export interface AuditActionCount {
+  action: string;
+  count: number;
+}
+
+export interface AuditCountsSummary {
+  totalCount: number;
+  byAction: AuditActionCount[];
+}
+
+/**
+ * Aggregate audit log entries into a per-action counts summary, optionally
+ * scoped to a date range. Used to power admin dashboards without requiring
+ * the full paginated log to be fetched and counted client-side.
+ */
+export async function getAuditCounts(
+  filters: Pick<AuditLogFilters, "startDate" | "endDate">,
+): Promise<AuditCountsSummary> {
+  const conditions = [];
+  if (filters.startDate) {
+    conditions.push(gte(auditLogs.createdAt, filters.startDate));
+  }
+  if (filters.endDate) {
+    conditions.push(lte(auditLogs.createdAt, filters.endDate));
+  }
+
+  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+  const countExpr = count();
+
+  const rows = await db
+    .select({ action: auditLogs.action, count: countExpr })
+    .from(auditLogs)
+    .where(whereClause)
+    .groupBy(auditLogs.action)
+    .orderBy(desc(countExpr));
+
+  const totalCount = rows.reduce((sum, row) => sum + row.count, 0);
+
+  return {
+    totalCount,
+    byAction: rows.map((row) => ({ action: row.action, count: row.count })),
+  };
 }

--- a/src/routes/audit/counts.ts
+++ b/src/routes/audit/counts.ts
@@ -1,0 +1,86 @@
+import { Router } from "express";
+import { rateLimit } from "express-rate-limit";
+import { z } from "zod";
+import { requireAdmin } from "../../middleware/requireAdmin";
+import { getAuditCounts } from "../../repositories/auditLogRepo";
+import { getRequestId } from "../../lib/requestContext";
+import { logger } from "../../config/logger";
+
+export interface AuditCountsRouterOptions {
+  rateLimitPerMinute?: number;
+}
+
+const auditCountsQuerySchema = z.object({
+  startDate: z.string()
+    .datetime({ message: "startDate must be a valid ISO 8601 datetime string" })
+    .transform((val) => new Date(val))
+    .optional(),
+  endDate: z.string()
+    .datetime({ message: "endDate must be a valid ISO 8601 datetime string" })
+    .transform((val) => new Date(val))
+    .optional(),
+});
+
+export function createAuditCountsRouter(opts: AuditCountsRouterOptions = {}): Router {
+  const router = Router();
+  const limit = opts.rateLimitPerMinute ?? 60;
+
+  router.use(
+    rateLimit({
+      windowMs: 60_000,
+      limit,
+      keyGenerator: (req) =>
+        (req.headers.authorization as string | undefined) ?? req.ip ?? "unknown",
+      standardHeaders: "draft-6",
+      legacyHeaders: false,
+      message: { error: { code: "rate_limit_exceeded" } },
+    }),
+  );
+
+  router.use(requireAdmin);
+
+  /**
+   * GET /api/audit/counts
+   * Returns a per-action counts summary of audit log entries, optionally
+   * scoped to a date range, for admin dashboards.
+   */
+  router.get("/", async (req, res, next) => {
+    const reqId = getRequestId() ?? (req as { id?: string }).id ?? "unknown";
+
+    try {
+      const parseResult = auditCountsQuerySchema.safeParse(req.query);
+
+      if (!parseResult.success) {
+        res.status(400).json({
+          error: {
+            code: "validation_error",
+            message: parseResult.error.issues[0]?.message ?? "invalid query parameters",
+            requestId: reqId,
+          },
+        });
+        return;
+      }
+
+      const filters = parseResult.data;
+
+      logger.info(
+        {
+          startDate: filters.startDate,
+          endDate: filters.endDate,
+          correlationId: reqId,
+        },
+        "Fetching admin audit counts summary",
+      );
+
+      const summary = await getAuditCounts(filters);
+
+      res.json({ data: summary });
+    } catch (e) {
+      next(e);
+    }
+  });
+
+  return router;
+}
+
+export const auditCountsRouter = createAuditCountsRouter();

--- a/tests/auditCounts.test.ts
+++ b/tests/auditCounts.test.ts
@@ -1,0 +1,154 @@
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { createAuditCountsRouter } from "../src/routes/audit/counts";
+import { errorHandler } from "../src/middleware/errorHandler";
+
+// ── Mock Repository ─────────────────────────────────────────────────────────
+
+jest.mock("../src/repositories/auditLogRepo");
+
+import { getAuditCounts } from "../src/repositories/auditLogRepo";
+const mockGetAuditCounts = getAuditCounts as jest.MockedFunction<typeof getAuditCounts>;
+
+// ── DB Mock (Prevents connection at import time) ─────────────────────────────
+
+jest.mock("../src/db/client", () => ({ db: {} }));
+
+// ── JWT Helpers ──────────────────────────────────────────────────────────────
+
+const SECRET = process.env.JWT_SECRET || "test-jwt-secret-at-least-32-bytes-long-000000";
+const ISSUER = process.env.JWT_ISSUER || "predictify";
+const AUDIENCE = process.env.JWT_AUDIENCE || "predictify-app";
+
+const ADMIN_ADDRESS = "GADMIN7777777777777777777777777777777777777777777777777777";
+const USER_ADDRESS  = "GUSER88888888888888888888888888888888888888888888888888888";
+
+function signJwt(payload: object): string {
+  return jwt.sign(payload, SECRET, { issuer: ISSUER, audience: AUDIENCE, expiresIn: "1h" });
+}
+
+const adminJwt = signJwt({ sub: ADMIN_ADDRESS, role: "admin" });
+const userJwt  = signJwt({ sub: USER_ADDRESS,  role: "user" });
+
+// ── App Factory ──────────────────────────────────────────────────────────────
+
+function makeApp(rateLimitPerMinute = 60): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/audit/counts", createAuditCountsRouter({ rateLimitPerMinute }));
+  app.use(errorHandler);
+  return app;
+}
+
+// ── Test Suites ──────────────────────────────────────────────────────────────
+
+describe("GET /api/audit/counts", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("auth", () => {
+    it("returns 403 with no Authorization header", async () => {
+      const res = await request(makeApp()).get("/api/audit/counts");
+      expect(res.status).toBe(403);
+      expect(res.body).toEqual({ error: { code: "forbidden" } });
+    });
+
+    it("returns 403 with a non-admin JWT (role: user)", async () => {
+      const res = await request(makeApp())
+        .get("/api/audit/counts")
+        .set("Authorization", `Bearer ${userJwt}`);
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 403 with a JWT signed by a different secret", async () => {
+      const badToken = jwt.sign(
+        { sub: ADMIN_ADDRESS, role: "admin" },
+        "wrong-secret-at-least-32-characters-long",
+        { issuer: ISSUER, audience: AUDIENCE },
+      );
+      const res = await request(makeApp())
+        .get("/api/audit/counts")
+        .set("Authorization", `Bearer ${badToken}`);
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("validation", () => {
+    it("returns 400 for invalid startDate format", async () => {
+      const res = await request(makeApp())
+        .get("/api/audit/counts?startDate=2024-01-01")
+        .set("Authorization", `Bearer ${adminJwt}`);
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+      expect(res.body.error.message).toContain("startDate must be a valid ISO 8601 datetime string");
+    });
+
+    it("returns 400 for invalid endDate format", async () => {
+      const res = await request(makeApp())
+        .get("/api/audit/counts?endDate=2024-13-45T25:00:00Z")
+        .set("Authorization", `Bearer ${adminJwt}`);
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+      expect(res.body.error.message).toContain("endDate must be a valid ISO 8601 datetime string");
+    });
+  });
+
+  describe("happy path & parameters mapping", () => {
+    it("calls getAuditCounts with correct filter mappings and returns the summary", async () => {
+      const mockResult = {
+        totalCount: 3,
+        byAction: [
+          { action: "market.create", count: 2 },
+          { action: "user.login", count: 1 },
+        ],
+      };
+      mockGetAuditCounts.mockResolvedValue(mockResult);
+
+      const startDateStr = "2026-06-27T00:00:00.000Z";
+      const endDateStr = "2026-06-27T23:59:59.000Z";
+
+      const res = await request(makeApp())
+        .get(`/api/audit/counts?startDate=${startDateStr}&endDate=${endDateStr}`)
+        .set("Authorization", `Bearer ${adminJwt}`);
+
+      expect(res.status).toBe(200);
+      expect(mockGetAuditCounts).toHaveBeenCalledWith({
+        startDate: new Date(startDateStr),
+        endDate: new Date(endDateStr),
+      });
+      expect(res.body).toEqual({ data: mockResult });
+    });
+
+    it("supports no filters (full summary)", async () => {
+      const mockResult = { totalCount: 0, byAction: [] };
+      mockGetAuditCounts.mockResolvedValue(mockResult);
+
+      const res = await request(makeApp())
+        .get("/api/audit/counts")
+        .set("Authorization", `Bearer ${adminJwt}`);
+
+      expect(res.status).toBe(200);
+      expect(mockGetAuditCounts).toHaveBeenCalledWith({});
+      expect(res.body).toEqual({ data: mockResult });
+    });
+  });
+
+  describe("rate limiting", () => {
+    it("returns 429 once the per-minute limit is exceeded", async () => {
+      mockGetAuditCounts.mockResolvedValue({ totalCount: 0, byAction: [] });
+      const app = makeApp(1);
+
+      const first = await request(app)
+        .get("/api/audit/counts")
+        .set("Authorization", `Bearer ${adminJwt}`);
+      expect(first.status).toBe(200);
+
+      const second = await request(app)
+        .get("/api/audit/counts")
+        .set("Authorization", `Bearer ${adminJwt}`);
+      expect(second.status).toBe(429);
+    });
+  });
+});

--- a/tests/auditLogRepo.test.ts
+++ b/tests/auditLogRepo.test.ts
@@ -1,4 +1,4 @@
-import { getAuditLogs } from "../src/repositories/auditLogRepo";
+import { getAuditLogs, getAuditCounts } from "../src/repositories/auditLogRepo";
 import { db } from "../src/db";
 
 // ── DB Mock ──────────────────────────────────────────────────────────────────
@@ -9,6 +9,7 @@ jest.mock("../src/db", () => {
     from: jest.fn().mockReturnThis(),
     where: jest.fn().mockReturnThis(),
     orderBy: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
     limit: jest.fn(),
   };
   return {
@@ -100,5 +101,54 @@ describe("auditLogRepo", () => {
     expect(result.data).toHaveLength(1);
     expect(result.data[0].id).toBe("1");
     expect(result.nextCursor).not.toBeNull();
+  });
+});
+
+describe("getAuditCounts", () => {
+  const mockGroupBy = mockDb.groupBy as jest.Mock;
+  const mockOrderBy = mockDb.orderBy as jest.Mock;
+  const mockWhere = mockDb.where as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("groups by action and returns a total plus per-action counts", async () => {
+    mockOrderBy.mockResolvedValueOnce([
+      { action: "market.create", count: 2 },
+      { action: "user.login", count: 1 },
+    ]);
+
+    const result = await getAuditCounts({});
+
+    expect(mockDb.select).toHaveBeenCalled();
+    expect(mockGroupBy).toHaveBeenCalled();
+    expect(mockWhere).toHaveBeenCalledWith(undefined);
+    expect(result).toEqual({
+      totalCount: 3,
+      byAction: [
+        { action: "market.create", count: 2 },
+        { action: "user.login", count: 1 },
+      ],
+    });
+  });
+
+  it("applies startDate/endDate filters", async () => {
+    mockOrderBy.mockResolvedValueOnce([]);
+
+    const startDate = new Date("2026-06-27T00:00:00Z");
+    const endDate = new Date("2026-06-27T23:59:59Z");
+
+    await getAuditCounts({ startDate, endDate });
+
+    expect(mockWhere).toHaveBeenCalledWith(expect.anything());
+  });
+
+  it("returns zero totals when there are no matching entries", async () => {
+    mockOrderBy.mockResolvedValueOnce([]);
+
+    const result = await getAuditCounts({});
+
+    expect(result).toEqual({ totalCount: 0, byAction: [] });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `GET /api/audit/counts`, an admin-only endpoint that returns a per-action counts summary of `audit_logs` entries (optionally scoped to a `startDate`/`endDate` range), for use in dashboards.
- Adds `getAuditCounts` to `src/repositories/auditLogRepo.ts` (groups by `action`, orders by count descending).
- Documents the endpoint in the OpenAPI registry and README, and registers it in `scripts/check-openapi.ts`.

## Test plan
- [x] `npm run lint` — no errors
- [x] `npx tsc -p tsconfig.json --noEmit` — no new errors introduced (diffed against `main`)
- [x] `npx jest tests/auditCounts.test.ts tests/auditLogRepo.test.ts` — all passing (auth, validation, rate limiting, happy path)
- [x] Confirmed no regressions in the broader test suite (compared against `main` baseline)

Closes #384