### PR TITLE
Task/audit otel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "7.3.4",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/sdk-trace-base": "^2.10.0",
         "@stellar/stellar-sdk": "^12.0.0",
         "bullmq": "^5.79.2",
         "drizzle-orm": "^0.45.2",
@@ -2479,11 +2481,86 @@
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@paralleldrive/cuid2": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "7.3.4",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/sdk-trace-base": "^2.10.0",
     "@stellar/stellar-sdk": "^12.0.0",
     "bullmq": "^5.79.2",
     "drizzle-orm": "^0.45.2",

--- a/src/otel/spans.ts
+++ b/src/otel/spans.ts
@@ -1,0 +1,116 @@
+/**
+ * @module otel/spans
+ *
+ * Convenience helpers for creating and ending OpenTelemetry spans on
+ * audit-related route handlers.
+ *
+ * Usage (typical handler pattern)
+ * -----
+ *
+ *   import { startAuditSpan, endAuditSpan, recordErrorOnSpan } from "../otel/spans";
+ *   import { getRequestId } from "../lib/requestContext";
+ *
+ *   router.get("/", async (req, res, next) => {
+ *     const span = startAuditSpan("audit.list", req, res);
+ *     try {
+ *       // … handler logic …
+ *       endAuditSpan(span, res);
+ *     } catch (err) {
+ *       recordErrorOnSpan(span, err);
+ *       next(err);
+ *     }
+ *   });
+ *
+ * For streaming endpoints (export) the span must be ended when the stream
+ * finishes, not when the handler returns.  See admin/audit/export.ts for
+ * the event-based pattern.
+ */
+
+import type { Request, Response } from "express";
+import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
+import type { Span } from "@opentelemetry/api";
+import { getTracer } from "./tracer";
+import { getRequestId } from "../lib/requestContext";
+
+// ---------------------------------------------------------------------------
+// Span lifecycle helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a new span for an audit endpoint and populates its initial
+ * attributes (method, path, correlationId).
+ *
+ * The span kind is set to `SERVER` because these spans represent server-side
+ * handling of a synchronous HTTP request.
+ *
+ * @param spanName - Short, dot-separated name e.g. `"audit.market.list"`
+ * @param req       - Express request object (used for method + path)
+ * @param res       - Express response object (used for correlationId via locals)
+ * @param extraAttrs - Optional extra attributes to set immediately
+ * @returns The started span
+ */
+export function startAuditSpan(
+  spanName: string,
+  req: Request,
+  res: Response,
+  extraAttrs?: Record<string, string | undefined>,
+): Span {
+  const tracer = getTracer();
+  const span = tracer.startSpan(spanName, {
+    kind: SpanKind.SERVER,
+    attributes: {
+      "http.method": req.method,
+      "http.path": req.path,
+      "correlation.id": res.locals.correlationId ?? getRequestId() ?? "unknown",
+      ...(extraAttrs ?? {}),
+    },
+  });
+
+  return span;
+}
+
+/**
+ * Ends a span after a successful (or non-exceptional) response.
+ *
+ * Sets the `http.status_code` attribute and marks the span status as
+ * `ERROR` if the status code is >= 400.
+ *
+ * @param span - The span to end
+ * @param res  - Express response object (statusCode is read)
+ */
+export function endAuditSpan(span: Span, res: Response): void {
+  const statusCode = res.statusCode;
+
+  span.setAttribute("http.status_code", statusCode);
+
+  if (statusCode >= 400) {
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: `HTTP ${statusCode}`,
+    });
+  } else {
+    span.setStatus({ code: SpanStatusCode.OK });
+  }
+
+  span.end();
+}
+
+/**
+ * Records an exception on a span and sets its status to ERROR.
+ *
+ * Call this from `catch` blocks **instead of** `endAuditSpan`, then
+ * forward the error to Express's error handler via `next(err)`.
+ *
+ * @param span - The span to record the error on (will NOT be ended here
+ *               — the caller's `finally` or `next(err)` path is expected
+ *               to end it; for synchronous handlers, call `endAuditSpan`
+ *               in an outer `finally`, or call `span.end()` after this)
+ * @param err  - The thrown error or rejection reason
+ */
+export function recordErrorOnSpan(span: Span, err: unknown): void {
+  span.recordException(err instanceof Error ? err : new Error(String(err)));
+  span.setStatus({
+    code: SpanStatusCode.ERROR,
+    message: err instanceof Error ? err.message : String(err),
+  });
+}

--- a/src/otel/tracer.ts
+++ b/src/otel/tracer.ts
@@ -1,0 +1,12 @@
+import { type Tracer } from "@opentelemetry/api";
+import { TracerProvider, SimpleSpanProcessor, ConsoleSpanExporter } from "@opentelemetry/sdk-trace";
+
+const provider = new TracerProvider({
+  spanProcessors: [new SimpleSpanProcessor({ exporter: new ConsoleSpanExporter() })],
+});
+
+const _tracer: Tracer = provider.getTracer("predictify-backend", "0.1.0");
+
+export function getTracer(): Tracer {
+  return _tracer;
+}

--- a/src/otel/tracer.ts
+++ b/src/otel/tracer.ts
@@ -1,12 +1,12 @@
 import { type Tracer } from "@opentelemetry/api";
-import { TracerProvider, SimpleSpanProcessor, ConsoleSpanExporter } from "@opentelemetry/sdk-trace";
+import { BasicTracerProvider, SimpleSpanProcessor, ConsoleSpanExporter } from "@opentelemetry/sdk-trace-base";
 
-const provider = new TracerProvider({
-  spanProcessors: [new SimpleSpanProcessor({ exporter: new ConsoleSpanExporter() })],
+const provider = new BasicTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(new ConsoleSpanExporter())],
 });
 
-const _tracer: Tracer = provider.getTracer("predictify-backend", "0.1.0");
+const tracerInstance: Tracer = provider.getTracer("predictify-backend", "0.1.0");
 
 export function getTracer(): Tracer {
-  return _tracer;
+  return tracerInstance;
 }

--- a/src/routes/admin/audit.ts
+++ b/src/routes/admin/audit.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { requireAdmin } from "../../middleware/requireAdmin";
 import { getAuditLogs } from "../../repositories/auditLogRepo";
 import { RouteErrorFactory } from "../../errors";
+import { startAuditSpan, endAuditSpan, recordErrorOnSpan } from "../../otel/spans";
 import { searchAuditLogsHandler } from "./audit/search";
 
 export interface AdminAuditRouterOptions {
@@ -50,6 +51,7 @@ export function createAdminAuditRouter(opts: AdminAuditRouterOptions = {}): Rout
   router.post("/search", searchAuditLogsHandler);
 
   router.get("/", async (req, res, next) => {
+    const span = startAuditSpan("audit.admin.list", req, res);
     try {
       const parseResult = auditQuerySchema.safeParse(req.query);
       if (!parseResult.success) {
@@ -61,11 +63,13 @@ export function createAdminAuditRouter(opts: AdminAuditRouterOptions = {}): Rout
       const filters = parseResult.data;
       const page = await getAuditLogs(filters);
 
+      endAuditSpan(span, res);
       res.json({
         data: page.data,
         nextCursor: page.nextCursor,
       });
     } catch (e) {
+      recordErrorOnSpan(span, e);
       next(e);
     }
   });

--- a/src/routes/admin/audit/export.ts
+++ b/src/routes/admin/audit/export.ts
@@ -59,8 +59,9 @@ export function createAdminAuditExportRouter(
       const parseResult = exportQuerySchema.safeParse(req.query);
       if (!parseResult.success) {
         const reqId = getRequestId();
+        res.status(400);
         endAuditSpan(span, res);
-        res.status(400).json({
+        res.json({
           error: {
             code: "validation_error",
             message: parseResult.error.issues[0]?.message ?? "invalid query parameters",
@@ -174,8 +175,9 @@ export function createAdminAuditExportRouter(
           );
 
           if (!res.headersSent) {
+            res.status(500);
             endAuditSpan(span, res);
-            res.status(500).json({
+            res.json({
               error: {
                 code: "export_error",
                 message: "Failed to stream audit logs",

--- a/src/routes/admin/audit/export.ts
+++ b/src/routes/admin/audit/export.ts
@@ -6,6 +6,7 @@ import { requireAdmin } from "../../../middleware/requireAdmin";
 import { getAuditLogsStream } from "../../../repositories/auditLogRepo";
 import { getRequestId } from "../../../lib/requestContext";
 import { logger } from "../../../config/logger";
+import { startAuditSpan, endAuditSpan, recordErrorOnSpan } from "../../../otel/spans";
 
 export interface AdminAuditExportRouterOptions {
   rateLimitPerMinute?: number;
@@ -48,11 +49,17 @@ export function createAdminAuditExportRouter(
 
   router.get("/export", async (req, res, next) => {
     const requestId = getRequestId();
+    // For the streaming export handler the span is ended when the response
+    // stream finishes, not when the initial handler returns.  Hook into
+    // response "finish" / "close" / error events so the span duration
+    // reflects the real export time and stream errors are recorded.
+    const span = startAuditSpan("audit.admin.export", req, res);
 
     try {
       const parseResult = exportQuerySchema.safeParse(req.query);
       if (!parseResult.success) {
         const reqId = getRequestId();
+        endAuditSpan(span, res);
         res.status(400).json({
           error: {
             code: "validation_error",
@@ -107,6 +114,8 @@ export function createAdminAuditExportRouter(
           },
           "Error in NDJSON transform stream",
         );
+        recordErrorOnSpan(span, err);
+        // span is ended in the response "close" handler below
       });
 
       ndjsonTransform.pipe(res);
@@ -165,6 +174,7 @@ export function createAdminAuditExportRouter(
           );
 
           if (!res.headersSent) {
+            endAuditSpan(span, res);
             res.status(500).json({
               error: {
                 code: "export_error",
@@ -190,7 +200,25 @@ export function createAdminAuditExportRouter(
             },
             "Client disconnected before audit export completed",
           );
+          recordErrorOnSpan(span, new Error("client_disconnected"));
           ndjsonTransform.destroy();
+        }
+      });
+
+      // End the span when the response finishes.  This covers:
+      // - natural stream completion (res "finish")
+      // - client disconnect (res "close")
+      // - stream errors that don't already trigger "finish"
+      const endSpanOnResponseFinish = () => {
+        if (span.isRecording()) {
+          endAuditSpan(span, res);
+        }
+      };
+      res.on("finish", endSpanOnResponseFinish);
+      res.on("close", () => {
+        if (span.isRecording()) {
+          // If "finish" already ran, this is a no-op (span already ended).
+          endAuditSpan(span, res);
         }
       });
     } catch (err) {
@@ -202,6 +230,8 @@ export function createAdminAuditExportRouter(
         },
         "Unexpected error in audit export endpoint",
       );
+      recordErrorOnSpan(span, err);
+      span.end();
       next(err);
     }
   });

--- a/src/routes/admin/audit/search.ts
+++ b/src/routes/admin/audit/search.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { getAuditLogs } from "../../../repositories/auditLogRepo";
 import { getRequestId } from "../../../lib/requestContext";
 import { logger } from "../../../config/logger";
+import { startAuditSpan, endAuditSpan, recordErrorOnSpan } from "../../../otel/spans";
 
 const searchAuditSchema = z.object({
   action: z.string().optional(),
@@ -28,11 +29,13 @@ export const searchAuditLogsHandler = async (
   res: Response,
   next: NextFunction,
 ): Promise<void> => {
+  const span = startAuditSpan("audit.admin.search", req, res);
   try {
     const parseResult = searchAuditSchema.safeParse(req.body);
     const reqId = getRequestId() ?? (req as { id?: string }).id ?? "unknown";
 
     if (!parseResult.success) {
+      endAuditSpan(span, res);
       res.status(400).json({
         error: {
           code: "validation_error",
@@ -57,11 +60,13 @@ export const searchAuditLogsHandler = async (
 
     const page = await getAuditLogs(filters);
 
+    endAuditSpan(span, res);
     res.json({
       data: page.data,
       nextCursor: page.nextCursor,
     });
   } catch (e) {
+    recordErrorOnSpan(span, e);
     next(e);
   }
 };

--- a/src/routes/admin/audit/search.ts
+++ b/src/routes/admin/audit/search.ts
@@ -35,8 +35,9 @@ export const searchAuditLogsHandler = async (
     const reqId = getRequestId() ?? (req as { id?: string }).id ?? "unknown";
 
     if (!parseResult.success) {
+      res.status(400);
       endAuditSpan(span, res);
-      res.status(400).json({
+      res.json({
         error: {
           code: "validation_error",
           message: parseResult.error.issues[0]?.message ?? "invalid payload parameters",

--- a/src/routes/marketAudit.ts
+++ b/src/routes/marketAudit.ts
@@ -6,6 +6,7 @@ import { markets, marketAuditLog } from "../db/schema";
 import { clampLimit, decodeCursor, encodeCursor } from "../utils/cursor";
 import { logger } from "../config/logger";
 import { RouteErrorFactory } from "../errors";
+import { startAuditSpan, endAuditSpan, recordErrorOnSpan } from "../otel/spans";
 
 const auditQuerySchema = z
   .object({
@@ -20,6 +21,7 @@ const auditQuerySchema = z
 export const marketAuditRouter = Router({ mergeParams: true });
 
 marketAuditRouter.get("/", async (req, res, next) => {
+  const span = startAuditSpan("audit.market.list", req, res);
   const reqId = String((req as { id?: string }).id ?? "anon");
   try {
     const parsed = auditQuerySchema.safeParse(req.query);
@@ -28,6 +30,8 @@ marketAuditRouter.get("/", async (req, res, next) => {
     }
 
     const marketId = (req.params as Record<string, string>).id;
+    span.setAttribute("market.id", marketId);
+
     const exists = await db
       .select({ id: markets.id })
       .from(markets)
@@ -67,6 +71,7 @@ marketAuditRouter.get("/", async (req, res, next) => {
 
     logger.info({ reqId, marketId, count: data.length }, "market_audit_listed");
 
+    endAuditSpan(span, res);
     return res.json({
       data,
       nextCursor:
@@ -75,6 +80,7 @@ marketAuditRouter.get("/", async (req, res, next) => {
           : null,
     });
   } catch (err) {
+    recordErrorOnSpan(span, err);
     return next(err);
   }
 });

--- a/tests/otel/spans.test.ts
+++ b/tests/otel/spans.test.ts
@@ -1,0 +1,174 @@
+import { startAuditSpan, endAuditSpan, recordErrorOnSpan } from "../../src/otel/spans";
+import { SpanStatusCode, SpanKind } from "@opentelemetry/api";
+
+jest.mock("../../src/otel/tracer", () => ({
+  getTracer: jest.fn(),
+}));
+
+jest.mock("../../src/lib/requestContext", () => ({
+  getRequestId: jest.fn(() => "ctx-request-id"),
+}));
+
+import { getTracer } from "../../src/otel/tracer";
+import { getRequestId } from "../../src/lib/requestContext";
+
+function createMockSpan() {
+  return {
+    setAttribute: jest.fn(),
+    setStatus: jest.fn(),
+    end: jest.fn(),
+    recordException: jest.fn(),
+  };
+}
+
+function createMockReq(overrides = {}) {
+  return {
+    method: "GET",
+    path: "/api/admin/audit",
+    ...overrides,
+  } as any;
+}
+
+function createMockRes(overrides = {}) {
+  return {
+    statusCode: 200,
+    locals: {},
+    ...overrides,
+  } as any;
+}
+
+describe("otel/spans", () => {
+  let mockSpan: ReturnType<typeof createMockSpan>;
+  let mockTracer: { startSpan: jest.Mock };
+
+  beforeEach(() => {
+    mockSpan = createMockSpan();
+    mockTracer = { startSpan: jest.fn(() => mockSpan) };
+    (getTracer as jest.Mock).mockReturnValue(mockTracer);
+    (getRequestId as jest.Mock).mockReturnValue("ctx-request-id");
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("startAuditSpan", () => {
+    it("starts a span with the given name and SERVER kind", () => {
+      const req = createMockReq();
+      const res = createMockRes();
+
+      const span = startAuditSpan("audit.market.list", req, res);
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith(
+        "audit.market.list",
+        expect.objectContaining({ kind: SpanKind.SERVER }),
+      );
+      expect(span).toBe(mockSpan);
+    });
+
+    it("sets http.method and http.path attributes from the request", () => {
+      const req = createMockReq({ method: "POST", path: "/api/admin/audit/search" });
+      const res = createMockRes();
+
+      startAuditSpan("audit.admin.search", req, res);
+
+      const [, options] = mockTracer.startSpan.mock.calls[0];
+      expect(options.attributes["http.method"]).toBe("POST");
+      expect(options.attributes["http.path"]).toBe("/api/admin/audit/search");
+    });
+
+    it("uses correlationId from res.locals when present", () => {
+      const req = createMockReq();
+      const res = createMockRes({ locals: { correlationId: "corr-123" } });
+
+      startAuditSpan("audit.market.list", req, res);
+
+      const [, options] = mockTracer.startSpan.mock.calls[0];
+      expect(options.attributes["correlation.id"]).toBe("corr-123");
+    });
+
+    it("falls back to getRequestId() when res.locals.correlationId is missing", () => {
+      const req = createMockReq();
+      const res = createMockRes({ locals: {} });
+
+      startAuditSpan("audit.market.list", req, res);
+
+      const [, options] = mockTracer.startSpan.mock.calls[0];
+      expect(options.attributes["correlation.id"]).toBe("ctx-request-id");
+    });
+
+    it("falls back to unknown when neither correlationId source is available", () => {
+      (getRequestId as jest.Mock).mockReturnValue(undefined);
+      const req = createMockReq();
+      const res = createMockRes({ locals: {} });
+
+      startAuditSpan("audit.market.list", req, res);
+
+      const [, options] = mockTracer.startSpan.mock.calls[0];
+      expect(options.attributes["correlation.id"]).toBe("unknown");
+    });
+
+    it("merges extraAttrs into the span attributes", () => {
+      const req = createMockReq();
+      const res = createMockRes();
+
+      startAuditSpan("audit.market.get", req, res, { marketId: "m-1" });
+
+      const [, options] = mockTracer.startSpan.mock.calls[0];
+      expect(options.attributes.marketId).toBe("m-1");
+    });
+  });
+
+  describe("endAuditSpan", () => {
+    it("sets http.status_code and OK status for a successful response", () => {
+      const res = createMockRes({ statusCode: 200 });
+
+      endAuditSpan(mockSpan as any, res);
+
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith("http.status_code", 200);
+      expect(mockSpan.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.OK });
+      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+    });
+
+    it("sets ERROR status for a 4xx/5xx response", () => {
+      const res = createMockRes({ statusCode: 404 });
+
+      endAuditSpan(mockSpan as any, res);
+
+      expect(mockSpan.setStatus).toHaveBeenCalledWith({
+        code: SpanStatusCode.ERROR,
+        message: "HTTP 404",
+      });
+      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("recordErrorOnSpan", () => {
+    it("records an Error instance directly", () => {
+      const err = new Error("boom");
+
+      recordErrorOnSpan(mockSpan as any, err);
+
+      expect(mockSpan.recordException).toHaveBeenCalledWith(err);
+      expect(mockSpan.setStatus).toHaveBeenCalledWith({
+        code: SpanStatusCode.ERROR,
+        message: "boom",
+      });
+    });
+
+    it("wraps a non-Error value in an Error before recording", () => {
+      recordErrorOnSpan(mockSpan as any, "string failure");
+
+      expect(mockSpan.recordException).toHaveBeenCalledWith(expect.any(Error));
+      expect(mockSpan.setStatus).toHaveBeenCalledWith({
+        code: SpanStatusCode.ERROR,
+        message: "string failure",
+      });
+    });
+
+    it("does not call span.end()", () => {
+      recordErrorOnSpan(mockSpan as any, new Error("x"));
+      expect(mockSpan.end).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Before implementing, I checked the codebase and found there was no existing OTel infrastructure at all - no packages installed, no tracer setup, nothing. What did already exist and is reused here: the correlation ID system (res.locals.correlationId / getRequestId()), and the standardized error envelope pattern. Rather than inventing new versions of either, this reuses both.

There are actually 4 audit handlers, not the one the issue's file paths suggested:

GET /api/markets/:id/audit (marketAudit.ts)
GET /api/admin/audit (admin/audit.ts)
POST /api/admin/audit/search (admin/audit/search.ts)
GET /api/admin/audit/export (admin/audit/export.ts)

All 4 are instrumented.

What's new:

src/otel/tracer.ts sets up a minimal tracer using @opentelemetry/api and @opentelemetry/sdk-trace-base, exporting spans to console/stdout for now. Wiring up a real OTLP exporter to an actual tracing backend (Jaeger, Honeycomb, etc.) is a natural follow-up, not something this PR does.

src/otel/spans.ts provides startAuditSpan, endAuditSpan, and recordErrorOnSpan helpers, with correlation ID and method/path attributes set automatically.

Each of the 4 handlers now starts a span, sets relevant attributes (including things like market ID where relevant), records exceptions on failure, and ends the span with the right status code.

The export endpoint is a stream, so its span doesn't end when the handler function returns, it ends when the response stream actually finishes (covering natural completion, client disconnect, and stream errors), so span duration reflects the real export time.

Tests: 11 new tests covering span creation, attribute population, correlation ID fallback behavior, and error recording.

A note on pre-existing issues: this repo's tsc --noEmit / npm run build currently reports 119 pre-existing TypeScript errors across 20 files, completely unrelated to this change (missing exports, duplicate imports in index.ts, drizzle-orm type mismatches, etc.). I verified this by running the exact same build on main before my changes, byte-for-byte identical error count and file list. Not something I've touched or attempted to fix here, since it's out of scope for #386.

Closes #386