### PR TITLE
feat: /api/webhooks/health endpoint (v7)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { sessionsRouter } from "./routes/me/sessions";
 import { notificationsRouter } from "./routes/notifications";
 import { socialRouter } from "./routes/social";
 import { webhooksRouter } from "./routes/webhooks";
+import { webhooksHealthRouter } from "./routes/webhooks/health";
 import { adminAuditRouter } from "./routes/admin/audit";
 import { adminAuditExportRouter } from "./routes/admin/audit/export";
 import { adminMarketsRouter } from "./routes/admin/markets";
@@ -136,6 +137,7 @@ export function createApp(_options: CreateAppOptions = {}): express.Express {
   app.use("/api/quota/requests", quotaRequestsRouter);
   app.use("/api/notifications", notificationsRouter);
   app.use("/api/webhooks", webhooksRouter);
+  app.use("/api/webhooks/health", webhooksHealthRouter);
   app.use("/api/users/health", usersHealthRouter);
   app.use("/api/users", socialRouter);
   app.use("/api/users", userPortfolioRouter);

--- a/src/routes/webhooks/health.ts
+++ b/src/routes/webhooks/health.ts
@@ -1,0 +1,191 @@
+/**
+ * webhooks/health.ts
+ *
+ * GET /api/webhooks/health
+ *
+ * Focused health probe for the webhook delivery subsystem. Checks the two
+ * runtime dependencies that the webhook pipeline relies on:
+ *   1. database — Postgres (SELECT 1), where deliveries & subscriptions live
+ *   2. queue    — Redis / BullMQ (PING), used by the webhook worker
+ *
+ * This complements the existing broader probes:
+ *   • GET /health                  — process liveness (no I/O)
+ *   • GET /healthz/dependencies    — shallow cached probe (5 s TTL)
+ *   • GET /api/health/ready        — deep readiness for orchestrators
+ *   • GET /api/health/dependencies — uncached full dependency snapshot
+ *   • GET /api/webhooks/health     — this file; webhook-subsystem focused
+ *
+ * Response codes
+ * ──────────────
+ *   200 OK           — both probes pass ("ok")
+ *   503 Unavailable  — at least one probe fails ("down")
+ *
+ * Response shape
+ * ──────────────
+ * {
+ *   "status":        "ok" | "down",
+ *   "correlationId": "<uuid>",
+ *   "checkedAt":     "<ISO-8601>",
+ *   "dependencies": {
+ *     "database": { "status": "ok"|"down", "latencyMs": <n>, "error?": "…" },
+ *     "queue":    { "status": "ok"|"down", "latencyMs": <n>, "error?": "…" }
+ *   }
+ * }
+ *
+ * Security
+ * ────────
+ * No authentication required — the response contains no sensitive data.
+ * In production, restrict access at the infrastructure level (internal ALB,
+ * VPC-only routing, etc.).
+ *
+ * The response is NOT cached. Callers that want caching should add a cache
+ * layer in front of this endpoint.
+ *
+ * Injectable dependencies
+ * ───────────────────────
+ * All external I/O is encapsulated in the `WebhooksHealthRouterDeps` callbacks
+ * so tests can substitute fully-controlled stubs without touching real
+ * infrastructure.
+ */
+
+import { Router, Request, Response } from "express";
+import { randomUUID } from "crypto";
+import { logger } from "../../config/logger";
+import { pool } from "../../db/client";
+import { redisConnection } from "../../queue";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type WebhookProbeStatus = "ok" | "down";
+
+export interface WebhookProbeResult {
+  status: WebhookProbeStatus;
+  latencyMs: number;
+  error?: string;
+}
+
+export interface WebhookDependencyHealth {
+  database: WebhookProbeResult;
+  queue: WebhookProbeResult;
+}
+
+export type WebhookCompositeStatus = "ok" | "down";
+
+// ── Injectable dependency interface ──────────────────────────────────────────
+
+export type ProbeDatabaseFn = () => Promise<WebhookProbeResult>;
+export type ProbeQueueFn = () => Promise<WebhookProbeResult>;
+
+export interface WebhooksHealthRouterDeps {
+  probeDatabase?: ProbeDatabaseFn;
+  probeQueue?: ProbeQueueFn;
+}
+
+// ── Default probes ───────────────────────────────────────────────────────────
+
+async function defaultProbeDatabase(): Promise<WebhookProbeResult> {
+  const start = Date.now();
+  try {
+    await pool.query("SELECT 1");
+    return { status: "ok", latencyMs: Date.now() - start };
+  } catch {
+    return {
+      status: "down",
+      latencyMs: Date.now() - start,
+      error: "Database unavailable",
+    };
+  }
+}
+
+async function defaultProbeQueue(): Promise<WebhookProbeResult> {
+  const start = Date.now();
+  try {
+    await redisConnection.ping();
+    return { status: "ok", latencyMs: Date.now() - start };
+  } catch {
+    return {
+      status: "down",
+      latencyMs: Date.now() - start,
+      error: "Webhook queue unavailable",
+    };
+  }
+}
+
+// ── Composite status ─────────────────────────────────────────────────────────
+
+function computeCompositeStatus(health: WebhookDependencyHealth): WebhookCompositeStatus {
+  if (health.database.status === "ok" && health.queue.status === "ok") return "ok";
+  return "down";
+}
+
+function compositeToHttpStatus(composite: WebhookCompositeStatus): number {
+  return composite === "ok" ? 200 : 503;
+}
+
+// ── Router factory ───────────────────────────────────────────────────────────
+
+/**
+ * Creates the /api/webhooks/health router with injected dependencies.
+ *
+ * @param deps - Override probe functions for testing. Defaults to production
+ *               implementations that hit real Postgres and Redis.
+ */
+export function createWebhooksHealthRouter(
+  deps: WebhooksHealthRouterDeps = {},
+): Router {
+  const probeDb: ProbeDatabaseFn = deps.probeDatabase ?? defaultProbeDatabase;
+  const probeQ: ProbeQueueFn = deps.probeQueue ?? defaultProbeQueue;
+  const router = Router();
+
+  /**
+   * GET /
+   *
+   * Runs both webhook-subsystem probes and returns the health snapshot.
+   */
+  router.get("/", async (req: Request, res: Response, next) => {
+    const correlationId =
+      ((req.headers["x-correlation-id"] as string | undefined) ?? "").trim() ||
+      randomUUID();
+
+    const requestStart = Date.now();
+
+    try {
+      const [database, queue] = await Promise.all([probeDb(), probeQ()]);
+      const health: WebhookDependencyHealth = { database, queue };
+      const composite = computeCompositeStatus(health);
+      const httpStatus = compositeToHttpStatus(composite);
+
+      logger.info(
+        {
+          correlationId,
+          status: composite,
+          httpStatus,
+          elapsedMs: Date.now() - requestStart,
+          database: database.status,
+          queue: queue.status,
+        },
+        "webhooks_health_check_complete",
+      );
+
+      res.status(httpStatus).json({
+        status: composite,
+        correlationId,
+        checkedAt: new Date().toISOString(),
+        dependencies: health,
+      });
+    } catch (err) {
+      logger.error(
+        { correlationId, err, elapsedMs: Date.now() - requestStart },
+        "webhooks_health_probe_threw",
+      );
+      next(err);
+    }
+  });
+
+  return router;
+}
+
+// ── Default export ───────────────────────────────────────────────────────────
+
+/** Production router instance wired into src/index.ts. */
+export const webhooksHealthRouter = createWebhooksHealthRouter();

--- a/tests/webhooksHealth.test.ts
+++ b/tests/webhooksHealth.test.ts
@@ -1,0 +1,488 @@
+/**
+ * webhooksHealth.test.ts
+ *
+ * Tests for GET /api/webhooks/health.
+ *
+ * Strategy
+ * ────────
+ * • The injectable `probeDatabase` and `probeQueue` functions replace all
+ *   external I/O — no real DB or Redis connections are made.
+ * • The router is mounted on a minimal Express app so tests are isolated
+ *   from the full application bootstrap.
+ * • The errorHandler is attached so unexpected-throw tests validate the
+ *   standard error envelope format.
+ *
+ * Coverage
+ * ────────
+ * • 200 both probes ok
+ * • 503 database down, queue ok
+ * • 503 database ok, queue down
+ * • 503 both probes down
+ * • Response shape: status, correlationId, checkedAt, dependencies
+ * • Per-dependency latency and error fields
+ * • correlationId: echo from header / UUID generation fallback
+ * • No authentication required
+ * • Probe errors propagate as 500 via errorHandler
+ * • Default probe functions are wired when no deps provided
+ * • Structured log emitted on each request
+ */
+
+// ── Env stubs (must precede all src/ imports) ─────────────────────────────────
+
+process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
+process.env.JWT_SECRET = "abcdefghijklmnopqrstuvwxyz123456789012";
+process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "test-contract-id";
+process.env.REDIS_URL = "redis://localhost:6379";
+
+// ── Module mocks (must precede dynamic imports) ───────────────────────────────
+
+jest.mock("../src/db/client", () => ({
+  db: {},
+  pool: { query: jest.fn() },
+  connectWithRetry: jest.fn(),
+  closeDb: jest.fn(),
+  getDb: jest.fn(),
+  getPool: jest.fn(),
+  setDbForTests: jest.fn(),
+}));
+
+jest.mock("../src/queue", () => ({
+  redisConnection: { ping: jest.fn().mockResolvedValue("PONG") },
+  webhookQueue: { add: jest.fn() },
+  backupVerificationQueue: { add: jest.fn() },
+  reconciliationQueue: { add: jest.fn() },
+  marketResolutionQueue: { add: jest.fn() },
+  webhookQueueName: "webhook-deliveries",
+  backupVerificationQueueName: "backup-verification",
+  reconciliationQueueName: "reconciliation",
+  marketResolutionQueueName: "market-resolution",
+}));
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import request from "supertest";
+import express from "express";
+import { createWebhooksHealthRouter } from "../src/routes/webhooks/health";
+import { errorHandler } from "../src/middleware/errorHandler";
+import type { WebhookDependencyHealth } from "../src/routes/webhooks/health";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const ALL_OK: WebhookDependencyHealth = {
+  database: { status: "ok", latencyMs: 2 },
+  queue: { status: "ok", latencyMs: 1 },
+};
+
+const DB_DOWN: WebhookDependencyHealth = {
+  database: { status: "down", latencyMs: 100, error: "Database unavailable" },
+  queue: { status: "ok", latencyMs: 1 },
+};
+
+const QUEUE_DOWN: WebhookDependencyHealth = {
+  database: { status: "ok", latencyMs: 2 },
+  queue: { status: "down", latencyMs: 50, error: "Webhook queue unavailable" },
+};
+
+const BOTH_DOWN: WebhookDependencyHealth = {
+  database: { status: "down", latencyMs: 100, error: "Database unavailable" },
+  queue: { status: "down", latencyMs: 50, error: "Webhook queue unavailable" },
+};
+
+// ── App factory ───────────────────────────────────────────────────────────────
+
+function makeApp(deps: {
+  probeDatabase?: () => Promise<WebhookDependencyHealth["database"]>;
+  probeQueue?: () => Promise<WebhookDependencyHealth["queue"]>;
+} = {}): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    "/api/webhooks/health",
+    createWebhooksHealthRouter(deps),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+const URL = "/api/webhooks/health";
+
+// ═════════════════════════════════════════════════════════════════════════════
+// HTTP status codes
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("HTTP status codes", () => {
+  it("returns 200 when both probes pass", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(ALL_OK.database),
+        probeQueue: () => Promise.resolve(ALL_OK.queue),
+      }),
+    ).get(URL);
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 503 when database is down", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(DB_DOWN.database),
+        probeQueue: () => Promise.resolve(DB_DOWN.queue),
+      }),
+    ).get(URL);
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 503 when queue is down", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(QUEUE_DOWN.database),
+        probeQueue: () => Promise.resolve(QUEUE_DOWN.queue),
+      }),
+    ).get(URL);
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 503 when both probes are down", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(BOTH_DOWN.database),
+        probeQueue: () => Promise.resolve(BOTH_DOWN.queue),
+      }),
+    ).get(URL);
+    expect(res.status).toBe(503);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Response body — composite status field
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("response body — status field", () => {
+  it("body.status is 'ok' when both probes pass", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(ALL_OK.database),
+        probeQueue: () => Promise.resolve(ALL_OK.queue),
+      }),
+    ).get(URL);
+    expect(res.body.status).toBe("ok");
+  });
+
+  it("body.status is 'down' when database is down", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(DB_DOWN.database),
+        probeQueue: () => Promise.resolve(DB_DOWN.queue),
+      }),
+    ).get(URL);
+    expect(res.body.status).toBe("down");
+  });
+
+  it("body.status is 'down' when queue is down", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(QUEUE_DOWN.database),
+        probeQueue: () => Promise.resolve(QUEUE_DOWN.queue),
+      }),
+    ).get(URL);
+    expect(res.body.status).toBe("down");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Response shape
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("response shape", () => {
+  it("includes all required top-level fields", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(ALL_OK.database),
+        probeQueue: () => Promise.resolve(ALL_OK.queue),
+      }),
+    ).get(URL);
+    expect(res.body).toHaveProperty("status");
+    expect(res.body).toHaveProperty("correlationId");
+    expect(res.body).toHaveProperty("checkedAt");
+    expect(res.body).toHaveProperty("dependencies");
+  });
+
+  it("dependencies contains database and queue", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(ALL_OK.database),
+        probeQueue: () => Promise.resolve(ALL_OK.queue),
+      }),
+    ).get(URL);
+    expect(res.body.dependencies).toHaveProperty("database");
+    expect(res.body.dependencies).toHaveProperty("queue");
+  });
+
+  it("each dependency entry contains status and latencyMs", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(ALL_OK.database),
+        probeQueue: () => Promise.resolve(ALL_OK.queue),
+      }),
+    ).get(URL);
+    for (const key of ["database", "queue"]) {
+      expect(res.body.dependencies[key]).toHaveProperty("status");
+      expect(res.body.dependencies[key]).toHaveProperty("latencyMs");
+    }
+  });
+
+  it("checkedAt is a valid ISO-8601 timestamp", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(ALL_OK.database),
+        probeQueue: () => Promise.resolve(ALL_OK.queue),
+      }),
+    ).get(URL);
+    expect(typeof res.body.checkedAt).toBe("string");
+    expect(() => new Date(res.body.checkedAt)).not.toThrow();
+    expect(new Date(res.body.checkedAt).getTime()).toBeGreaterThan(0);
+  });
+
+  it("includes per-dependency latency values from the probe", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(ALL_OK.database),
+        probeQueue: () => Promise.resolve(ALL_OK.queue),
+      }),
+    ).get(URL);
+    expect(res.body.dependencies.database.latencyMs).toBe(2);
+    expect(res.body.dependencies.queue.latencyMs).toBe(1);
+  });
+
+  it("includes error field when a probe is down", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(DB_DOWN.database),
+        probeQueue: () => Promise.resolve(DB_DOWN.queue),
+      }),
+    ).get(URL);
+    expect(res.body.dependencies.database.error).toBe("Database unavailable");
+  });
+
+  it("does not expose error field when probe is ok", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(ALL_OK.database),
+        probeQueue: () => Promise.resolve(ALL_OK.queue),
+      }),
+    ).get(URL);
+    expect(res.body.dependencies.database).not.toHaveProperty("error");
+    expect(res.body.dependencies.queue).not.toHaveProperty("error");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Correlation ID
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("correlationId", () => {
+  it("echoes the x-correlation-id header when provided", async () => {
+    const id = "webhooks-health-trace-123";
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(ALL_OK.database),
+        probeQueue: () => Promise.resolve(ALL_OK.queue),
+      }),
+    )
+      .get(URL)
+      .set("x-correlation-id", id);
+    expect(res.body.correlationId).toBe(id);
+  });
+
+  it("generates a UUID when x-correlation-id is not provided", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(ALL_OK.database),
+        probeQueue: () => Promise.resolve(ALL_OK.queue),
+      }),
+    ).get(URL);
+    expect(res.body.correlationId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it("generates a UUID when x-correlation-id is an empty string", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(ALL_OK.database),
+        probeQueue: () => Promise.resolve(ALL_OK.queue),
+      }),
+    )
+      .get(URL)
+      .set("x-correlation-id", "");
+    expect(res.body.correlationId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it("correlationId differs between requests when not supplied", async () => {
+    const app = makeApp({
+      probeDatabase: () => Promise.resolve(ALL_OK.database),
+      probeQueue: () => Promise.resolve(ALL_OK.queue),
+    });
+    const [r1, r2] = await Promise.all([
+      request(app).get(URL),
+      request(app).get(URL),
+    ]);
+    expect(r1.body.correlationId).not.toBe(r2.body.correlationId);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Auth / access control
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("authentication", () => {
+  it("does not require an Authorization header", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(ALL_OK.database),
+        probeQueue: () => Promise.resolve(ALL_OK.queue),
+      }),
+    ).get(URL);
+    expect(res.status).toBe(200);
+  });
+
+  it("ignores a supplied Authorization header", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(ALL_OK.database),
+        probeQueue: () => Promise.resolve(ALL_OK.queue),
+      }),
+    )
+      .get(URL)
+      .set("Authorization", "Bearer some-random-token");
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("ok");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Error handling
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("error handling", () => {
+  it("returns 500 and propagates to errorHandler when probeDatabase throws", async () => {
+    const throwing = () => Promise.reject(new Error("database exploded"));
+    const res = await request(
+      makeApp({
+        probeDatabase: throwing,
+        probeQueue: () => Promise.resolve(ALL_OK.queue),
+      }),
+    ).get(URL);
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 500 and propagates to errorHandler when probeQueue throws", async () => {
+    const throwing = () => Promise.reject(new Error("queue exploded"));
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(ALL_OK.database),
+        probeQueue: throwing,
+      }),
+    ).get(URL);
+    expect(res.status).toBe(500);
+  });
+
+  it("calls probeDatabase and probeQueue exactly once per request", async () => {
+    const probeDatabase = jest.fn().mockResolvedValue(ALL_OK.database);
+    const probeQueue = jest.fn().mockResolvedValue(ALL_OK.queue);
+    await request(makeApp({ probeDatabase, probeQueue })).get(URL);
+    expect(probeDatabase).toHaveBeenCalledTimes(1);
+    expect(probeQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs both probes in parallel (not sequentially)", async () => {
+    const order: string[] = [];
+    const probeDatabase = jest.fn().mockImplementation(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      order.push("database");
+      return ALL_OK.database;
+    });
+    const probeQueue = jest.fn().mockImplementation(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      order.push("queue");
+      return ALL_OK.queue;
+    });
+    await request(makeApp({ probeDatabase, probeQueue })).get(URL);
+    // Both should have been called
+    expect(probeDatabase).toHaveBeenCalledTimes(1);
+    expect(probeQueue).toHaveBeenCalledTimes(1);
+    // Order may vary, but both should complete (parallel execution)
+    expect(order).toHaveLength(2);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Default router export
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("default router", () => {
+  it("exports a default webhooksHealthRouter as a valid Express router", async () => {
+    const { webhooksHealthRouter } = await import("../src/routes/webhooks/health");
+    expect(typeof webhooksHealthRouter).toBe("function");
+    expect(
+      Array.isArray(
+        (webhooksHealthRouter as unknown as { stack: unknown[] }).stack,
+      ),
+    ).toBe(true);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Edge cases
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("edge cases", () => {
+  it("handles database returning error field with message", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () =>
+          Promise.resolve({
+            status: "down" as const,
+            latencyMs: 200,
+            error: "Connection refused",
+          }),
+        probeQueue: () => Promise.resolve(ALL_OK.queue),
+      }),
+    ).get(URL);
+    expect(res.body.dependencies.database.error).toBe("Connection refused");
+    expect(res.body.status).toBe("down");
+  });
+
+  it("handles queue returning error field with message", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () => Promise.resolve(ALL_OK.database),
+        probeQueue: () =>
+          Promise.resolve({
+            status: "down" as const,
+            latencyMs: 100,
+            error: "Redis connection timeout",
+          }),
+      }),
+    ).get(URL);
+    expect(res.body.dependencies.queue.error).toBe("Redis connection timeout");
+    expect(res.body.status).toBe("down");
+  });
+
+  it("returns 200 with zero latency values", async () => {
+    const res = await request(
+      makeApp({
+        probeDatabase: () =>
+          Promise.resolve({ status: "ok" as const, latencyMs: 0 }),
+        probeQueue: () =>
+          Promise.resolve({ status: "ok" as const, latencyMs: 0 }),
+      }),
+    ).get(URL);
+    expect(res.status).toBe(200);
+    expect(res.body.dependencies.database.latencyMs).toBe(0);
+    expect(res.body.dependencies.queue.latencyMs).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #435

---

# feat: `/api/webhooks/health` endpoint (v7)

## Summary

Add a focused health probe endpoint for the webhook delivery subsystem at `GET /api/webhooks/health`.

## Motivation

The webhook delivery pipeline depends on two critical runtime dependencies: **Postgres** (where deliveries and subscriptions are stored) and **Redis/BullMQ** (the queue used by the webhook worker). While the existing `/api/health/dependencies` probe covers all four system-wide dependencies, operators need a **narrow, webhook-specific** health check that isolates just the webhook subsystem's dependencies for targeted alerting and load-balancer routing.

## Implementation

### New file: `src/routes/webhooks/health.ts`

- **Route:** `GET /api/webhooks/health`
- **Pattern:** Factory function `createWebhooksHealthRouter(deps)` with injectable probe functions for full testability
- **Dependencies probed:**
  1. `database` — Postgres via `pool.query("SELECT 1")`
  2. `queue` — Redis via `redisConnection.ping()`
- **Composite status:** `"ok"` when both pass, `"down"` when either fails
- **HTTP status:** `200` when ok, `503` when down
- **Correlation ID:** Accepts `x-correlation-id` header; generates UUID v4 if absent/empty
- **Logging:** Structured pino logs with correlation ID, status, per-dependency status, and elapsed time
- **Error handling:** Unexpected errors propagate to the global `errorHandler` middleware (returns 500)
- **No caching:** Fresh probe on every call (unlike `/healthz/dependencies` which caches for 5s)
- **No auth:** Returns no sensitive data; restrict at infrastructure level in production

### Modified file: `src/index.ts`

- Import `webhooksHealthRouter` from `./routes/webhooks/health`
- Mount at `app.use("/api/webhooks/health", webhooksHealthRouter)` (after `/api/webhooks`, before `/api/users/health`)

### Response shape

```json
{
  "status": "ok",
  "correlationId": "550e8400-e29b-41d4-a716-446655440000",
  "checkedAt": "2026-07-26T12:00:00.000Z",
  "dependencies": {
    "database": {
      "status": "ok",
      "latencyMs": 2
    },
    "queue": {
      "status": "ok",
      "latencyMs": 1
    }
  }
}
```

When a dependency is down:

```json
{
  "status": "down",
  "correlationId": "...",
  "checkedAt": "...",
  "dependencies": {
    "database": {
      "status": "down",
      "latencyMs": 100,
      "error": "Database unavailable"
    },
    "queue": {
      "status": "ok",
      "latencyMs": 1
    }
  }
}
```

## Tests

### New file: `tests/webhooksHealth.test.ts` — 28 tests, all passing

| Category | Tests | Coverage |
|---|---|---|
| HTTP status codes | 4 | 200 all-ok, 503 db-down, 503 queue-down, 503 both-down |
| Response body — status field | 3 | Composite status mapping verification |
| Response shape | 7 | Top-level fields, dependency entries, latencies, error fields |
| Correlation ID | 4 | Header echo, UUID fallback, empty string, uniqueness |
| Authentication | 2 | No auth required, ignores Authorization header |
| Error handling | 4 | Probe throws → 500, call count verification, parallel execution |
| Default router | 1 | Export validation |
| Edge cases | 3 | Error messages, zero latency |

**Test strategy:** Injectable probe functions replace all external I/O. No real Postgres or Redis connections. Router mounted on minimal Express app with `errorHandler`.

## Existing test regression check

Ran `healthDependencies.test.ts` and `health.test.ts` — both pass with no changes. The `healthReady.test.ts` failure (Redis connection refused) is pre-existing and unrelated.

## Checklist

- [x] Implementation matches the description
- [x] Tests added and passing (28/28)
- [x] Lint passing (eslint, no errors)
- [x] Input validation at boundary (correlation ID handling)
- [x] Structured logging with correlation IDs
- [x] No sensitive data exposed
- [x] Injectable dependencies for testability
- [x] Documentation and inline comments
- [x] No breaking changes to existing routes
