### PR TITLE
feat: metrics on /api/webhooks

### DIFF
--- a/src/metrics/registry.ts
+++ b/src/metrics/registry.ts
@@ -83,3 +83,18 @@ export const usersEndpointDuration = new Histogram({
   buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10],
   registers: [register],
 });
+
+export const webhooksEndpointRequestsTotal = new Counter({
+  name: "webhooks_endpoint_requests_total",
+  help: "Total number of requests to /api/webhooks endpoints, segmented by method, route, and status",
+  labelNames: ["method", "route", "status"] as const,
+  registers: [register],
+});
+
+export const webhooksEndpointDuration = new Histogram({
+  name: "webhooks_endpoint_duration_seconds",
+  help: "Request duration in seconds for /api/webhooks endpoints, segmented by method, route, and status",
+  labelNames: ["method", "route", "status"] as const,
+  buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10],
+  registers: [register],
+});

--- a/src/metrics/webhooksMetrics.ts
+++ b/src/metrics/webhooksMetrics.ts
@@ -1,0 +1,28 @@
+import type { Request, Response, NextFunction } from "express";
+import { webhooksEndpointRequestsTotal, webhooksEndpointDuration } from "./registry";
+
+function sanitizeRoute(route: string): string {
+  return route
+    .replace(/\/[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}/gi, "/:id")
+    .replace(/\/\d+/g, "/:id");
+}
+
+export function webhooksMetricsMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const start = process.hrtime.bigint();
+
+  res.on("finish", () => {
+    const durationNs = Number(process.hrtime.bigint() - start);
+    const durationSec = durationNs / 1e9;
+
+    const routeTemplate: string = req.route?.path || req.path;
+
+    const route = sanitizeRoute(routeTemplate);
+    const method = req.method;
+    const status = String(res.statusCode);
+
+    webhooksEndpointRequestsTotal.inc({ method, route, status });
+    webhooksEndpointDuration.observe({ method, route, status }, durationSec);
+  });
+
+  next();
+}

--- a/src/routes/adminWebhooks.ts
+++ b/src/routes/adminWebhooks.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Router } from "express";
 import { requireAdmin } from "../middleware/requireAdmin";
+import { webhooksMetricsMiddleware } from "../metrics/webhooksMetrics";
 import type { IWebhookDispatcher } from "../services/webhookDispatcher";
 import type { DlqRow, WebhookStore } from "../services/webhookStore";
 import { RouteErrorFactory } from "../errors";
@@ -34,6 +35,7 @@ const UUID_RE =
 
 export function createAdminWebhooksRouter(deps: AdminWebhookDeps): Router {
   const router = Router();
+  router.use(webhooksMetricsMiddleware);
   router.use(requireAdmin);
 
   router.get("/dlq", async (req, res, next) => {

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { logger } from "../config/logger";
 import { getRequestId } from "../lib/requestContext";
 import { requireAdmin } from "../middleware/requireAdmin";
+import { webhooksMetricsMiddleware } from "../metrics/webhooksMetrics";
 import type { WebhookDelivery, WebhookStore } from "../services/webhookStore";
 
 export interface WebhooksRouterDeps {
@@ -42,6 +43,7 @@ function serializeDelivery(row: WebhookDelivery) {
 export function createWebhooksRouter(deps: WebhooksRouterDeps): Router {
   const router = Router();
 
+  router.use(webhooksMetricsMiddleware);
   router.use(requireAdmin);
 
   router.get("/", async (req, res, next) => {

--- a/tests/webhooksMetrics.test.ts
+++ b/tests/webhooksMetrics.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Tests for per-endpoint Prometheus metrics on /api/webhooks.
+ *
+ * Verifies that `webhooksEndpointRequestsTotal` (Counter) and
+ * `webhooksEndpointDuration` (Histogram) are incremented/observed for each
+ * route handler in src/routes/webhooks.ts and src/routes/adminWebhooks.ts.
+ *
+ * Strategy: mount the webhook routers directly on a small Express app
+ * with mocked deps so we exercise only the route + metrics wiring.
+ */
+
+// ---------------------------------------------------------------------------
+// 1. Env vars (must run BEFORE project imports)
+// ---------------------------------------------------------------------------
+process.env.NODE_ENV = "test";
+process.env.PORT = "3001";
+process.env.LOG_LEVEL = "fatal";
+process.env.DATABASE_URL = "postgres://localhost/test";
+process.env.JWT_SECRET = "webhooks-metrics-test-secret-at-least-32-bytes!!";
+process.env.JWT_ISSUER = "predictify";
+process.env.JWT_AUDIENCE = "predictify-app";
+process.env.JWT_TTL_SECONDS = "3600";
+process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "CABCDEF";
+
+// ---------------------------------------------------------------------------
+// 2. Project imports (env is set)
+// ---------------------------------------------------------------------------
+import express from "express";
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { v4 as uuidv4 } from "uuid";
+import { createWebhooksRouter } from "../src/routes/webhooks";
+import { createAdminWebhooksRouter } from "../src/routes/adminWebhooks";
+import { errorHandler } from "../src/middleware/errorHandler";
+import { requestContextStorage } from "../src/lib/requestContext";
+import { WebhookDispatcher, type HttpSender } from "../src/services/webhookDispatcher";
+import { InMemoryWebhookStore } from "../src/services/webhookStore";
+import {
+  webhooksEndpointRequestsTotal,
+  webhooksEndpointDuration,
+} from "../src/metrics/registry";
+
+// ---------------------------------------------------------------------------
+// 3. Helpers
+// ---------------------------------------------------------------------------
+const JWT_SECRET = process.env.JWT_SECRET!;
+const SIGNING_SECRET = "test-webhook-signing-secret";
+
+function token(role?: string) {
+  return jwt.sign({ sub: "user_1", ...(role ? { role } : {}) }, JWT_SECRET, {
+    issuer: process.env.JWT_ISSUER!,
+    audience: process.env.JWT_AUDIENCE!,
+    expiresIn: "5m",
+  });
+}
+
+const adminAuth = { Authorization: `Bearer ${token("admin")}` };
+const userAuth = { Authorization: `Bearer ${token()}` };
+
+function buildHarness(send: HttpSender = async () => ({ status: 200 })) {
+  const store = new InMemoryWebhookStore();
+  const dispatcher = new WebhookDispatcher({
+    store,
+    send,
+    signingSecret: SIGNING_SECRET,
+    backoffMs: () => 0,
+  });
+  const app = express();
+  app.use(express.json());
+  app.use(
+    (
+      req: express.Request,
+      _res: express.Response,
+      next: express.NextFunction,
+    ) => {
+      const requestId = uuidv4();
+      (req as { id?: string }).id = requestId;
+      requestContextStorage.run({ requestId }, next);
+    },
+  );
+  app.use("/api/webhooks", createWebhooksRouter({ store }));
+  app.use(
+    "/api/admin/webhooks",
+    createAdminWebhooksRouter({ store, dispatcher }),
+  );
+  app.use(errorHandler);
+  return { app, store, dispatcher };
+}
+
+async function seedDeliveries(dispatcher: WebhookDispatcher, n: number) {
+  for (let i = 0; i < n; i++) {
+    await dispatcher.enqueue({
+      eventId: `evt_${i}`,
+      eventType: "market.resolved",
+      targetUrl: "https://example.test/hook",
+      payload: Buffer.from(`body-${i}`),
+      maxAttempts: 3,
+    });
+  }
+}
+
+/**
+ * Read the current value (.value) for a given label set from the counter's
+ * internal hashMap.
+ */
+function counterValue(
+  counter: typeof webhooksEndpointRequestsTotal,
+  labels: Record<string, string>,
+): number {
+  const key = Object.keys(labels)
+    .sort()
+    .map((k) => `${k}:${labels[k]}`)
+    .join(",") + ",";
+  const entry = counter.hashMap[key] as { value: number } | undefined;
+  return entry?.value ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("Per-endpoint metrics on /api/webhooks", () => {
+  describe("GET /api/webhooks", () => {
+    it("increments counter with method, route, and status labels on 200", async () => {
+      const { app, dispatcher } = buildHarness();
+      await seedDeliveries(dispatcher, 2);
+
+      const before = counterValue(webhooksEndpointRequestsTotal, {
+        method: "GET",
+        route: "/",
+        status: "200",
+      });
+
+      await request(app).get("/api/webhooks?limit=10").set(adminAuth);
+
+      const after = counterValue(webhooksEndpointRequestsTotal, {
+        method: "GET",
+        route: "/",
+        status: "200",
+      });
+      expect(after).toBe(before + 1);
+    });
+
+    it("observes duration in histogram on 200", async () => {
+      const { app, dispatcher } = buildHarness();
+      await seedDeliveries(dispatcher, 1);
+
+      const res = await request(app).get("/api/webhooks").set(adminAuth);
+
+      expect(res.status).toBe(200);
+      const metrics = await webhooksEndpointDuration.get();
+      const routeMetric = metrics.values.find(
+        (v) => v.labels.route === "/" && v.labels.method === "GET",
+      );
+      expect(routeMetric).toBeDefined();
+    });
+
+    it("records status=403 for unauthenticated requests", async () => {
+      const { app } = buildHarness();
+
+      const before = counterValue(webhooksEndpointRequestsTotal, {
+        method: "GET",
+        route: "/",
+        status: "403",
+      });
+
+      await request(app).get("/api/webhooks");
+
+      const after = counterValue(webhooksEndpointRequestsTotal, {
+        method: "GET",
+        route: "/",
+        status: "403",
+      });
+      expect(after).toBe(before + 1);
+    });
+
+    it("records status=403 for non-admin token", async () => {
+      const { app } = buildHarness();
+
+      const before = counterValue(webhooksEndpointRequestsTotal, {
+        method: "GET",
+        route: "/",
+        status: "403",
+      });
+
+      await request(app).get("/api/webhooks").set(userAuth);
+
+      const after = counterValue(webhooksEndpointRequestsTotal, {
+        method: "GET",
+        route: "/",
+        status: "403",
+      });
+      expect(after).toBe(before + 1);
+    });
+
+    it("records status=400 for invalid query params", async () => {
+      const { app } = buildHarness();
+
+      const before = counterValue(webhooksEndpointRequestsTotal, {
+        method: "GET",
+        route: "/",
+        status: "400",
+      });
+
+      await request(app).get("/api/webhooks?limit=abc").set(adminAuth);
+
+      const after = counterValue(webhooksEndpointRequestsTotal, {
+        method: "GET",
+        route: "/",
+        status: "400",
+      });
+      expect(after).toBe(before + 1);
+    });
+  });
+
+  // ── GET /api/admin/webhooks/dlq ─────────────────────────────────────
+
+  describe("GET /api/admin/webhooks/dlq", () => {
+    it("increments counter on 200", async () => {
+      const { app } = buildHarness();
+
+      const before = counterValue(webhooksEndpointRequestsTotal, {
+        method: "GET",
+        route: "/dlq",
+        status: "200",
+      });
+
+      await request(app).get("/api/admin/webhooks/dlq").set(adminAuth);
+
+      const after = counterValue(webhooksEndpointRequestsTotal, {
+        method: "GET",
+        route: "/dlq",
+        status: "200",
+      });
+      expect(after).toBe(before + 1);
+    });
+
+    it("observes duration in histogram", async () => {
+      const { app } = buildHarness();
+
+      const res = await request(app).get("/api/admin/webhooks/dlq").set(adminAuth);
+
+      expect(res.status).toBe(200);
+      const metrics = await webhooksEndpointDuration.get();
+      const routeMetric = metrics.values.find(
+        (v) => v.labels.route === "/dlq" && v.labels.method === "GET",
+      );
+      expect(routeMetric).toBeDefined();
+    });
+
+    it("records status=403 for unauthenticated requests", async () => {
+      const { app } = buildHarness();
+
+      const before = counterValue(webhooksEndpointRequestsTotal, {
+        method: "GET",
+        route: "/dlq",
+        status: "403",
+      });
+
+      await request(app).get("/api/admin/webhooks/dlq");
+
+      const after = counterValue(webhooksEndpointRequestsTotal, {
+        method: "GET",
+        route: "/dlq",
+        status: "403",
+      });
+      expect(after).toBe(before + 1);
+    });
+  });
+
+  // ── POST /api/admin/webhooks/dlq/:id/replay ─────────────────────────
+
+  describe("POST /api/admin/webhooks/dlq/:id/replay", () => {
+    it("increments counter on 404 (not found)", async () => {
+      const { app } = buildHarness();
+
+      const before = counterValue(webhooksEndpointRequestsTotal, {
+        method: "POST",
+        route: "/dlq/:id/replay",
+        status: "404",
+      });
+
+      await request(app)
+        .post(
+          "/api/admin/webhooks/dlq/550e8400-e29b-41d4-a716-446655440000/replay",
+        )
+        .set(adminAuth)
+        .send();
+
+      const after = counterValue(webhooksEndpointRequestsTotal, {
+        method: "POST",
+        route: "/dlq/:id/replay",
+        status: "404",
+      });
+      expect(after).toBe(before + 1);
+    });
+
+    it("records status=403 for unauthenticated requests", async () => {
+      const { app } = buildHarness();
+
+      const before = counterValue(webhooksEndpointRequestsTotal, {
+        method: "POST",
+        route: "/dlq/:id/replay",
+        status: "403",
+      });
+
+      await request(app)
+        .post(
+          "/api/admin/webhooks/dlq/550e8400-e29b-41d4-a716-446655440000/replay",
+        )
+        .send();
+
+      const after = counterValue(webhooksEndpointRequestsTotal, {
+        method: "POST",
+        route: "/dlq/:id/replay",
+        status: "403",
+      });
+      expect(after).toBe(before + 1);
+    });
+
+    it("observes duration in histogram", async () => {
+      const { app } = buildHarness();
+
+      const res = await request(app)
+        .post(
+          "/api/admin/webhooks/dlq/550e8400-e29b-41d4-a716-446655440000/replay",
+        )
+        .set(adminAuth)
+        .send();
+
+      expect(res.status).toBe(404);
+      const metrics = await webhooksEndpointDuration.get();
+      const routeMetric = metrics.values.find(
+        (v) =>
+          v.labels.route === "/dlq/:id/replay" && v.labels.method === "POST",
+      );
+      expect(routeMetric).toBeDefined();
+    });
+  });
+
+  // ── Label structure ──────────────────────────────────────────────────
+
+  describe("histogram label structure", () => {
+    it("includes method, route, and status labels", async () => {
+      const { app, dispatcher } = buildHarness();
+      await seedDeliveries(dispatcher, 1);
+
+      await request(app).get("/api/webhooks").set(adminAuth);
+
+      const metrics = await webhooksEndpointDuration.get();
+      const hookMetric = metrics.values.find(
+        (v) => v.labels.route === "/",
+      );
+      expect(hookMetric).toBeDefined();
+      expect(hookMetric!.labels).toHaveProperty("method", "GET");
+      expect(hookMetric!.labels).toHaveProperty("status", "200");
+    });
+  });
+
+  describe("counter label structure", () => {
+    it("includes method, route, and status labels", async () => {
+      const { app, dispatcher } = buildHarness();
+      await seedDeliveries(dispatcher, 1);
+
+      await request(app).get("/api/webhooks").set(adminAuth);
+
+      const metrics = await webhooksEndpointRequestsTotal.get();
+      const hookMetric = metrics.values.find(
+        (v) => v.labels.route === "/",
+      );
+      expect(hookMetric).toBeDefined();
+      expect(hookMetric!.labels).toHaveProperty("method", "GET");
+      expect(hookMetric!.labels).toHaveProperty("status", "200");
+      expect(hookMetric!.value).toBeGreaterThanOrEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
# feat: metrics on /api/webhooks

## Summary

Adds Prometheus histogram and counter metrics for all `/api/webhooks` endpoints, following the established `usersMetrics.ts` pattern from `/api/users`.

## Changes

### New file: `src/metrics/webhooksMetrics.ts`

Express middleware that tracks per-request metrics using `process.hrtime.bigint()` and `res.on("finish", ...)`:

- **`webhooksEndpointRequestsTotal`** (Counter) — incremented on every response finish with labels `{method, route, status}`
- **`webhooksEndpointDuration`** (Histogram) — observed on every response finish with the same labels

Route sanitization collapses UUIDs and numeric IDs to `/:id` for label cardinality control.

### Modified: `src/metrics/registry.ts`

Added two new metrics:

```typescript
webhooks_endpoint_requests_total{method, route, status}  // Counter
webhooks_endpoint_duration_seconds{method, route, status} // Histogram
```

Buckets: `[0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10]` (same as all existing histograms).

### Modified: `src/routes/webhooks.ts` and `src/routes/adminWebhooks.ts`

Wired `webhooksMetricsMiddleware` before `requireAdmin` so it captures **all** responses including auth failures (403), validation errors (400), and successful responses (200).

## Endpoints Covered

| Method | Route | Status Codes Tracked |
|--------|-------|---------------------|
| GET | `/api/webhooks` | 200, 400, 403 |
| GET | `/api/admin/webhooks/dlq` | 200, 403 |
| POST | `/api/admin/webhooks/dlq/:id/replay` | 202, 400, 403, 404, 409 |

## Tests

### New file: `tests/webhooksMetrics.test.ts`

**13 tests**, all passing:

**GET /api/webhooks (5 tests):**
- Counter increments with method/route/status labels on 200
- Histogram observes duration on 200
- Records status=403 for unauthenticated requests
- Records status=403 for non-admin token
- Records status=400 for invalid query params

**GET /api/admin/webhooks/dlq (3 tests):**
- Counter increments on 200
- Histogram observes duration
- Records status=403 for unauthenticated

**POST /api/admin/webhooks/dlq/:id/replay (3 tests):**
- Counter increments on 404 (not found)
- Records status=403 for unauthenticated
- Histogram observes duration

**Label structure (2 tests):**
- Histogram includes method, route, and status labels
- Counter includes method, route, and status labels

## Design Decisions

- **Middleware placement**: `webhooksMetricsMiddleware` is placed **before** `requireAdmin` so it captures all responses including auth failures — matching the `usersMetricsMiddleware` pattern in `users.ts`
- **Labels**: `method`, `route`, `status` — identical to the `/api/users` metrics for consistency
- **Route sanitization**: UUIDs and numeric IDs collapsed to `/:id` to prevent label cardinality explosion
- **Measurement**: `process.hrtime.bigint()` for nanosecond precision, same as existing metrics

## Files Changed

| File | Action | Lines changed |
|------|--------|--------------|
| `src/metrics/registry.ts` | Modified | +15 |
| `src/metrics/webhooksMetrics.ts` | Added | +28 |
| `src/routes/webhooks.ts` | Modified | +2 |
| `src/routes/adminWebhooks.ts` | Modified | +2 |
| `tests/webhooksMetrics.test.ts` | Added | +357 |

## Checklist

- [x] Implementation matches the description
- [x] Tests added and passing (13/13)
- [x] ESLint clean
- [x] Follows repo conventions (same pattern as usersMetrics)
- [x] Labels: method, route, status
- [x] Histogram buckets match existing histograms

Closes #434
