### PR TITLE
feat(webhooks): enforce CORS allowlist on /api/webhooks

### DIFF
--- a/src/config/env-schema.ts
+++ b/src/config/env-schema.ts
@@ -44,6 +44,9 @@ const baseSchema = z.object({
   PG_POOL_MAX: z.coerce.number().int().positive().default(10),
   PG_STATEMENT_TIMEOUT_MS: z.coerce.number().int().positive().default(5000),
 
+  // ── Webhook CORS ─────────────────────────────────────────
+  WEBHOOK_CORS_ALLOWED_ORIGINS: z.string().default(""),
+
   // ── Geo-blocking ──────────────────────────────────────────
   GEO_BLOCKED_COUNTRIES: z.string().default("").transform((val) =>
     val.split(",").map((s) => s.trim().toUpperCase()).filter(Boolean),

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -1,0 +1,114 @@
+import type { NextFunction, Request, Response } from "express";
+import { env } from "../config/env";
+import { logger } from "../config/logger";
+
+export interface CorsAllowlistOptions {
+  allowedOrigins: string[];
+  allowCredentials?: boolean;
+  maxAgeSeconds?: number;
+}
+
+function parseOrigin(req: Request): string | undefined {
+  const origin = req.headers["origin"];
+  if (!origin || typeof origin !== "string") return undefined;
+  return origin.trim();
+}
+
+function isOriginAllowed(origin: string, allowedOrigins: string[]): boolean {
+  return allowedOrigins.includes(origin);
+}
+
+function denyOrigin(res: Response, message: string): void {
+  const correlationId =
+    (res.locals.correlationId as string) ?? "unknown";
+  res.status(403).json({
+    error: {
+      code: "forbidden",
+      message,
+      correlationId,
+    },
+  });
+}
+
+/**
+ * Creates an Express middleware that enforces a CORS allowlist.
+ *
+ * - Requests without a matching `Origin` header are denied with 403.
+ * - OPTIONS preflight requests from allowed origins are acknowledged with 204
+ *   and cached via `Access-Control-Max-Age`.
+ * - When the allowlist is empty **all** origins are denied (deny by default).
+ */
+export function createCorsAllowlistMiddleware(
+  options: CorsAllowlistOptions,
+) {
+  const { allowedOrigins, allowCredentials = true, maxAgeSeconds = 600 } = options;
+
+  if (!allowedOrigins.length) {
+    logger.warn("CORS allowlist is empty — all origins will be denied");
+  }
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const origin = parseOrigin(req);
+
+    if (!origin) {
+      logger.warn(
+        { path: req.path, method: req.method },
+        "CORS: missing Origin header",
+      );
+      denyOrigin(res, "Origin header is required");
+      return;
+    }
+
+    if (!isOriginAllowed(origin, allowedOrigins)) {
+      logger.warn(
+        { origin, path: req.path, method: req.method },
+        "CORS: origin not allowed",
+      );
+      denyOrigin(res, `Origin "${origin}" is not allowed`);
+      return;
+    }
+
+    res.setHeader("Access-Control-Allow-Origin", origin);
+    if (allowCredentials) {
+      res.setHeader("Access-Control-Allow-Credentials", "true");
+    }
+
+    if (req.method === "OPTIONS") {
+      res.setHeader(
+        "Access-Control-Allow-Methods",
+        "GET, POST, PATCH, DELETE, OPTIONS",
+      );
+      res.setHeader(
+        "Access-Control-Allow-Headers",
+        "Content-Type, Authorization, x-request-id",
+      );
+      res.setHeader("Access-Control-Max-Age", String(maxAgeSeconds));
+      res.status(204).end();
+      return;
+    }
+
+    next();
+  };
+}
+
+/**
+ * Pre-configured CORS middleware for the webhooks endpoint.
+ * Reads allowed origins from the `WEBHOOK_CORS_ALLOWED_ORIGINS` env variable.
+ */
+let webhookCorsMiddleware: ReturnType<typeof createCorsAllowlistMiddleware> | null = null;
+
+export function webhookCors(): ReturnType<typeof createCorsAllowlistMiddleware> {
+  if (!webhookCorsMiddleware) {
+    const raw = env.WEBHOOK_CORS_ALLOWED_ORIGINS ?? "";
+    const allowedOrigins = raw
+      .split(",")
+      .map((o) => o.trim())
+      .filter((o) => o.length > 0);
+    webhookCorsMiddleware = createCorsAllowlistMiddleware({
+      allowedOrigins,
+      allowCredentials: true,
+      maxAgeSeconds: 600,
+    });
+  }
+  return webhookCorsMiddleware;
+}

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { z } from "zod";
 import { logger } from "../config/logger";
 import { getRequestId } from "../lib/requestContext";
+import { webhookCors } from "../middleware/cors";
 import { requireAdmin } from "../middleware/requireAdmin";
 import type { WebhookDelivery, WebhookStore } from "../services/webhookStore";
 
@@ -42,6 +43,9 @@ function serializeDelivery(row: WebhookDelivery) {
 export function createWebhooksRouter(deps: WebhooksRouterDeps): Router {
   const router = Router();
 
+  // Enforce CORS allowlist before admin auth so unapproved origins are
+  // rejected early without leaking auth challenge details.
+  router.use(webhookCors());
   router.use(requireAdmin);
 
   router.get("/", async (req, res, next) => {

--- a/tests/cors.test.ts
+++ b/tests/cors.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "@jest/globals";
+import request from "supertest";
+import express from "express";
+import { createCorsAllowlistMiddleware } from "../src/middleware/cors";
+import { errorHandler } from "../src/middleware/errorHandler";
+
+function buildApp(allowedOrigins: string[]) {
+  const app = express();
+  app.use(express.json());
+  const corsMw = createCorsAllowlistMiddleware({ allowedOrigins });
+  app.use("/test", corsMw, (_req, res) => {
+    res.json({ success: true });
+  });
+  app.use(errorHandler);
+  return app;
+}
+
+describe("createCorsAllowlistMiddleware", () => {
+  describe("origin validation", () => {
+    it("allows requests from an allowed origin", async () => {
+      const app = buildApp(["https://trusted.example.com"]);
+      const res = await request(app)
+        .post("/test")
+        .set("Origin", "https://trusted.example.com")
+        .send({});
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+
+    it("sets Access-Control-Allow-Origin header", async () => {
+      const app = buildApp(["https://trusted.example.com"]);
+      const res = await request(app)
+        .post("/test")
+        .set("Origin", "https://trusted.example.com")
+        .send({});
+      expect(res.headers["access-control-allow-origin"]).toBe(
+        "https://trusted.example.com",
+      );
+    });
+
+    it("denies requests from an origin not in the allowlist", async () => {
+      const app = buildApp(["https://trusted.example.com"]);
+      const res = await request(app)
+        .post("/test")
+        .set("Origin", "https://evil.example.com")
+        .send({});
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe("forbidden");
+    });
+
+    it("denies requests with no Origin header", async () => {
+      const app = buildApp(["https://trusted.example.com"]);
+      const res = await request(app).post("/test").send({});
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe("forbidden");
+    });
+
+    it("denies all origins when allowlist is empty", async () => {
+      const app = buildApp([]);
+      const res = await request(app)
+        .post("/test")
+        .set("Origin", "https://trusted.example.com")
+        .send({});
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("preflight handling", () => {
+    it("responds with 204 for allowed OPTIONS preflight", async () => {
+      const app = buildApp(["https://trusted.example.com"]);
+      const res = await request(app)
+        .options("/test")
+        .set("Origin", "https://trusted.example.com");
+      expect(res.status).toBe(204);
+    });
+
+    it("sets Access-Control-Max-Age on preflight response", async () => {
+      const app = buildApp(["https://trusted.example.com"]);
+      const res = await request(app)
+        .options("/test")
+        .set("Origin", "https://trusted.example.com");
+      expect(res.headers["access-control-max-age"]).toBe("600");
+    });
+
+    it("sets Access-Control-Allow-Methods on preflight", async () => {
+      const app = buildApp(["https://trusted.example.com"]);
+      const res = await request(app)
+        .options("/test")
+        .set("Origin", "https://trusted.example.com");
+      expect(res.headers["access-control-allow-methods"]).toBeDefined();
+    });
+
+    it("denies preflight from disallowed origin", async () => {
+      const app = buildApp(["https://trusted.example.com"]);
+      const res = await request(app)
+        .options("/test")
+        .set("Origin", "https://evil.example.com");
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("credentials support", () => {
+    it("sets Access-Control-Allow-Credentials when enabled", async () => {
+      const app = buildApp(["https://trusted.example.com"]);
+      const res = await request(app)
+        .post("/test")
+        .set("Origin", "https://trusted.example.com")
+        .send({});
+      expect(res.headers["access-control-allow-credentials"]).toBe("true");
+    });
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -5,3 +5,4 @@ process.env.JWT_SECRET = "test-jwt-secret-that-is-at-least-32-chars!";
 process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
 process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
 process.env.PREDICTIFY_CONTRACT_ID = "CTEST0000000000000000000000000000000000000000000000000000";
+process.env.WEBHOOK_CORS_ALLOWED_ORIGINS = "http://localhost:5173,https://admin.predictify.dev";


### PR DESCRIPTION
## Overview

This PR adds a dedicated CORS allowlist enforcement middleware and applies it to the \/api/webhooks\ endpoint. Requests from origins not present in the \WEBHOOK_CORS_ALLOWED_ORIGINS\ environment variable are denied with a **403 Forbidden** response before reaching the admin auth layer. The middleware handles OPTIONS preflight with caching headers and defaults to denying all origins when the allowlist is empty.

## Related Issue

Closes #464

## Changes

### 🔒 CORS Allowlist Middleware

- **\[ADD\]** \src/middleware/cors.ts\ — Express middleware factory with:
  - Origin validation against a configurable allowlist
  - Deny-by-default when allowlist is empty
  - 403 error envelope for denied origins (code: \orbidden\)
  - OPTIONS preflight handling with \Access-Control-Max-Age\ caching (10 min)
  - \Access-Control-Allow-Credentials\ support
  - Structured logging with correlation IDs
  - Pre-configured \webhookCors()\ reading from \WEBHOOK_CORS_ALLOWED_ORIGINS\ env var
- **\[MODIFY\]** \src/routes/webhooks.ts\ — Apply CORS middleware before admin auth so unapproved origins are rejected early without leaking auth challenge details
- **\[MODIFY\]** \src/config/env-schema.ts\ — Add \WEBHOOK_CORS_ALLOWED_ORIGINS\ env variable (default empty, denying all)
- **\[ADD\]** \	ests/cors.test.ts\ — 10 focused tests covering:
  - Allowed origins pass through
  - Denied origins receive 403
  - Missing origin header receives 403
  - Empty allowlist denies all by default
  - OPTIONS preflight returns 204 with caching headers
  - Preflight from disallowed origin denied
  - Credentials header set when enabled
- **\[MODIFY\]** \	ests/setup.ts\ — Set \WEBHOOK_CORS_ALLOWED_ORIGINS\ for test environment so existing tests continue to pass

## Verification Results

| Acceptance Criteria | Status |
|--|--|
| Allowed origins pass CORS check | ✅ 10/10 middleware tests pass |
| Denied origins receive 403 | ✅ Verified with expected error envelope |
| Empty allowlist denies all by default | ✅ Verified (deny-by-default) |
| Preflight cached with \Access-Control-Max-Age\ | ✅ 204 + max-age=600 |
| Lint passes | ✅ No ESLint errors |