### PR TITLE
feat(disputes): compress large responses (gzip/deflate)

### DIFF
--- a/src/middleware/compression.ts
+++ b/src/middleware/compression.ts
@@ -1,0 +1,188 @@
+/**
+ * @module compression
+ *
+ * Provides gzip/deflate response compression for Express routes.
+ *
+ * ## Overview
+ *
+ * `compressResponse` is an Express middleware that compresses outgoing JSON
+ * responses when:
+ *
+ * 1. The client advertises `gzip` or `deflate` in its `Accept-Encoding` header.
+ * 2. The serialised response body meets or exceeds `COMPRESSION_THRESHOLD`
+ *    (default: 1 KiB).
+ *
+ * Small responses below the threshold are sent uncompressed to avoid the CPU
+ * overhead of compressing tiny payloads.
+ *
+ * ## Encoding preference
+ *
+ * `gzip` is preferred over `deflate` because it is more widely supported and
+ * adds a CRC32 checksum for data-integrity verification.  `identity` (no
+ * compression) is always accepted as a fallback.
+ *
+ * ## How it works
+ *
+ * The middleware intercepts `res.json()` before the body is written to the
+ * socket.  It serialises the payload, decides whether to compress, and writes
+ * the appropriate `Content-Encoding`, `Content-Length`, and `Vary` headers
+ * before flushing the bytes.
+ *
+ * ## Usage
+ *
+ * ```ts
+ * import { compressResponse } from "../middleware/compression";
+ *
+ * // Apply to a specific router
+ * router.use(compressResponse);
+ *
+ * // Or apply to a single route
+ * router.post("/", compressResponse, myHandler);
+ * ```
+ */
+
+import zlib from "zlib";
+import type { Request, Response, NextFunction, RequestHandler } from "express";
+import { logger } from "../config/logger";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimum serialised response size (in bytes) required before compression is
+ * applied.  Responses smaller than this threshold are sent as-is to avoid
+ * wasting CPU on negligible savings.
+ *
+ * Default: 1024 bytes (1 KiB).
+ */
+export const COMPRESSION_THRESHOLD = 1024;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Encoding = "gzip" | "deflate" | "identity";
+
+/**
+ * Parses the `Accept-Encoding` request header and returns the best supported
+ * encoding for this middleware.
+ *
+ * Priority order: gzip > deflate > identity.
+ *
+ * @param acceptEncoding - Raw value of the `Accept-Encoding` header.
+ * @returns The chosen encoding.
+ */
+export function selectEncoding(
+  acceptEncoding: string | undefined,
+): Encoding {
+  if (!acceptEncoding) return "identity";
+  const header = acceptEncoding.toLowerCase();
+  if (header.includes("gzip")) return "gzip";
+  if (header.includes("deflate")) return "deflate";
+  return "identity";
+}
+
+/**
+ * Synchronously compresses `data` using the given encoding.
+ *
+ * @param data     - The buffer to compress.
+ * @param encoding - `"gzip"` or `"deflate"`.
+ * @returns A compressed `Buffer`.
+ * @throws When the underlying zlib call fails.
+ */
+function compress(data: Buffer, encoding: "gzip" | "deflate"): Buffer {
+  return encoding === "gzip"
+    ? zlib.gzipSync(data)
+    : zlib.deflateSync(data);
+}
+
+// ---------------------------------------------------------------------------
+// Middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Express middleware that compresses JSON responses for disputes endpoints.
+ *
+ * - Intercepts `res.json()` to serialise and optionally compress the body.
+ * - Adds `Vary: Accept-Encoding` so caches store separate entries per encoding.
+ * - Only compresses when `Accept-Encoding` includes `gzip` or `deflate` *and*
+ *   the serialised body is ≥ `COMPRESSION_THRESHOLD` bytes.
+ * - Falls back to uncompressed for small payloads or unsupported encodings.
+ */
+export const compressResponse: RequestHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  // Always advertise that the response varies by Accept-Encoding so HTTP
+  // caches (proxies, CDNs) store separate copies per encoding.
+  res.setHeader("Vary", "Accept-Encoding");
+
+  const encoding = selectEncoding(req.headers["accept-encoding"] as string | undefined);
+
+  if (encoding === "identity") {
+    // Client does not want compression — proceed normally.
+    next();
+    return;
+  }
+
+  // Intercept res.json to apply compression before writing to the socket.
+  const originalJson = res.json.bind(res);
+
+  res.json = function compressedJson(body: unknown): Response {
+    const serialised = JSON.stringify(body);
+    const rawBuffer = Buffer.from(serialised, "utf8");
+
+    // Skip compression for small responses.
+    if (rawBuffer.byteLength < COMPRESSION_THRESHOLD) {
+      logger.debug(
+        {
+          path: req.path,
+          method: req.method,
+          bytes: rawBuffer.byteLength,
+          threshold: COMPRESSION_THRESHOLD,
+        },
+        "compression_skipped_below_threshold",
+      );
+      return originalJson(body);
+    }
+
+    try {
+      const compressed = compress(rawBuffer, encoding);
+
+      logger.debug(
+        {
+          path: req.path,
+          method: req.method,
+          encoding,
+          originalBytes: rawBuffer.byteLength,
+          compressedBytes: compressed.byteLength,
+          ratio: (
+            ((rawBuffer.byteLength - compressed.byteLength) /
+              rawBuffer.byteLength) *
+            100
+          ).toFixed(1),
+        },
+        "compression_applied",
+      );
+
+      res.setHeader("Content-Encoding", encoding);
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+      res.setHeader("Content-Length", compressed.byteLength);
+
+      res.status(res.statusCode);
+      res.end(compressed);
+      return res;
+    } catch (err) {
+      // If compression fails for any reason, fall back to uncompressed.
+      logger.warn(
+        { path: req.path, method: req.method, encoding, err },
+        "compression_failed_fallback_to_identity",
+      );
+      return originalJson(body);
+    }
+  };
+
+  next();
+};

--- a/src/routes/disputes.ts
+++ b/src/routes/disputes.ts
@@ -5,8 +5,13 @@ import { openDispute, DisputeError } from "../services/disputeService";
 import { validateHttpsUrl, validateSsrf } from "../utils/url";
 import { logger } from "../config/logger";
 import { RouteErrorFactory } from "../errors";
+import { compressResponse } from "../middleware/compression";
 
 export const disputesRouter = Router({ mergeParams: true });
+
+// Apply compression to all disputes responses — large payloads (≥ 1 KiB)
+// are gzip/deflate compressed based on the client's Accept-Encoding header.
+disputesRouter.use(compressResponse);
 
 const openDisputeSchema = z.object({
   reason: z.string().min(10).max(500),

--- a/tests/compression.test.ts
+++ b/tests/compression.test.ts
@@ -1,0 +1,625 @@
+/**
+ * Tests for the compression middleware.
+ *
+ * Covers:
+ * - Unit tests for `selectEncoding` helper
+ * - Unit tests for `compressResponse` middleware in isolation
+ * - Integration tests via the disputes route:
+ *     - Large responses (≥ 1 KiB) are gzip/deflate compressed
+ *     - Small responses (< 1 KiB) are NOT compressed
+ *     - Clients that omit Accept-Encoding receive identity (no compression)
+ *     - Error responses are compressed when above threshold
+ *     - `Vary: Accept-Encoding` header is always present
+ */
+
+import zlib from "zlib";
+import express, { Request, Response } from "express";
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { compressResponse, selectEncoding, COMPRESSION_THRESHOLD } from "../../src/middleware/compression";
+
+// ---------------------------------------------------------------------------
+// Constants shared across test cases
+// ---------------------------------------------------------------------------
+
+const JWT_SECRET = process.env.JWT_SECRET ?? "test-jwt-secret-that-is-at-least-32-chars!!";
+const JWT_ISSUER = "predictify";
+const JWT_AUDIENCE = "predictify-app";
+
+function makeToken(): string {
+  return jwt.sign(
+    {
+      sub: "550e8400-e29b-41d4-a716-446655440000",
+      stellarAddress: "GABCDEF123...",
+    },
+    JWT_SECRET,
+    { issuer: JWT_ISSUER, audience: JWT_AUDIENCE, expiresIn: "1h" },
+  );
+}
+
+/**
+ * Generates a JSON-serialisable object whose serialised form is at least
+ * `minBytes` bytes long.
+ */
+function buildLargePayload(minBytes = COMPRESSION_THRESHOLD + 512): Record<string, unknown> {
+  const filler = "x".repeat(minBytes);
+  return {
+    id: "dispute-abc-123",
+    marketId: "market-xyz-456",
+    openedBy: "550e8400-e29b-41d4-a716-446655440000",
+    reason: filler,
+    evidenceUri: null,
+    status: "open",
+    createdAt: new Date("2025-01-01T00:00:00Z").toISOString(),
+  };
+}
+
+/**
+ * Generates a JSON-serialisable object whose serialised form is smaller than
+ * `COMPRESSION_THRESHOLD`.
+ */
+function buildSmallPayload(): Record<string, unknown> {
+  return {
+    id: "dispute-small",
+    status: "ok",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal Express app with compressResponse on a test route
+// ---------------------------------------------------------------------------
+
+function buildTestApp(payloadFn: () => unknown, statusCode = 200): express.Express {
+  const app = express();
+  app.use(compressResponse);
+  app.get("/test", (_req: Request, res: Response) => {
+    res.status(statusCode).json(payloadFn());
+  });
+  return app;
+}
+
+// ===========================================================================
+// 1. Unit tests — selectEncoding
+// ===========================================================================
+
+describe("selectEncoding", () => {
+  it("returns gzip when Accept-Encoding includes gzip", () => {
+    expect(selectEncoding("gzip, deflate, br")).toBe("gzip");
+  });
+
+  it("returns gzip for gzip-only header", () => {
+    expect(selectEncoding("gzip")).toBe("gzip");
+  });
+
+  it("prefers gzip over deflate", () => {
+    expect(selectEncoding("deflate, gzip")).toBe("gzip");
+  });
+
+  it("returns deflate when Accept-Encoding includes only deflate", () => {
+    expect(selectEncoding("deflate")).toBe("deflate");
+  });
+
+  it("returns identity when Accept-Encoding is absent (undefined)", () => {
+    expect(selectEncoding(undefined)).toBe("identity");
+  });
+
+  it("returns identity for empty string", () => {
+    expect(selectEncoding("")).toBe("identity");
+  });
+
+  it("returns identity for unsupported encodings like br only", () => {
+    expect(selectEncoding("br")).toBe("identity");
+  });
+
+  it("is case-insensitive for GZIP", () => {
+    expect(selectEncoding("GZIP")).toBe("gzip");
+  });
+
+  it("is case-insensitive for DEFLATE", () => {
+    expect(selectEncoding("DEFLATE")).toBe("deflate");
+  });
+});
+
+// ===========================================================================
+// 2. Unit tests — compressResponse middleware (direct invocation)
+// ===========================================================================
+
+describe("compressResponse middleware (unit)", () => {
+  function makeMocks(acceptEncoding?: string) {
+    const req = {
+      path: "/test",
+      method: "POST",
+      headers: acceptEncoding
+        ? { "accept-encoding": acceptEncoding }
+        : {},
+    } as unknown as Request;
+
+    const jsonMock = jest.fn().mockImplementation(function (this: Response) {
+      return this;
+    });
+
+    const res = {
+      setHeader: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      end: jest.fn(),
+      statusCode: 201,
+      json: jsonMock,
+    } as unknown as Response;
+
+    const next = jest.fn();
+
+    return { req, res, next, jsonMock };
+  }
+
+  it("calls next() for all Accept-Encoding values", () => {
+    const { req, res, next } = makeMocks("gzip");
+    compressResponse(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("always sets Vary: Accept-Encoding header", () => {
+    const { req, res, next } = makeMocks("gzip");
+    compressResponse(req, res, next);
+    expect(res.setHeader).toHaveBeenCalledWith("Vary", "Accept-Encoding");
+  });
+
+  it("sets Vary header even when Accept-Encoding is absent", () => {
+    const { req, res, next } = makeMocks(undefined);
+    compressResponse(req, res, next);
+    expect(res.setHeader).toHaveBeenCalledWith("Vary", "Accept-Encoding");
+  });
+
+  it("does not replace res.json when encoding is identity", () => {
+    const { req, res, next, jsonMock } = makeMocks(undefined);
+    compressResponse(req, res, next);
+    expect(res.json).toBe(jsonMock); // original function unchanged
+  });
+
+  it("replaces res.json when encoding is gzip", () => {
+    const { req, res, next, jsonMock } = makeMocks("gzip");
+    compressResponse(req, res, next);
+    expect(res.json).not.toBe(jsonMock); // replaced
+  });
+
+  it("replaces res.json when encoding is deflate", () => {
+    const { req, res, next, jsonMock } = makeMocks("deflate");
+    compressResponse(req, res, next);
+    expect(res.json).not.toBe(jsonMock); // replaced
+  });
+});
+
+// ===========================================================================
+// 3. Integration tests — via a minimal Express test app
+// ===========================================================================
+
+describe("compressResponse integration — large payload (≥ threshold)", () => {
+  const largePayload = buildLargePayload();
+
+  it("gzip-compresses response when Accept-Encoding: gzip", async () => {
+    const app = buildTestApp(() => largePayload);
+    const res = await request(app)
+      .get("/test")
+      .set("Accept-Encoding", "gzip")
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => callback(null, Buffer.concat(chunks)));
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-encoding"]).toBe("gzip");
+    expect(res.headers["vary"]).toContain("Accept-Encoding");
+
+    // Decompress and verify the body is intact.
+    const decompressed = zlib.gunzipSync(res.body as Buffer).toString("utf8");
+    const parsed = JSON.parse(decompressed);
+    expect(parsed).toEqual(largePayload);
+  });
+
+  it("deflate-compresses response when Accept-Encoding: deflate", async () => {
+    const app = buildTestApp(() => largePayload);
+    const res = await request(app)
+      .get("/test")
+      .set("Accept-Encoding", "deflate")
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => callback(null, Buffer.concat(chunks)));
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-encoding"]).toBe("deflate");
+
+    const decompressed = zlib.inflateSync(res.body as Buffer).toString("utf8");
+    const parsed = JSON.parse(decompressed);
+    expect(parsed).toEqual(largePayload);
+  });
+
+  it("prefers gzip over deflate with combined Accept-Encoding header", async () => {
+    const app = buildTestApp(() => largePayload);
+    const res = await request(app)
+      .get("/test")
+      .set("Accept-Encoding", "deflate, gzip")
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => callback(null, Buffer.concat(chunks)));
+      });
+
+    expect(res.headers["content-encoding"]).toBe("gzip");
+  });
+
+  it("sets Content-Encoding header for gzip", async () => {
+    const app = buildTestApp(() => largePayload);
+    const res = await request(app)
+      .get("/test")
+      .set("Accept-Encoding", "gzip");
+
+    expect(res.headers["content-encoding"]).toBe("gzip");
+  });
+
+  it("sets Content-Type to application/json for compressed response", async () => {
+    const app = buildTestApp(() => largePayload);
+    const res = await request(app)
+      .get("/test")
+      .set("Accept-Encoding", "gzip");
+
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+  });
+
+  it("returns a smaller Content-Length for gzip-compressed payload", async () => {
+    const app = buildTestApp(() => largePayload);
+    const res = await request(app)
+      .get("/test")
+      .set("Accept-Encoding", "gzip");
+
+    const rawLength = Buffer.byteLength(JSON.stringify(largePayload), "utf8");
+    const contentLength = parseInt(res.headers["content-length"] ?? "0", 10);
+    expect(contentLength).toBeGreaterThan(0);
+    expect(contentLength).toBeLessThan(rawLength);
+  });
+
+  it("preserves the HTTP status code with compression", async () => {
+    const app = buildTestApp(() => largePayload, 201);
+    const res = await request(app)
+      .get("/test")
+      .set("Accept-Encoding", "gzip");
+
+    expect(res.status).toBe(201);
+  });
+});
+
+describe("compressResponse integration — small payload (< threshold)", () => {
+  const smallPayload = buildSmallPayload();
+
+  it("does NOT set Content-Encoding for small payloads", async () => {
+    const app = buildTestApp(() => smallPayload);
+    const res = await request(app)
+      .get("/test")
+      .set("Accept-Encoding", "gzip");
+
+    expect(res.headers["content-encoding"]).toBeUndefined();
+  });
+
+  it("still sets Vary: Accept-Encoding even for small payloads", async () => {
+    const app = buildTestApp(() => smallPayload);
+    const res = await request(app)
+      .get("/test")
+      .set("Accept-Encoding", "gzip");
+
+    expect(res.headers["vary"]).toContain("Accept-Encoding");
+  });
+
+  it("returns the raw JSON body for small payloads", async () => {
+    const app = buildTestApp(() => smallPayload);
+    const res = await request(app)
+      .get("/test")
+      .set("Accept-Encoding", "gzip");
+
+    expect(res.body).toEqual(smallPayload);
+  });
+});
+
+describe("compressResponse integration — no Accept-Encoding (identity)", () => {
+  const largePayload = buildLargePayload();
+
+  it("does NOT compress when Accept-Encoding header is absent", async () => {
+    const app = buildTestApp(() => largePayload);
+    const res = await request(app).get("/test");
+
+    expect(res.headers["content-encoding"]).toBeUndefined();
+  });
+
+  it("still sets Vary: Accept-Encoding even without Accept-Encoding header", async () => {
+    const app = buildTestApp(() => largePayload);
+    const res = await request(app).get("/test");
+
+    expect(res.headers["vary"]).toContain("Accept-Encoding");
+  });
+
+  it("returns correct JSON body without compression", async () => {
+    const app = buildTestApp(() => largePayload);
+    const res = await request(app).get("/test");
+
+    expect(res.body).toEqual(largePayload);
+  });
+
+  it("does NOT compress when Accept-Encoding is identity", async () => {
+    const app = buildTestApp(() => largePayload);
+    const res = await request(app)
+      .get("/test")
+      .set("Accept-Encoding", "identity");
+
+    expect(res.headers["content-encoding"]).toBeUndefined();
+    expect(res.body).toEqual(largePayload);
+  });
+});
+
+describe("compressResponse integration — unsupported encoding (br only)", () => {
+  const largePayload = buildLargePayload();
+
+  it("does NOT compress for unsupported encoding like br", async () => {
+    const app = buildTestApp(() => largePayload);
+    const res = await request(app)
+      .get("/test")
+      .set("Accept-Encoding", "br");
+
+    expect(res.headers["content-encoding"]).toBeUndefined();
+    expect(res.body).toEqual(largePayload);
+  });
+});
+
+// ===========================================================================
+// 4. Integration tests — via the disputes route
+// ===========================================================================
+
+jest.mock("../../src/services/disputeService", () => {
+  const actual = jest.requireActual("../../src/services/disputeService");
+  return {
+    ...actual,
+    openDispute: jest.fn(),
+  };
+});
+
+jest.mock("../../src/utils/url", () => ({
+  validateHttpsUrl: jest.fn().mockReturnValue({ valid: true }),
+  validateSsrf: jest.fn().mockResolvedValue({ valid: true }),
+}));
+
+import { openDispute, DisputeError } from "../../src/services/disputeService";
+import { createApp } from "../../src/index";
+
+const mockedOpenDispute = openDispute as jest.MockedFunction<typeof openDispute>;
+
+const VALID_BODY = {
+  reason: "The outcome is incorrect because the oracle data was manipulated.",
+};
+
+/** A large dispute with a reason field sized above COMPRESSION_THRESHOLD. */
+function makeLargeDispute() {
+  return {
+    id: "dispute-large-001",
+    marketId: "market-abc",
+    openedBy: "550e8400-e29b-41d4-a716-446655440000",
+    reason: "x".repeat(COMPRESSION_THRESHOLD + 256),
+    evidenceUri: null,
+    status: "open",
+    createdAt: new Date("2025-06-01T00:00:00Z"),
+  };
+}
+
+/** A compact dispute whose JSON representation stays under threshold. */
+function makeSmallDispute() {
+  return {
+    id: "d1",
+    marketId: "m1",
+    openedBy: "u1",
+    reason: "short",
+    evidenceUri: null,
+    status: "open",
+    createdAt: new Date("2025-06-01T00:00:00Z"),
+  };
+}
+
+describe("POST /api/markets/:id/disputes — compression", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns a gzip-compressed response for large dispute payloads", async () => {
+    const dispute = makeLargeDispute();
+    mockedOpenDispute.mockResolvedValue(dispute);
+
+    const res = await request(createApp())
+      .post("/api/markets/market-abc/disputes")
+      .set("Authorization", `Bearer ${makeToken()}`)
+      .set("Accept-Encoding", "gzip")
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => callback(null, Buffer.concat(chunks)));
+      })
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(201);
+    expect(res.headers["content-encoding"]).toBe("gzip");
+
+    const decompressed = zlib.gunzipSync(res.body as Buffer).toString("utf8");
+    const parsed = JSON.parse(decompressed);
+    expect(parsed.data.id).toBe("dispute-large-001");
+    expect(parsed.data.reason).toHaveLength(COMPRESSION_THRESHOLD + 256);
+  });
+
+  it("returns a deflate-compressed response for large dispute payloads", async () => {
+    const dispute = makeLargeDispute();
+    mockedOpenDispute.mockResolvedValue(dispute);
+
+    const res = await request(createApp())
+      .post("/api/markets/market-abc/disputes")
+      .set("Authorization", `Bearer ${makeToken()}`)
+      .set("Accept-Encoding", "deflate")
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => callback(null, Buffer.concat(chunks)));
+      })
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(201);
+    expect(res.headers["content-encoding"]).toBe("deflate");
+
+    const decompressed = zlib.inflateSync(res.body as Buffer).toString("utf8");
+    const parsed = JSON.parse(decompressed);
+    expect(parsed.data.id).toBe("dispute-large-001");
+  });
+
+  it("does NOT compress small dispute payloads even with Accept-Encoding: gzip", async () => {
+    const dispute = makeSmallDispute();
+    mockedOpenDispute.mockResolvedValue(dispute);
+
+    const res = await request(createApp())
+      .post("/api/markets/market-abc/disputes")
+      .set("Authorization", `Bearer ${makeToken()}`)
+      .set("Accept-Encoding", "gzip")
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(201);
+    expect(res.headers["content-encoding"]).toBeUndefined();
+    expect(res.body.data.id).toBe("d1");
+  });
+
+  it("does NOT compress when Accept-Encoding is absent", async () => {
+    const dispute = makeLargeDispute();
+    mockedOpenDispute.mockResolvedValue(dispute);
+
+    const res = await request(createApp())
+      .post("/api/markets/market-abc/disputes")
+      .set("Authorization", `Bearer ${makeToken()}`)
+      // No Accept-Encoding header
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(201);
+    expect(res.headers["content-encoding"]).toBeUndefined();
+  });
+
+  it("always sets Vary: Accept-Encoding on disputes responses", async () => {
+    const dispute = makeSmallDispute();
+    mockedOpenDispute.mockResolvedValue(dispute);
+
+    const res = await request(createApp())
+      .post("/api/markets/market-abc/disputes")
+      .set("Authorization", `Bearer ${makeToken()}`)
+      .send(VALID_BODY);
+
+    expect(res.headers["vary"]).toContain("Accept-Encoding");
+  });
+
+  it("preserves 201 status code with gzip compression", async () => {
+    const dispute = makeLargeDispute();
+    mockedOpenDispute.mockResolvedValue(dispute);
+
+    const res = await request(createApp())
+      .post("/api/markets/market-abc/disputes")
+      .set("Authorization", `Bearer ${makeToken()}`)
+      .set("Accept-Encoding", "gzip")
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => callback(null, Buffer.concat(chunks)));
+      })
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(201);
+  });
+
+  it("returns a 409 error response correctly (without compression for small error bodies)", async () => {
+    mockedOpenDispute.mockRejectedValue(
+      new DisputeError(409, "duplicate_dispute", "An open dispute already exists"),
+    );
+
+    const res = await request(createApp())
+      .post("/api/markets/market-abc/disputes")
+      .set("Authorization", `Bearer ${makeToken()}`)
+      .set("Accept-Encoding", "gzip")
+      .send(VALID_BODY);
+
+    // Error responses from DisputeError are typically small → no compression
+    expect(res.status).toBe(409);
+    expect(res.headers["vary"]).toContain("Accept-Encoding");
+  });
+
+  it("401 response from requireAuth is still returned correctly", async () => {
+    const res = await request(createApp())
+      .post("/api/markets/market-abc/disputes")
+      .set("Accept-Encoding", "gzip")
+      .send(VALID_BODY);
+    // No Authorization header → 401, Vary header still set
+    expect(res.status).toBe(401);
+    expect(res.headers["vary"]).toContain("Accept-Encoding");
+  });
+});
+
+// ===========================================================================
+// 5. COMPRESSION_THRESHOLD export test
+// ===========================================================================
+
+describe("COMPRESSION_THRESHOLD constant", () => {
+  it("is 1024 bytes (1 KiB)", () => {
+    expect(COMPRESSION_THRESHOLD).toBe(1024);
+  });
+
+  it("payload exactly at threshold IS compressed", async () => {
+    // Create a payload that serialises to exactly COMPRESSION_THRESHOLD bytes.
+    // We'll create the payload iteratively to hit the exact target.
+    let fillerLength = COMPRESSION_THRESHOLD - 15; // initial estimate
+    let serialised: string;
+    do {
+      fillerLength++;
+      const candidate = { d: "x".repeat(fillerLength) };
+      serialised = JSON.stringify(candidate);
+    } while (serialised.length < COMPRESSION_THRESHOLD);
+
+    const exactPayload = JSON.parse(serialised) as Record<string, unknown>;
+    const app = buildTestApp(() => exactPayload);
+
+    const res = await request(app)
+      .get("/test")
+      .set("Accept-Encoding", "gzip");
+
+    // Should be compressed because length === COMPRESSION_THRESHOLD
+    expect(res.headers["content-encoding"]).toBe("gzip");
+  });
+
+  it("payload one byte below threshold is NOT compressed", async () => {
+    // Build a payload that serialises to exactly COMPRESSION_THRESHOLD - 1 bytes.
+    let fillerLength = COMPRESSION_THRESHOLD - 15;
+    let serialised: string;
+    do {
+      fillerLength++;
+      const candidate = { d: "x".repeat(fillerLength) };
+      serialised = JSON.stringify(candidate);
+    } while (serialised.length < COMPRESSION_THRESHOLD - 1);
+
+    // Trim one character so we land at exactly threshold - 1
+    const underPayload = { d: "x".repeat(fillerLength - 1) };
+    const underSerialized = JSON.stringify(underPayload);
+    // Only proceed if we're actually under threshold
+    if (underSerialized.length >= COMPRESSION_THRESHOLD) {
+      // If we can't get under threshold easily, just skip the byte-exact test
+      return;
+    }
+
+    const app = buildTestApp(() => underPayload);
+    const res = await request(app)
+      .get("/test")
+      .set("Accept-Encoding", "gzip");
+
+    expect(res.headers["content-encoding"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Enables gzip and deflate response compression for the `/api/markets/:id/disputes` endpoint. Large responses (≥ 1 KiB) are transparently compressed using Node.js's built-in `zlib` module — no new runtime dependencies are introduced.

---

## Changes

### `src/middleware/compression.ts` (new)

A self-contained Express middleware module exporting:

| Export | Description |
|---|---|
| `COMPRESSION_THRESHOLD` | `1024` bytes — minimum serialised response size before compression is applied |
| `selectEncoding(acceptEncoding)` | Parses `Accept-Encoding` and returns `"gzip"`, `"deflate"`, or `"identity"`. Prefers gzip. |
| `compressResponse` | Express `RequestHandler` — intercepts `res.json()`, compresses large payloads, sets appropriate headers |

Key behaviour:
- `Vary: Accept-Encoding` is **always** set so HTTP caches (CDNs, proxies) store separate entries per encoding.
- Payloads below `COMPRESSION_THRESHOLD` are forwarded to the original `res.json()` unchanged.
- Compression errors fall back to identity (uncompressed) and log a warning — no 500s.
- Status code is preserved through compression.

### `src/routes/disputes.ts` (modified)

Added `import { compressResponse } from "../middleware/compression"` and registered it as router-level middleware:

```ts
disputesRouter.use(compressResponse);
```

This applies compression to all current and future handlers on the disputes router without touching individual route handlers.

### `tests/compression.test.ts` (new)

625-line test file covering:

| Suite | Cases |
|---|---|
| **`selectEncoding` unit** | gzip, deflate, gzip+deflate (prefers gzip), absent header, empty string, unsupported (br), case-insensitive |
| **`compressResponse` unit** | `next()` called, `Vary` always set, `res.json` replaced only for compressed encodings, identity leaves original `res.json` |
| **Integration — large payload** | gzip round-trip (gunzip + JSON.parse), deflate round-trip (inflate + JSON.parse), gzip preferred over deflate, `Content-Encoding` header, `Content-Type` preserved, `Content-Length` smaller than raw, status code preserved |
| **Integration — small payload** | No `Content-Encoding`, `Vary` still set, raw JSON body intact |
| **Integration — identity** | No compression without `Accept-Encoding`, identity explicit, unsupported (br) |
| **Disputes route (createApp)** | gzip 201 round-trip, deflate 201 round-trip, small response uncompressed, absent header uncompressed, `Vary` always on disputes, status preserved, error 409 unaffected, 401 auth still works |
| **`COMPRESSION_THRESHOLD` boundary** | Constant is 1024, payload at threshold IS compressed, payload below threshold is NOT |

---

## Design decisions

**No new dependencies.** The implementation uses `zlib` from the Node.js standard library. The popular `compression` npm package uses the same underlying primitives and would add a transitive dependency for no functional gain here.

**Router-level middleware, not global.** Compression is scoped to `disputesRouter` only — other routes are unaffected. A global `app.use(compressResponse)` could interfere with streaming responses (SSE, NDJSON export) and was intentionally avoided.

**Synchronous zlib.** `gzipSync` / `deflateSync` are used rather than the async streaming variants because `res.json()` is a synchronous call and the payloads involved are bounded JSON objects. For streaming endpoints the async pipeline approach would be appropriate.

**Threshold at 1 KiB.** The `COMPRESSION_THRESHOLD` (1024 bytes) is a named, exported constant so it can be adjusted or overridden in tests without magic numbers.

---

## Files changed

```
src/middleware/compression.ts   (new — 188 lines)
src/routes/disputes.ts          (modified — +3 lines)
tests/compression.test.ts       (new — 625 lines)
```

---

## How to verify

```bash
# Run the new compression tests
npx jest tests/compression.test.ts --no-coverage

# Run the existing disputes tests to confirm nothing regressed
npx jest tests/disputes.test.ts --no-coverage
```

Resolves #52.