### PR TITLE
feat: cursor pagination /api/users

### DIFF
--- a/src/openapi/registry.ts
+++ b/src/openapi/registry.ts
@@ -1095,6 +1095,61 @@ const FollowResult = z
 
 registry.registerPath({
   method: "get",
+  path: "/api/users",
+  operationId: "listUsers",
+  tags: ["Users"],
+  summary: "List all users (cursor-paginated)",
+  description:
+    "Returns a cursor-paginated list of registered users sorted newest-first " +
+    "(DESC createdAt, DESC id).  Pass the opaque `nextCursor` value from one " +
+    "response as the `cursor` query parameter of the next request to advance " +
+    "through pages.  A null `nextCursor` indicates the last page.",
+  request: {
+    query: z.object({
+      cursor: z.string().optional().openapi({
+        description: "Opaque cursor token from the previous page's nextCursor field.",
+        example: "djF8MjZ8MjAyNi0wMS0wMVQwMDowMDowMC4wMDBafGFiY2Qtd...",
+      }),
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(20)
+        .openapi({ description: "Page size (1–100, default 20)." }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Paginated list of users",
+      content: {
+        "application/json": {
+          schema: z.object({
+            data: z.array(
+              z
+                .object({
+                  id: z.string().uuid(),
+                  stellarAddress: z.string(),
+                  createdAt: z.string().datetime(),
+                })
+                .openapi("UserListRow"),
+            ),
+            nextCursor: z.string().nullable().openapi({
+              description: "Cursor for the next page, or null on the last page.",
+            }),
+          }),
+        },
+      },
+    },
+    400: {
+      description: "Validation error",
+      content: { "application/json": { schema: ValidationErrorBody } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/api/users/me",
   operationId: "getCurrentUser",
   tags: ["Users"],

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,7 +1,7 @@
   
 import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
-import { getUserByAddress, getUserPredictions, getCurrentUserProfile, getUserProfile } from "../services/userService";
+import { getUserByAddress, getUserPredictions, getCurrentUserProfile, getUserProfile, listUsers } from "../services/userService";
 import { requireAuthForbidden } from "../middleware/requireAuth";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { logger } from "../config/logger";
@@ -11,6 +11,68 @@ import { clampLimit, DEFAULT_PAGE_SIZE } from "../utils/cursor";
 export const usersRouter = Router();
 
 const stellarAddressSchema = z.string().regex(/^G[A-Z2-7]{55}$/, "Invalid Stellar address");
+
+/**
+ * GET /api/users
+ *
+ * Returns a cursor-paginated list of all registered users, sorted newest-first
+ * (DESC createdAt, DESC id).  The composite sort key `(createdAt, id)` is
+ * stable: even when two users are created in the same millisecond the UUID
+ * tie-breaker is unique, so pages never overlap or skip rows.
+ *
+ * Query parameters:
+ *   - cursor  (optional) — opaque base64url token from the previous page's `nextCursor`
+ *   - limit   (optional, default 20, max 100) — page size
+ *
+ * Response:
+ *   { data: UserListRow[], nextCursor: string | null }
+ *
+ * Pagination:
+ *   `nextCursor` is null on the last page.  Pass it verbatim as `?cursor=` to
+ *   fetch the next page.  A missing, tampered, or version-mismatched cursor is
+ *   silently treated as absent (restart from page one) rather than 500-ing.
+ *
+ * Errors:
+ *   400 validation_error — query params fail the zod schema
+ */
+usersRouter.get("/", async (req: Request, res: Response, next: NextFunction) => {
+  const reqId = getRequestId();
+
+  try {
+    const querySchema = z.object({
+      cursor: z.string().optional(),
+      limit: z.coerce.number().int().min(1).max(100).default(DEFAULT_PAGE_SIZE),
+    });
+
+    const queryParse = querySchema.safeParse(req.query);
+    if (!queryParse.success) {
+      logger.warn({ reqId, issues: queryParse.error.issues }, "users_list_invalid_query");
+      return res.status(400).json({
+        error: {
+          code: "validation_error",
+          message: queryParse.error.issues[0]?.message ?? "invalid query parameters",
+          requestId: reqId,
+        },
+      });
+    }
+
+    const { cursor, limit: rawLimit } = queryParse.data;
+    const limit = clampLimit(rawLimit);
+
+    logger.debug({ reqId, limit, hasCursor: !!cursor }, "users_list_request");
+
+    const page = await listUsers({ cursor, limit });
+
+    logger.info(
+      { reqId, count: page.data.length, hasNext: !!page.nextCursor },
+      "users_list_served",
+    );
+
+    return res.json({ data: page.data, nextCursor: page.nextCursor });
+  } catch (e) {
+    return next(e);
+  }
+});
 
 usersRouter.get("/me", requireAuthForbidden, async (req: AuthenticatedRequest, res, next) => {
   try {

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -2,7 +2,7 @@ import { db } from "../db/client";
 import { users, predictions, markets } from "../db/schema";
 import { and, eq, desc, lt, or, count } from "drizzle-orm";
 import { Result, ok, err } from "../errors/RouteError";
-import { encodeCursor, decodeCursor, Page } from "../utils/cursor";
+import { encodeCursor, decodeCursor, Page, clampLimit, DEFAULT_PAGE_SIZE } from "../utils/cursor";
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
@@ -208,5 +208,77 @@ export async function getUserPredictions(
       resolutionTime: r.resolutionTime.toISOString(),
     })),
     nextCursor,
+  };
+}
+
+// ── listUsers ──────────────────────────────────────────────────────────────
+
+/**
+ * Serialised shape of a single user row returned by GET /api/users.
+ */
+export interface UserListRow {
+  id: string;
+  stellarAddress: string;
+  createdAt: string;
+}
+
+/**
+ * Return a cursor-paginated list of all users, sorted DESC by (createdAt, id)
+ * for stable ordering even when two users share the same timestamp.
+ *
+ * Cursor format: opaque base64url token encoding `{ sortValue: createdAt ISO,
+ * id }` via the shared `encodeCursor` / `decodeCursor` helpers in
+ * `src/utils/cursor.ts`.  A missing, tampered, or version-mismatched cursor
+ * is silently treated as absent (restart from page one) rather than 500-ing.
+ *
+ * Keyset WHERE clause for DESC (createdAt, id):
+ *   (createdAt < cursorTime) OR (createdAt = cursorTime AND id < cursorId)
+ *
+ * Fetch limit + 1 rows so we can detect whether a next page exists without
+ * a separate COUNT query.
+ */
+export async function listUsers(opts: {
+  cursor?: string;
+  limit?: number;
+}): Promise<Page<UserListRow>> {
+  const limit = clampLimit(opts.limit ?? DEFAULT_PAGE_SIZE);
+  const cursorKey = decodeCursor(opts.cursor);
+
+  const conditions: ReturnType<typeof eq>[] = [];
+
+  if (cursorKey) {
+    const cursorTime = new Date(cursorKey.sortValue);
+    conditions.push(
+      or(
+        lt(users.createdAt, cursorTime),
+        and(eq(users.createdAt, cursorTime), lt(users.id, cursorKey.id)),
+      )! as ReturnType<typeof eq>,
+    );
+  }
+
+  const rows = await db
+    .select({
+      id: users.id,
+      stellarAddress: users.stellarAddress,
+      createdAt: users.createdAt,
+    })
+    .from(users)
+    .where(conditions.length ? and(...conditions) : undefined)
+    .orderBy(desc(users.createdAt), desc(users.id))
+    .limit(limit + 1);
+
+  const hasMore = rows.length > limit;
+  const data = rows.slice(0, limit);
+  const last = data[data.length - 1];
+
+  return {
+    data: data.map((r) => ({
+      ...r,
+      createdAt: r.createdAt.toISOString(),
+    })),
+    nextCursor:
+      hasMore && last
+        ? encodeCursor({ sortValue: last.createdAt.toISOString(), id: last.id })
+        : null,
   };
 }

--- a/tests/usersList.test.ts
+++ b/tests/usersList.test.ts
@@ -1,0 +1,339 @@
+/**
+ * tests/usersList.test.ts
+ *
+ * Focused unit tests for GET /api/users (cursor-paginated user listing).
+ *
+ * Strategy
+ * --------
+ * Mount `usersRouter` on a minimal Express app.  Two layers are mocked so the
+ * suite runs in CI without a live PostgreSQL instance:
+ *
+ *   1. `pg` / `drizzle-orm/node-postgres` — prevents socket opens at module load.
+ *   2. `../src/services/userService`       — lets tests control listUsers output.
+ *
+ * Coverage targets
+ * ----------------
+ *   - Happy path: first page with nextCursor present
+ *   - Happy path: last page with nextCursor = null
+ *   - Cursor threading: nextCursor from page N passed into page N+1
+ *   - Default limit (20) is used when ?limit is absent
+ *   - Custom valid limit is forwarded to the service
+ *   - limit=0 rejected with 400 validation_error
+ *   - limit=101 rejected with 400 validation_error
+ *   - Non-numeric limit rejected with 400 validation_error
+ *   - Tampered / garbage cursor forwarded to service (no 500 at route layer)
+ *   - Service error propagates as 500
+ *   - Response shape: { data: UserListRow[], nextCursor: string | null }
+ *   - Each UserListRow contains id, stellarAddress, createdAt
+ */
+
+// ---------------------------------------------------------------------------
+// 1. Env vars — set before any project import.
+// ---------------------------------------------------------------------------
+process.env.NODE_ENV = "test";
+process.env.PORT = "3001";
+process.env.LOG_LEVEL = "fatal";
+process.env.DATABASE_URL = "postgres://localhost/test";
+process.env.JWT_SECRET = "users-list-test-secret-at-least-32-bytes!!!!";
+process.env.JWT_ISSUER = "predictify";
+process.env.JWT_AUDIENCE = "predictify-app";
+process.env.JWT_TTL_SECONDS = "3600";
+process.env.STELLAR_NETWORK = "testnet";
+process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "CABCDEF";
+
+// ---------------------------------------------------------------------------
+// 2. Mock pg so no socket is opened during module load.
+// ---------------------------------------------------------------------------
+jest.mock("pg", () => {
+  const Pool = jest.fn().mockImplementation(() => ({
+    connect: jest.fn(),
+    query: jest.fn(),
+    end: jest.fn(),
+    on: jest.fn(),
+  }));
+  return { Pool };
+});
+
+// ---------------------------------------------------------------------------
+// 3. Mock drizzle-orm/node-postgres — prevents DB calls leaking out.
+// ---------------------------------------------------------------------------
+jest.mock("drizzle-orm/node-postgres", () => ({
+  drizzle: jest.fn(() => ({
+    select: jest.fn(),
+    query: { users: { findFirst: jest.fn() } },
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// 3a. Mock src/db/client so pool.on() does not throw during module init.
+// ---------------------------------------------------------------------------
+jest.mock("../src/db/client", () => ({
+  db: {
+    select: jest.fn(),
+    query: { users: { findFirst: jest.fn() } },
+  },
+  pool: { on: jest.fn(), end: jest.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// 4. Mock userService so individual tests control listUsers output.
+// ---------------------------------------------------------------------------
+jest.mock("../src/services/userService", () => ({
+  __esModule: true,
+  listUsers: jest.fn(),
+  // Keep all other exports to avoid import errors from the router.
+  getUserByAddress: jest.fn(),
+  getUserPredictions: jest.fn(),
+  getCurrentUserProfile: jest.fn(),
+  getUserProfile: jest.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// 5. Project imports — safe after mocks are in place.
+// ---------------------------------------------------------------------------
+import express from "express";
+import request from "supertest";
+import { usersRouter } from "../src/routes/users";
+import { errorHandler } from "../src/middleware/errorHandler";
+import { listUsers } from "../src/services/userService";
+import { encodeCursor } from "../src/utils/cursor";
+
+const mockListUsers = listUsers as jest.MockedFunction<typeof listUsers>;
+
+// ---------------------------------------------------------------------------
+// App factory
+// ---------------------------------------------------------------------------
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/users", usersRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+const USER_1 = {
+  id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  stellarAddress: "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW",
+  createdAt: "2026-06-27T12:00:00.000Z",
+};
+const USER_2 = {
+  id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+  stellarAddress: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+  createdAt: "2026-06-26T12:00:00.000Z",
+};
+
+const CURSOR_FOR_USER_1 = encodeCursor({
+  sortValue: USER_1.createdAt,
+  id: USER_1.id,
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const app = makeApp();
+
+function usersListUrl(params: Record<string, string | number> = {}): string {
+  const qs = Object.keys(params).length
+    ? "?" + new URLSearchParams(params as Record<string, string>).toString()
+    : "";
+  return `/api/users${qs}`;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/users", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // ── Happy paths ────────────────────────────────────────────────────────────
+
+  describe("happy paths", () => {
+    it("returns 200 with data and nextCursor on the first page", async () => {
+      mockListUsers.mockResolvedValueOnce({
+        data: [USER_1, USER_2],
+        nextCursor: CURSOR_FOR_USER_1,
+      });
+
+      const res = await request(app).get(usersListUrl());
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(2);
+      expect(res.body.nextCursor).toBe(CURSOR_FOR_USER_1);
+    });
+
+    it("returns nextCursor = null on the last page", async () => {
+      mockListUsers.mockResolvedValueOnce({
+        data: [USER_2],
+        nextCursor: null,
+      });
+
+      const res = await request(app).get(usersListUrl());
+
+      expect(res.status).toBe(200);
+      expect(res.body.nextCursor).toBeNull();
+    });
+
+    it("response data rows have id, stellarAddress, and createdAt", async () => {
+      mockListUsers.mockResolvedValueOnce({
+        data: [USER_1],
+        nextCursor: null,
+      });
+
+      const res = await request(app).get(usersListUrl());
+
+      expect(res.status).toBe(200);
+      const row = res.body.data[0];
+      expect(row).toMatchObject({
+        id: USER_1.id,
+        stellarAddress: USER_1.stellarAddress,
+        createdAt: USER_1.createdAt,
+      });
+    });
+
+    it("returns an empty data array with nextCursor = null when there are no users", async () => {
+      mockListUsers.mockResolvedValueOnce({ data: [], nextCursor: null });
+
+      const res = await request(app).get(usersListUrl());
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual([]);
+      expect(res.body.nextCursor).toBeNull();
+    });
+  });
+
+  // ── Limit forwarding ───────────────────────────────────────────────────────
+
+  describe("limit handling", () => {
+    it("forwards limit=5 to listUsers", async () => {
+      mockListUsers.mockResolvedValueOnce({ data: [], nextCursor: null });
+
+      await request(app).get(usersListUrl({ limit: 5 }));
+
+      expect(mockListUsers).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 5 }),
+      );
+    });
+
+    it("defaults to limit=20 when ?limit is absent", async () => {
+      mockListUsers.mockResolvedValueOnce({ data: [], nextCursor: null });
+
+      await request(app).get(usersListUrl());
+
+      expect(mockListUsers).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 20 }),
+      );
+    });
+
+    it("accepts limit=100 (maximum)", async () => {
+      mockListUsers.mockResolvedValueOnce({ data: [], nextCursor: null });
+
+      const res = await request(app).get(usersListUrl({ limit: 100 }));
+
+      expect(res.status).toBe(200);
+      expect(mockListUsers).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 100 }),
+      );
+    });
+
+    it("rejects limit=0 with 400 validation_error", async () => {
+      const res = await request(app).get(usersListUrl({ limit: 0 }));
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+      expect(mockListUsers).not.toHaveBeenCalled();
+    });
+
+    it("rejects limit=101 with 400 validation_error", async () => {
+      const res = await request(app).get(usersListUrl({ limit: 101 }));
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+      expect(mockListUsers).not.toHaveBeenCalled();
+    });
+
+    it("rejects non-numeric limit with 400 validation_error", async () => {
+      const res = await request(app).get(usersListUrl({ limit: "banana" }));
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+      expect(mockListUsers).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Cursor threading ───────────────────────────────────────────────────────
+
+  describe("cursor threading", () => {
+    it("forwards cursor string to listUsers", async () => {
+      mockListUsers.mockResolvedValueOnce({ data: [USER_2], nextCursor: null });
+
+      await request(app).get(usersListUrl({ cursor: CURSOR_FOR_USER_1 }));
+
+      expect(mockListUsers).toHaveBeenCalledWith(
+        expect.objectContaining({ cursor: CURSOR_FOR_USER_1 }),
+      );
+    });
+
+    it("threads nextCursor from page 1 into page 2 correctly", async () => {
+      // Page 1 — service returns USER_1 with a nextCursor
+      mockListUsers.mockResolvedValueOnce({
+        data: [USER_1],
+        nextCursor: CURSOR_FOR_USER_1,
+      });
+      const page1 = await request(app).get(usersListUrl({ limit: 1 }));
+      expect(page1.status).toBe(200);
+      const cursor = page1.body.nextCursor as string;
+      expect(cursor).toBe(CURSOR_FOR_USER_1);
+
+      // Page 2 — pass cursor back; service returns USER_2, no further pages
+      mockListUsers.mockResolvedValueOnce({
+        data: [USER_2],
+        nextCursor: null,
+      });
+      const page2 = await request(app).get(usersListUrl({ limit: 1, cursor }));
+      expect(page2.status).toBe(200);
+      expect(page2.body.data[0].id).toBe(USER_2.id);
+      expect(page2.body.nextCursor).toBeNull();
+
+      // Verify the cursor was forwarded verbatim
+      expect(mockListUsers).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ cursor }),
+      );
+    });
+
+    it("forwards a tampered cursor to listUsers without 500-ing at the route layer", async () => {
+      // The route does not validate the cursor; listUsers (or decodeCursor) handles it.
+      mockListUsers.mockResolvedValueOnce({ data: [], nextCursor: null });
+
+      const res = await request(app).get(
+        usersListUrl({ cursor: "!!!INVALID!!!" }),
+      );
+
+      expect(res.status).toBe(200);
+      // Service was called — it decides how to handle the bad cursor.
+      expect(mockListUsers).toHaveBeenCalledWith(
+        expect.objectContaining({ cursor: "!!!INVALID!!!" }),
+      );
+    });
+  });
+
+  // ── Error propagation ─────────────────────────────────────────────────────
+
+  describe("error propagation", () => {
+    it("propagates a service error as HTTP 500", async () => {
+      mockListUsers.mockRejectedValueOnce(new Error("DB exploded"));
+
+      const res = await request(app).get(usersListUrl());
+
+      expect(res.status).toBe(500);
+    });
+  });
+});


### PR DESCRIPTION
Implements GET /api/users with keyset pagination over (created_at, id) for stable, efficient listing of all registered users.

Changes:
- src/services/userService.ts: add listUsers() + UserListRow type
  - Keyset WHERE: (created_at < cursorTime) OR (created_at = cursorTime AND id < cursorId)
  - Sort: DESC created_at, DESC id
  - Fetch limit+1 to detect next page without a COUNT query
  - Reuses encodeCursor/decodeCursor from src/utils/cursor.ts
- src/routes/users.ts: add GET / handler
  - zod validation for cursor (optional) and limit (1–100, default 20)
  - Returns { data: UserListRow[], nextCursor: string | null }
  - Invalid/tampered cursor forwarded to service (graceful restart from page 1)
- src/openapi/registry.ts: register GET /api/users (operationId: listUsers)
  - Documents cursor, limit query params and UserListRow schema
- tests/usersList.test.ts: 14 focused unit tests (no live DB)
  - Happy paths, limit validation, cursor threading, error propagation

closes #408