### PR TITLE
Fix: Add /api/analytics/summary aggregate (Auto-Generated)

### DIFF
--- a/docs/analytics-summary.md
+++ b/docs/analytics-summary.md
@@ -1,0 +1,26 @@
+# Analytics Summary API
+
+## `GET /api/analytics/summary`
+
+Returns system-wide aggregate analytics for the application.
+
+### Response
+
+Successful responses use the standard `{ data }` envelope:
+
+```json
+{
+  "data": {
+    "totalUsers": 12,
+    "totalMarkets": 8,
+    "activeMarkets": 5,
+    "resolvedMarkets": 3,
+    "totalPredictions": 42,
+    "totalVolume": "1234.5600000"
+  }
+}
+```
+
+`totalVolume` is returned as a string to preserve PostgreSQL numeric precision.
+
+The endpoint does not accept query parameters. Unsupported parameters return `400` with the standard `validation_error` envelope. Requests and responses include the `x-correlation-id` header for tracing; a correlation ID is generated when one is not supplied.

--- a/src/__tests__/routes/analyticsSummary.test.ts
+++ b/src/__tests__/routes/analyticsSummary.test.ts
@@ -1,0 +1,98 @@
+import express from "express";
+import request from "supertest";
+import { db } from "../../db/client";
+import { errorHandler } from "../../middleware/errorHandler";
+import { createAnalyticsSummaryRouter } from "../../routes/analytics/summary";
+
+jest.mock("../../db/client", () => ({
+  db: {
+    execute: jest.fn(),
+  },
+}));
+
+jest.mock("../../config/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const execute = db.execute as jest.MockedFunction<typeof db.execute>;
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use("/api/analytics/summary", createAnalyticsSummaryRouter());
+  app.use(errorHandler);
+  return app;
+}
+
+describe("GET /api/analytics/summary", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the aggregate summary in the standard data envelope", async () => {
+    execute.mockResolvedValueOnce({
+      rows: [
+        {
+          total_users: "12",
+          total_markets: "8",
+          active_markets: "5",
+          resolved_markets: "3",
+          total_predictions: "42",
+          total_volume: "1234.5600000",
+        },
+      ],
+    } as never);
+
+    const response = await request(makeApp())
+      .get("/api/analytics/summary")
+      .set("x-correlation-id", "analytics-test-1");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["x-correlation-id"]).toBe("analytics-test-1");
+    expect(response.body).toEqual({
+      data: {
+        totalUsers: 12,
+        totalMarkets: 8,
+        activeMarkets: 5,
+        resolvedMarkets: 3,
+        totalPredictions: 42,
+        totalVolume: "1234.5600000",
+      },
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns zero values when the aggregate query has no row", async () => {
+    execute.mockResolvedValueOnce({ rows: [] } as never);
+
+    const response = await request(makeApp()).get("/api/analytics/summary");
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toEqual({
+      totalUsers: 0,
+      totalMarkets: 0,
+      activeMarkets: 0,
+      resolvedMarkets: 0,
+      totalPredictions: 0,
+      totalVolume: "0",
+    });
+  });
+
+  it("rejects unsupported query parameters at the boundary", async () => {
+    const response = await request(makeApp()).get("/api/analytics/summary?from=2026-01-01");
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe("validation_error");
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("passes database failures to the standard error handler", async () => {
+    execute.mockRejectedValueOnce(new Error("database unavailable"));
+
+    const response = await request(makeApp()).get("/api/analytics/summary");
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/src/routes/analytics/summary.ts
+++ b/src/routes/analytics/summary.ts
@@ -1,0 +1,109 @@
+import { Router, type NextFunction, type Request, type Response } from "express";
+import { sql } from "drizzle-orm";
+import { db } from "../../db/client";
+import { logger } from "../../config/logger";
+
+interface AnalyticsSummaryRow {
+  total_users: string | number;
+  total_markets: string | number;
+  active_markets: string | number;
+  resolved_markets: string | number;
+  total_predictions: string | number;
+  total_volume: string | number | null;
+}
+
+export interface AnalyticsSummary {
+  totalUsers: number;
+  totalMarkets: number;
+  activeMarkets: number;
+  resolvedMarkets: number;
+  totalPredictions: number;
+  totalVolume: string;
+}
+
+function correlationIdFor(request: Request): string {
+  const header = request.header("x-correlation-id");
+  return header && header.trim().length > 0 ? header.trim() : crypto.randomUUID();
+}
+
+function integerValue(value: string | number | null | undefined): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function decimalValue(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return "0";
+  }
+
+  return String(value);
+}
+
+function validateQuery(request: Request, response: Response): boolean {
+  const keys = Object.keys(request.query);
+  if (keys.length === 0) {
+    return true;
+  }
+
+  response.status(400).json({
+    error: {
+      code: "validation_error",
+      message: "The analytics summary endpoint does not accept query parameters",
+      details: keys.map((key) => ({ path: [key], message: "Unknown query parameter" })),
+    },
+  });
+  return false;
+}
+
+async function getSummary(request: Request, response: Response, next: NextFunction): Promise<void> {
+  const correlationId = correlationIdFor(request);
+  response.setHeader("x-correlation-id", correlationId);
+
+  if (!validateQuery(request, response)) {
+    return;
+  }
+
+  try {
+    const result = await db.execute<AnalyticsSummaryRow>(sql`
+      SELECT
+        (SELECT COUNT(*) FROM users) AS total_users,
+        (SELECT COUNT(*) FROM markets) AS total_markets,
+        (SELECT COUNT(*) FROM markets WHERE status = 'active') AS active_markets,
+        (SELECT COUNT(*) FROM markets WHERE status = 'resolved') AS resolved_markets,
+        (SELECT COUNT(*) FROM predictions) AS total_predictions,
+        (SELECT COALESCE(SUM(amount), 0) FROM predictions) AS total_volume
+    `);
+
+    const row = result.rows[0] ?? {
+      total_users: 0,
+      total_markets: 0,
+      active_markets: 0,
+      resolved_markets: 0,
+      total_predictions: 0,
+      total_volume: "0",
+    };
+
+    const data: AnalyticsSummary = {
+      totalUsers: integerValue(row.total_users),
+      totalMarkets: integerValue(row.total_markets),
+      activeMarkets: integerValue(row.active_markets),
+      resolvedMarkets: integerValue(row.resolved_markets),
+      totalPredictions: integerValue(row.total_predictions),
+      totalVolume: decimalValue(row.total_volume),
+    };
+
+    logger.info({ correlationId, event: "analytics.summary.read" }, "Analytics summary generated");
+    response.json({ data });
+  } catch (error) {
+    logger.error({ correlationId, err: error, event: "analytics.summary.error" }, "Failed to generate analytics summary");
+    next(error);
+  }
+}
+
+export function createAnalyticsSummaryRouter(): Router {
+  const router = Router();
+  router.get("/", getSummary);
+  return router;
+}
+
+export const analyticsSummaryRouter = createAnalyticsSummaryRouter();


### PR DESCRIPTION
Closes #294

This PR was generated by the DripTide AI coder and scoped strictly to issue #294.

### Changes
Added a system-wide analytics summary router with aggregate user, market, prediction, and volume metrics; added focused route tests covering successful responses, empty results, query validation, and database failures; documented the new API endpoint and response contract.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #294` so the Drips Wave bot resolves the issue on merge._