### PR TITLE
Add graceful timeout on /api/leaderboard

### DIFF
--- a/src/middleware/timeout.ts
+++ b/src/middleware/timeout.ts
@@ -1,13 +1,34 @@
 import { Request, Response, NextFunction } from "express";
 
+export interface RequestTimeoutOptions {
+  /** HTTP status code to send when the timeout is exceeded. Defaults to 408. */
+  statusCode?: number;
+  /** Machine-readable error code included in the response envelope. Defaults to "timeout". */
+  code?: string;
+  /** Human-readable message included in the response envelope. */
+  message?: string;
+}
+
 /**
  * Creates an Express middleware that enforces a maximum request duration.
  * If the route handler does not finish before `timeoutMs`, the request is
- * aborted gracefully with a 408 Request Timeout error envelope.
+ * aborted gracefully with an error envelope (408 Request Timeout by default).
+ *
+ * The AbortSignal exposed on `res.locals.abortSignal` lets downstream route
+ * handlers cooperatively stop waiting on in-flight work (e.g. via
+ * `abortableRace`) once the deadline is reached or the client disconnects,
+ * instead of forcibly killing the underlying operation.
  *
  * @param timeoutMs - Time in milliseconds before the request times out
+ * @param options - Overrides for the status code / error code / message sent on timeout
  */
-export function requestTimeout(timeoutMs: number) {
+export function requestTimeout(timeoutMs: number, options: RequestTimeoutOptions = {}) {
+  const {
+    statusCode = 408,
+    code = "timeout",
+    message = "Request timeout exceeded",
+  } = options;
+
   return (req: Request, res: Response, next: NextFunction) => {
     let settled = false;
     const controller = new AbortController();
@@ -31,10 +52,10 @@ export function requestTimeout(timeoutMs: number) {
       abort();
       if (!res.headersSent) {
         const correlationId = (res.locals.correlationId as string) || "unknown";
-        res.status(408).json({
+        res.status(statusCode).json({
           error: {
-            code: "timeout",
-            message: "Request timeout exceeded",
+            code,
+            message,
             requestId: correlationId,
           },
         });
@@ -50,4 +71,40 @@ export function requestTimeout(timeoutMs: number) {
 
     next();
   };
+}
+
+/** Thrown by `abortableRace` when the given signal fires before the promise settles. */
+export class RequestAbortedError extends Error {
+  constructor(message = "Request aborted before completion") {
+    super(message);
+    this.name = "RequestAbortedError";
+  }
+}
+
+/**
+ * Races `promise` against `signal`. If `signal` aborts first, the returned
+ * promise rejects with `RequestAbortedError` so the caller can stop waiting
+ * on (and acting on the result of) work that the timeout middleware has
+ * already given up on — cooperative cancellation rather than a hard kill of
+ * the underlying operation.
+ */
+export function abortableRace<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(new RequestAbortedError());
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new RequestAbortedError());
+    signal.addEventListener("abort", onAbort, { once: true });
+
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
 }

--- a/src/routes/leaderboard.ts
+++ b/src/routes/leaderboard.ts
@@ -3,10 +3,27 @@ import { z } from "zod";
 import { getLeaderboard, getLeaderboardWithRefresh, getUserLeaderboardEntry } from "../services/leaderboardService";
 import { rateLimitAnon } from "../middleware/rateLimitAnon";
 import { RouteErrorFactory } from "../errors";
+import { abortableRace, requestTimeout, RequestAbortedError } from "../middleware/timeout";
+import { logger } from "../config/logger";
 
 export const leaderboardRouter = Router();
 
+/**
+ * Leaderboard reads hit a materialized view (and optionally trigger a
+ * synchronous REFRESH via `?refresh=true`), so a slow/locked view can hang
+ * the request far longer than a normal read. Bound it and fail with a 504
+ * rather than tying up the connection indefinitely.
+ */
+const LEADERBOARD_TIMEOUT_MS = 5000;
+
 leaderboardRouter.use(rateLimitAnon);
+leaderboardRouter.use(
+  requestTimeout(LEADERBOARD_TIMEOUT_MS, {
+    statusCode: 504,
+    code: "gateway_timeout",
+    message: "Leaderboard request timed out",
+  }),
+);
 
 export enum LeaderboardPeriod {
   ALL_TIME = "all-time",
@@ -24,14 +41,16 @@ const leaderboardQuerySchema = z.object({
 export type LeaderboardQuery = z.infer<typeof leaderboardQuerySchema>;
 
 leaderboardRouter.get("/", async (req, res, next) => {
+  const signal = res.locals.abortSignal as AbortSignal | undefined;
   try {
     const { limit, offset, refresh, period } = leaderboardQuerySchema.parse(req.query);
-    
-    const data = refresh 
-      ? await getLeaderboardWithRefresh(limit, offset, period)
-      : await getLeaderboard(limit, offset, period);
-    
-    res.json({ 
+
+    const fetch = refresh
+      ? getLeaderboardWithRefresh(limit, offset, period)
+      : getLeaderboard(limit, offset, period);
+    const data = await abortableRace(fetch, signal);
+
+    res.json({
       data,
       meta: {
         limit,
@@ -42,22 +61,39 @@ leaderboardRouter.get("/", async (req, res, next) => {
       }
     });
   } catch (e) {
+    if (e instanceof RequestAbortedError) {
+      // The timeout middleware already sent (or the client already dropped)
+      // the response; just stop working and log for observability.
+      logger.warn(
+        { correlationId: res.locals.correlationId, path: req.path },
+        "Abandoned /api/leaderboard request after timeout",
+      );
+      return;
+    }
     next(e);
   }
 });
 
 leaderboardRouter.get("/user/:stellarAddress", async (req, res, next) => {
+  const signal = res.locals.abortSignal as AbortSignal | undefined;
   try {
     const { period } = z.object({
       period: z.nativeEnum(LeaderboardPeriod).default(LeaderboardPeriod.ALL_TIME),
     }).parse(req.query);
 
-    const entry = await getUserLeaderboardEntry(req.params.stellarAddress, period);
+    const entry = await abortableRace(getUserLeaderboardEntry(req.params.stellarAddress, period), signal);
     if (!entry) {
       throw RouteErrorFactory.notFound("Leaderboard entry not found");
     }
     res.json({ data: entry });
   } catch (e) {
+    if (e instanceof RequestAbortedError) {
+      logger.warn(
+        { correlationId: res.locals.correlationId, path: req.path },
+        "Abandoned /api/leaderboard/user request after timeout",
+      );
+      return;
+    }
     next(e);
   }
 });

--- a/tests/leaderboardTimeout.test.ts
+++ b/tests/leaderboardTimeout.test.ts
@@ -1,0 +1,76 @@
+process.env.NODE_ENV = "test";
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgresql://test:test@localhost:5432/predictify_test";
+process.env.JWT_SECRET = "test-jwt-secret-that-is-at-least-32-chars!";
+process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "CTEST0000000000000000000000000000000000000000000000000000";
+
+jest.mock("../src/services/leaderboardService");
+
+import request from "supertest";
+import express from "express";
+import { leaderboardRouter } from "../src/routes/leaderboard";
+import * as leaderboardService from "../src/services/leaderboardService";
+
+const mockGetLeaderboard = leaderboardService.getLeaderboard as jest.MockedFunction<
+  typeof leaderboardService.getLeaderboard
+>;
+
+describe("GET /api/leaderboard timeout handling", () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    app.use("/api/leaderboard", leaderboardRouter);
+  });
+
+  it(
+    "responds 504 with a standardized error envelope when the service call hangs past the deadline",
+    async () => {
+      mockGetLeaderboard.mockImplementationOnce(() => new Promise(() => {}));
+
+      const res = await request(app).get("/api/leaderboard");
+
+      expect(res.status).toBe(504);
+      expect(res.body).toEqual({
+        error: {
+          code: "gateway_timeout",
+          message: "Leaderboard request timed out",
+          requestId: expect.any(String),
+        },
+      });
+    },
+    8000,
+  );
+
+  it(
+    "does not throw or double-respond when the hung call resolves after the timeout has already fired",
+    async () => {
+      let resolveLate: (value: leaderboardService.LeaderboardEntry[]) => void = () => {};
+      mockGetLeaderboard.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveLate = resolve;
+          }),
+      );
+
+      const res = await request(app).get("/api/leaderboard");
+      expect(res.status).toBe(504);
+
+      resolveLate([]);
+      await new Promise((r) => setTimeout(r, 50));
+    },
+    8000,
+  );
+
+  it("responds normally within the deadline when the service resolves quickly", async () => {
+    mockGetLeaderboard.mockResolvedValueOnce([]);
+
+    const res = await request(app).get("/api/leaderboard");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+});

--- a/tests/middleware/timeout.test.ts
+++ b/tests/middleware/timeout.test.ts
@@ -1,4 +1,4 @@
-import { requestTimeout } from "../../src/middleware/timeout";
+import { abortableRace, RequestAbortedError, requestTimeout } from "../../src/middleware/timeout";
 import { Request, Response, NextFunction } from "express";
 
 describe("requestTimeout Middleware", () => {
@@ -57,5 +57,55 @@ describe("requestTimeout Middleware", () => {
 
     expect(res.status).not.toHaveBeenCalled();
     expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it("honors a custom statusCode/code/message, e.g. 504 for gateway timeouts", () => {
+    const middleware = requestTimeout(1000, {
+      statusCode: 504,
+      code: "gateway_timeout",
+      message: "Leaderboard request timed out",
+    });
+    middleware(req as Request, res as Response, next);
+
+    jest.advanceTimersByTime(1000);
+
+    expect(res.status).toHaveBeenCalledWith(504);
+    expect(res.json).toHaveBeenCalledWith({
+      error: {
+        code: "gateway_timeout",
+        message: "Leaderboard request timed out",
+        requestId: "test-req-id",
+      },
+    });
+  });
+});
+
+describe("abortableRace", () => {
+  it("resolves with the promise's value when it settles before the signal aborts", async () => {
+    const controller = new AbortController();
+    await expect(abortableRace(Promise.resolve("ok"), controller.signal)).resolves.toBe("ok");
+  });
+
+  it("passes through the original promise when no signal is given", async () => {
+    await expect(abortableRace(Promise.resolve("ok"))).resolves.toBe("ok");
+  });
+
+  it("rejects with RequestAbortedError once the signal aborts, ignoring the original promise", async () => {
+    const controller = new AbortController();
+    const neverResolves = new Promise(() => {});
+
+    const race = abortableRace(neverResolves, controller.signal);
+    controller.abort();
+
+    await expect(race).rejects.toBeInstanceOf(RequestAbortedError);
+  });
+
+  it("rejects immediately if the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(abortableRace(Promise.resolve("ok"), controller.signal)).rejects.toBeInstanceOf(
+      RequestAbortedError,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- `GET /api/leaderboard` and `GET /api/leaderboard/user/:stellarAddress` now enforce a 5s per-request deadline. If the underlying service call (materialized-view read, or the synchronous `REFRESH MATERIALIZED VIEW` triggered by `?refresh=true`) doesn't finish in time, the request fails fast with `504 Gateway Timeout` instead of hanging.
- `requestTimeout` (src/middleware/timeout.ts) now takes an optional `{ statusCode, code, message }` so callers can customize the response instead of the previously hardcoded 408. Existing usages (`authRouter`, `usersRouter`) are unchanged (still default to 408).
- Added `abortableRace`, a small helper that races a promise against the middleware's `AbortSignal` so the route handler cooperatively stops waiting on (and acting on) a hung service call once the deadline fires, rather than writing a second response or operating on stale data after the client has already gotten a 504.
- Correlation-ID-tagged structured log line (`logger.warn`) when a request is abandoned after timeout, for observability.

## Why 504 instead of the existing 408 default
The generic `requestTimeout` default (408) is used elsewhere for "client took too long" semantics. For `/api/leaderboard` the slow part is server-side (DB/materialized view), so per the issue this endpoint specifically returns 504.

## Files changed
- `src/middleware/timeout.ts` — configurable status/code/message + `abortableRace` + `RequestAbortedError`
- `src/routes/leaderboard.ts` — wires the 504 timeout + cooperative abort into both leaderboard routes
- `tests/middleware/timeout.test.ts` — covers the new options param and `abortableRace`
- `tests/leaderboardTimeout.test.ts` — end-to-end supertest coverage: 504 on a hung service call, no crash/double-response when the stale call resolves late, and normal 200 within the deadline

## Test plan
- [x] `npx jest tests/middleware/timeout.test.ts tests/leaderboardTimeout.test.ts` — 11/11 passing
- [x] `npx eslint src/routes/leaderboard.ts src/middleware/timeout.ts tests/leaderboardTimeout.test.ts tests/middleware/timeout.test.ts` — clean
- [x] `npx tsc -p tsconfig.json --noEmit` — no new errors introduced by these files (checked by diffing against pre-existing repo-wide errors)

Closes #489