### PR TITLE
feat: reconciliation runbook + on-demand endpoint

### DIFF
--- a/docs/runbook-reconciliation.md
+++ b/docs/runbook-reconciliation.md
@@ -5,15 +5,24 @@
 Use the admin reconciliation endpoint to inspect a single market and compare the
 backend's database snapshot with the available on-chain snapshot.
 
+The endpoint is **on-demand and read-only** — it never mutates state. Run it any
+time you suspect a discrepancy between what Predictify's database has recorded
+and what the Soroban contract holds on-chain.
+
+---
+
 ## Endpoint
 
-`GET /api/admin/recon/markets/:id`
+```
+GET /api/admin/recon/markets/:id
+```
 
 ### Security
 
-- Admin-only route guarded by the existing bearer JWT admin middleware.
-- Every successful inspection is audit logged as
-  `admin.reconciliation.market.inspect`.
+- Admin-only route guarded by the existing bearer JWT admin middleware
+  (`requireAdmin`). The JWT must carry `role: "admin"`.
+- Every call is audit-logged as `admin.reconciliation.market.inspect` with the
+  caller's wallet address, IP, and correlation ID.
 - Correlate the request with the `x-request-id` response header and the
   `correlationId` field in the JSON payload.
 
@@ -21,58 +30,59 @@ backend's database snapshot with the available on-chain snapshot.
 
 ```bash
 curl --request GET \
-  --url http://localhost:3000/api/admin/recon/markets/MARKET_ID \
+  --url https://<host>/api/admin/recon/markets/<MARKET_ID> \
   --header 'Authorization: Bearer <admin-jwt>' \
-  --header 'X-Request-Id: recon-market-123'
+  --header 'X-Request-Id: recon-<uuid>'
 ```
 
-### Success response
+Supply `X-Request-Id` with a stable identifier so the log entry and the JSON
+response both carry the same correlation token.
+
+### Success response (`200 OK`)
 
 ```json
 {
   "data": {
-    "marketId": "MARKET_ID",
-    "correlationId": "recon-market-123",
+    "marketId": "abc123",
+    "correlationId": "recon-market-abc123",
     "generatedAt": "2026-06-27T12:00:00.000Z",
     "status": "ok",
     "dbSnapshot": {
       "positions": [
-        {
-          "stellarAddress": "G...USER",
-          "outcome": "yes",
-          "amount": "100"
-        }
+        { "stellarAddress": "GABC…", "outcome": "yes", "amount": "100" },
+        { "stellarAddress": "GXYZ…", "outcome": "no",  "amount": "50"  }
       ],
-      "totalAmount": "100"
+      "totalAmount": "150"
     },
     "onChainSnapshot": {
       "positions": [
-        {
-          "stellarAddress": "G...USER",
-          "outcome": "yes",
-          "amount": "100"
-        }
+        { "stellarAddress": "GABC…", "outcome": "yes", "amount": "100" },
+        { "stellarAddress": "GXYZ…", "outcome": "no",  "amount": "50"  }
       ],
-      "totalAmount": "100",
+      "totalAmount": "150",
       "available": true,
       "source": "soroban-rpc",
       "unavailableReason": null
     },
     "summary": {
-      "totalKeys": 1,
-      "matches": 1,
+      "totalKeys": 2,
+      "matches": 2,
       "mismatches": 0,
       "missingOnChain": 0,
       "missingInDb": 0
     },
     "diffs": [
       {
-        "key": {
-          "stellarAddress": "G...USER",
-          "outcome": "yes"
-        },
+        "key": { "stellarAddress": "GABC…", "outcome": "yes" },
         "dbAmount": "100",
         "onChainAmount": "100",
+        "difference": "0",
+        "status": "match"
+      },
+      {
+        "key": { "stellarAddress": "GXYZ…", "outcome": "no" },
+        "dbAmount": "50",
+        "onChainAmount": "50",
         "difference": "0",
         "status": "match"
       }
@@ -81,27 +91,121 @@ curl --request GET \
 }
 ```
 
+### Partial response (on-chain adapter not configured)
+
+When the deployment does not yet have a live on-chain adapter wired in, the
+endpoint returns `status: "partial"`:
+
+```json
+{
+  "data": {
+    "status": "partial",
+    "onChainSnapshot": {
+      "positions": [],
+      "totalAmount": "0",
+      "available": false,
+      "source": "soroban-rpc",
+      "unavailableReason": "On-chain market position lookup is not configured for this deployment yet."
+    },
+    "summary": {
+      "totalKeys": 2,
+      "matches": 0,
+      "mismatches": 0,
+      "missingOnChain": 2,
+      "missingInDb": 0
+    }
+  }
+}
+```
+
+All DB positions appear as `missing_on_chain` diffs. This is expected until the
+Soroban contract read adapter is connected.
+
+---
+
 ## Diff semantics
 
-Each diff entry is keyed by `(stellarAddress, outcome)`.
+Each diff entry is keyed by `(stellarAddress, outcome)`. Positions are
+aggregated by that composite key before comparison so duplicate rows are
+collapsed correctly.
 
-- `match`: amounts are identical.
-- `mismatch`: amounts exist on both sides but differ.
-- `missing_on_chain`: present in DB only.
-- `missing_in_db`: present on-chain only.
+| `status`           | Meaning                                                 |
+|--------------------|---------------------------------------------------------|
+| `match`            | Amounts identical on both sides. No action required.    |
+| `mismatch`         | Both sides have the key but amounts differ. Investigate.|
+| `missing_on_chain` | Present in DB only. May indicate an indexing lead.      |
+| `missing_in_db`    | Present on-chain only. May indicate a missed event.     |
 
-## Operational notes
+The `difference` field for `mismatch` entries is `dbAmount − onChainAmount`.
+A positive value means the DB holds more than the contract; negative means the
+contract holds more.
 
-- The route is intentionally scoped to one market so results are fast to review.
-- DB rows are aggregated by `(stellarAddress, outcome)` before comparison.
-- If the deployment does not yet have a live on-chain position adapter wired in,
-  the endpoint returns `status: "partial"` and `onChainSnapshot.available: false`
-  with an explanatory `unavailableReason`.
-- Use the `summary` counters first, then inspect individual `diffs`.
+---
+
+## Interpreting results
+
+**`summary.mismatches > 0`**
+
+The DB and the contract disagree on at least one position amount. Check the
+`diffs` array for the affected `(stellarAddress, outcome)` pairs. Cross-
+reference the audit log and indexer events to find the discrepant transaction.
+
+**`summary.missingOnChain > 0` (with `status: "ok"`)**
+
+Predictions are recorded in the DB but not yet visible on-chain. This may be
+normal during settlement lag. If the gap persists, run the reindex endpoint:
+
+```bash
+POST /api/admin/reindex  { "ledger": <start_ledger> }
+```
+
+**`summary.missingInDb > 0`**
+
+On-chain positions have no matching DB record. This typically indicates a missed
+Soroban event. Use the gap-scan worker to detect and backfill:
+
+```bash
+npm run indexer:gap-scan
+```
+
+**`status: "partial"`**
+
+On-chain data was unavailable. Results reflect DB state only and every DB
+position will appear as `missing_on_chain`. Wire the Soroban contract read
+adapter before relying on reconciliation for live balance verification.
+
+---
 
 ## Failure modes
 
-- `400 validation_error`: invalid market id path param.
-- `403 forbidden`: missing or non-admin bearer token.
-- `404 not_found`: no such market.
-- `500 internal_error`: unexpected backend failure.
+| HTTP status | `error.code`       | Cause                                      |
+|-------------|--------------------|--------------------------------------------|
+| `400`       | `validation_error` | Market ID path param is blank or too long. |
+| `403`       | `forbidden`        | Missing, expired, or non-admin JWT.        |
+| `404`       | `not_found`        | No market with that ID exists in the DB.   |
+| `500`       | `internal_error`   | Unexpected backend failure.                |
+
+---
+
+## Operational notes
+
+- The endpoint is scoped to **one market per call** so results are fast and
+  easy to reason about.
+- DB rows are aggregated by `(stellarAddress, outcome)` before diffing.
+  Duplicate confirmed predictions are summed, not double-counted.
+- The call is idempotent and produces no side effects beyond the audit log row.
+- Use the `summary` counters to triage at a glance, then drill into `diffs`
+  for individual position details.
+- For bulk or scheduled reconciliation, enqueue a `market` job on the
+  `reconciliation` BullMQ queue (see `src/workers/reconciliationWorker.ts`).
+
+---
+
+## Related resources
+
+- `src/routes/admin/reconciliation.ts` — HTTP handler
+- `src/services/reconciliationService.ts` — diff logic and audit
+- `src/workers/reconciliationWorker.ts` — async BullMQ worker
+- `docs/job-queue.md` — queue design and enqueue patterns
+- `POST /api/admin/reindex` — trigger a ledger backfill
+- `GET /api/admin/health/detail` — check indexer lag before reconciling

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { notificationsRouter } from "./routes/notifications";
 import { socialRouter } from "./routes/social";
 import { adminAuditRouter } from "./routes/admin/audit";
 import { adminMarketsRouter } from "./routes/admin/markets";
+import { adminReconciliationRouter } from "./routes/admin/reconciliation";
 import { adminSchemaVersionsRouter } from "./routes/admin/schema-versions";
 import { devicesRouter } from "./routes/devices";
 import { errorHandler } from "./middleware/errorHandler";
@@ -140,6 +141,7 @@ export function createApp(_deps: AppDeps = {}): express.Express {
   app.use("/api/admin/audit", adminAuditRouter);
   app.use("/api/admin/users", adminUsersRouter);
   app.use("/api/admin/markets", adminMarketsRouter);
+  app.use("/api/admin/recon", adminReconciliationRouter);
   app.use("/api/admin/db", adminDbVacuumRouter);
 
   app.get("/metrics", async (req, res) => {

--- a/src/openapi/registry.ts
+++ b/src/openapi/registry.ts
@@ -1714,3 +1714,98 @@ registry.registerPath({
     },
   },
 });
+
+// ── /api/admin/recon ─────────────────────────────────────────────────────────
+
+const ReconciliationSidePosition = z
+  .object({
+    stellarAddress: z.string(),
+    outcome: z.string(),
+    amount: z.string(),
+  })
+  .openapi("ReconciliationSidePosition");
+
+const ReconciliationDiffEntry = z
+  .object({
+    key: z.object({ stellarAddress: z.string(), outcome: z.string() }),
+    dbAmount: z.string(),
+    onChainAmount: z.string().nullable(),
+    difference: z.string().nullable(),
+    status: z.enum(["match", "mismatch", "missing_on_chain", "missing_in_db"]),
+  })
+  .openapi("ReconciliationDiffEntry");
+
+const ReconciliationSummary = z
+  .object({
+    totalKeys: z.number().int(),
+    matches: z.number().int(),
+    mismatches: z.number().int(),
+    missingOnChain: z.number().int(),
+    missingInDb: z.number().int(),
+  })
+  .openapi("ReconciliationSummary");
+
+const MarketReconciliationResult = z
+  .object({
+    marketId: z.string(),
+    correlationId: z.string(),
+    generatedAt: z.string().datetime(),
+    status: z.enum(["ok", "partial"]),
+    dbSnapshot: z.object({
+      positions: z.array(ReconciliationSidePosition),
+      totalAmount: z.string(),
+    }),
+    onChainSnapshot: z.object({
+      positions: z.array(ReconciliationSidePosition),
+      totalAmount: z.string(),
+      available: z.boolean(),
+      source: z.string(),
+      unavailableReason: z.string().nullable(),
+    }),
+    summary: ReconciliationSummary,
+    diffs: z.array(ReconciliationDiffEntry),
+  })
+  .openapi("MarketReconciliationResult");
+
+registry.registerPath({
+  method: "get",
+  path: "/api/admin/recon/markets/{id}",
+  operationId: "adminReconcileMarket",
+  tags: ["Admin"],
+  summary: "On-demand market reconciliation (admin only)",
+  description:
+    "Compares confirmed on-chain positions against the database snapshot for a " +
+    "single market and returns a structured diff. " +
+    "Every call is audit-logged as `admin.reconciliation.market.inspect`. " +
+    "Returns `status: \"partial\"` when the on-chain adapter is not yet wired.",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: z.object({ id: z.string().min(1).max(255).describe("Market ID") }),
+  },
+  responses: {
+    200: {
+      description: "Reconciliation result",
+      content: {
+        "application/json": {
+          schema: z.object({ data: MarketReconciliationResult }),
+        },
+      },
+    },
+    400: {
+      description: "Validation error — invalid market ID",
+      content: { "application/json": { schema: ValidationErrorBody } },
+    },
+    403: {
+      description: "Forbidden — missing or non-admin JWT",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    404: {
+      description: "Market not found",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    500: {
+      description: "Internal server error",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+  },
+});

--- a/tests/adminReconciliation.test.ts
+++ b/tests/adminReconciliation.test.ts
@@ -44,12 +44,54 @@ function makeApp(): express.Express {
   return app;
 }
 
+/** Minimal valid reconciliation result for reuse across tests. */
+function makeResult(
+  overrides: Partial<Awaited<ReturnType<typeof reconcileMarket>>> = {},
+): Awaited<ReturnType<typeof reconcileMarket>> {
+  return {
+    marketId: "market-1",
+    correlationId: "recon-123",
+    generatedAt: "2026-06-27T12:00:00.000Z",
+    status: "ok",
+    dbSnapshot: {
+      positions: [{ stellarAddress: "G1", outcome: "yes", amount: "100" }],
+      totalAmount: "100",
+    },
+    onChainSnapshot: {
+      positions: [{ stellarAddress: "G1", outcome: "yes", amount: "100" }],
+      totalAmount: "100",
+      available: true,
+      source: "soroban-rpc",
+      unavailableReason: null,
+    },
+    summary: {
+      totalKeys: 1,
+      matches: 1,
+      mismatches: 0,
+      missingOnChain: 0,
+      missingInDb: 0,
+    },
+    diffs: [
+      {
+        key: { stellarAddress: "G1", outcome: "yes" },
+        dbAmount: "100",
+        onChainAmount: "100",
+        difference: "0",
+        status: "match",
+      },
+    ],
+    ...overrides,
+  };
+}
+
 describe("GET /api/admin/recon/markets/:id", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("returns 403 without an admin token", async () => {
+  // ── Auth guards ────────────────────────────────────────────────────────────
+
+  it("returns 403 without any token", async () => {
     const res = await request(makeApp()).get(
       "/api/admin/recon/markets/market-1",
     );
@@ -57,40 +99,57 @@ describe("GET /api/admin/recon/markets/:id", () => {
     expect(res.body).toEqual({ error: { code: "forbidden" } });
   });
 
-  it("returns 200 with a structured diff payload", async () => {
-    mockReconcileMarket.mockResolvedValue({
-      marketId: "market-1",
-      correlationId: "recon-123",
-      generatedAt: "2026-06-27T12:00:00.000Z",
-      status: "ok",
-      dbSnapshot: {
-        positions: [{ stellarAddress: "G1", outcome: "yes", amount: "100" }],
-        totalAmount: "100",
-      },
-      onChainSnapshot: {
-        positions: [{ stellarAddress: "G1", outcome: "yes", amount: "90" }],
-        totalAmount: "90",
-        available: true,
-        source: "soroban-rpc",
-        unavailableReason: null,
-      },
-      summary: {
-        totalKeys: 1,
-        matches: 0,
-        mismatches: 1,
-        missingOnChain: 0,
-        missingInDb: 0,
-      },
-      diffs: [
-        {
-          key: { stellarAddress: "G1", outcome: "yes" },
-          dbAmount: "100",
-          onChainAmount: "90",
-          difference: "10",
-          status: "mismatch",
+  it("returns 403 for non-admin JWTs", async () => {
+    const res = await request(makeApp())
+      .get("/api/admin/recon/markets/market-1")
+      .set(
+        "Authorization",
+        `Bearer ${signJwt({ sub: USER_ADDRESS, role: "user" })}`,
+      );
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: { code: "forbidden" } });
+  });
+
+  it("returns 403 for a malformed bearer token", async () => {
+    const res = await request(makeApp())
+      .get("/api/admin/recon/markets/market-1")
+      .set("Authorization", "Bearer not.a.valid.jwt");
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: { code: "forbidden" } });
+  });
+
+  // ── Happy path ─────────────────────────────────────────────────────────────
+
+  it("returns 200 with a full structured diff payload on mismatch", async () => {
+    mockReconcileMarket.mockResolvedValue(
+      makeResult({
+        onChainSnapshot: {
+          positions: [{ stellarAddress: "G1", outcome: "yes", amount: "90" }],
+          totalAmount: "90",
+          available: true,
+          source: "soroban-rpc",
+          unavailableReason: null,
         },
-      ],
-    });
+        summary: {
+          totalKeys: 1,
+          matches: 0,
+          mismatches: 1,
+          missingOnChain: 0,
+          missingInDb: 0,
+        },
+        diffs: [
+          {
+            key: { stellarAddress: "G1", outcome: "yes" },
+            dbAmount: "100",
+            onChainAmount: "90",
+            difference: "10",
+            status: "mismatch",
+          },
+        ],
+      }),
+    );
 
     const res = await request(makeApp())
       .get("/api/admin/recon/markets/market-1")
@@ -124,7 +183,85 @@ describe("GET /api/admin/recon/markets/:id", () => {
     });
   });
 
-  it("returns 400 for an empty market id", async () => {
+  it("returns 200 with status partial when on-chain data is unavailable", async () => {
+    mockReconcileMarket.mockResolvedValue(
+      makeResult({
+        status: "partial",
+        onChainSnapshot: {
+          positions: [],
+          totalAmount: "0",
+          available: false,
+          source: "soroban-rpc",
+          unavailableReason: "adapter not configured",
+        },
+        summary: {
+          totalKeys: 1,
+          matches: 0,
+          mismatches: 0,
+          missingOnChain: 1,
+          missingInDb: 0,
+        },
+        diffs: [
+          {
+            key: { stellarAddress: "G1", outcome: "yes" },
+            dbAmount: "100",
+            onChainAmount: null,
+            difference: null,
+            status: "missing_on_chain",
+          },
+        ],
+      }),
+    );
+
+    const res = await request(makeApp())
+      .get("/api/admin/recon/markets/market-1")
+      .set(
+        "Authorization",
+        `Bearer ${signJwt({ sub: ADMIN_ADDRESS, role: "admin" })}`,
+      );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("partial");
+    expect(res.body.data.onChainSnapshot.available).toBe(false);
+    expect(res.body.data.onChainSnapshot.unavailableReason).toBe(
+      "adapter not configured",
+    );
+  });
+
+  it("echoes the x-request-id from the request header", async () => {
+    mockReconcileMarket.mockResolvedValue(makeResult());
+
+    const res = await request(makeApp())
+      .get("/api/admin/recon/markets/market-1")
+      .set(
+        "Authorization",
+        `Bearer ${signJwt({ sub: ADMIN_ADDRESS, role: "admin" })}`,
+      )
+      .set("X-Request-Id", "my-custom-id");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-request-id"]).toBe("my-custom-id");
+    expect(res.body.data.correlationId).toBe("recon-123"); // value from mock
+  });
+
+  it("passes the adminAddress from the JWT sub claim to the service", async () => {
+    mockReconcileMarket.mockResolvedValue(makeResult());
+
+    await request(makeApp())
+      .get("/api/admin/recon/markets/market-1")
+      .set(
+        "Authorization",
+        `Bearer ${signJwt({ sub: ADMIN_ADDRESS, role: "admin" })}`,
+      );
+
+    expect(mockReconcileMarket).toHaveBeenCalledWith(
+      expect.objectContaining({ adminAddress: ADMIN_ADDRESS }),
+    );
+  });
+
+  // ── Input validation ───────────────────────────────────────────────────────
+
+  it("returns 400 for a whitespace-only market id", async () => {
     const res = await request(makeApp())
       .get("/api/admin/recon/markets/%20")
       .set(
@@ -138,7 +275,9 @@ describe("GET /api/admin/recon/markets/:id", () => {
     expect(res.body.error.requestId).toBe("bad-request-id");
   });
 
-  it("surfaces service not_found via the standardized envelope", async () => {
+  // ── Error propagation ──────────────────────────────────────────────────────
+
+  it("surfaces service not_found as 404 via the standardized envelope", async () => {
     const error = Object.assign(new Error("missing"), {
       status: 404,
       code: "not_found",
@@ -162,15 +301,22 @@ describe("GET /api/admin/recon/markets/:id", () => {
     });
   });
 
-  it("returns 403 for non-admin JWTs", async () => {
+  it("propagates unexpected service errors as 500", async () => {
+    mockReconcileMarket.mockRejectedValue(new Error("unexpected db failure"));
+
     const res = await request(makeApp())
       .get("/api/admin/recon/markets/market-1")
       .set(
         "Authorization",
-        `Bearer ${signJwt({ sub: USER_ADDRESS, role: "user" })}`,
+        `Bearer ${signJwt({ sub: ADMIN_ADDRESS, role: "admin" })}`,
       );
 
-    expect(res.status).toBe(403);
-    expect(res.body).toEqual({ error: { code: "forbidden" } });
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBeDefined();
+  });
+
+  it("does not call reconcileMarket when auth fails", async () => {
+    await request(makeApp()).get("/api/admin/recon/markets/market-1");
+    expect(mockReconcileMarket).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
- Mount adminReconciliationRouter at /api/admin/recon in src/index.ts
- Add OpenAPI spec entry for GET /api/admin/recon/markets/:id
- Expand adminReconciliation tests: partial status, auth edge cases, 500 propagation, adminAddress forwarding, x-request-id echo
- Rewrite docs/runbook-reconciliation.md with diff semantics table, interpretation guide, partial-response example, and failure-mode table

closes #326