### PR TITLE
feat: add ETag/304 conditional GET caching to /api/users

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ current — this cuts bandwidth for clients that poll frequently. Implemented in
 Currently applied to:
 
 - `GET /api/markets` / `GET /api/markets/:id`
+- `GET /api/users` / `GET /api/users/me` / `GET /api/users/:address/predictions` /
+  `GET /api/users/:stellarAddress/profile`
 - `GET /api/auth/*` (session-derived responses)
 - `GET /api/indexer/health` — cursor/chain-tip lag rarely changes between polls, so
   monitoring/orchestrator probes that hit this endpoint on a tight interval get a

--- a/docs/users-api.md
+++ b/docs/users-api.md
@@ -1,0 +1,94 @@
+# Users API
+
+## `GET /api/users`
+
+Returns a cursor-paginated list of registered users, ordered newest-first
+(`createdAt DESC, id DESC`).
+
+### Query Parameters
+
+| Parameter | Type   | Required | Default | Constraints  | Description                                                    |
+|-----------|--------|----------|---------|--------------|----------------------------------------------------------------|
+| `limit`   | number | no       | `20`    | 1-100        | Number of rows to return per page.                             |
+| `cursor`  | string | no       | --      | opaque token | Cursor from the previous page's `nextCursor`. Absent = page 1. |
+
+### Pagination
+
+This endpoint uses **keyset (cursor) pagination** on `(createdAt DESC, id DESC)`.
+
+- Pass the returned `nextCursor` verbatim as `?cursor=` to fetch the next page.
+- `nextCursor` is `null` on the last page.
+- Cursors are versioned. A stale or tampered cursor is safely ignored (the
+  response restarts from page 1) rather than causing a 500 or a wrong offset.
+
+### Response
+
+`200 OK`
+
+```json
+{
+  "data": [
+    {
+      "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      "stellarAddress": "GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW",
+      "createdAt": "2026-06-27T12:00:00.000Z"
+    }
+  ],
+  "nextCursor": "djF8MjR8..."
+}
+```
+
+### Errors
+
+- `400 validation_error` - invalid query parameters
+
+### Conditional requests and caching
+
+`GET /api/users` supports strong ETags for conditional revalidation. Every
+successful response includes an `ETag` header and `Cache-Control: no-cache`.
+Clients may send an `If-None-Match` header with the latest ETag to receive a
+`304 Not Modified` response without a body when the page has not changed.
+
+Example:
+
+```http
+GET /api/users
+If-None-Match: "<etag>"
+```
+
+## `GET /api/users/me`
+
+Returns the authenticated user's own profile. Requires a valid JWT.
+
+Supports strong ETag / `304` conditional GET on the `{ data: profile }` payload.
+
+## `GET /api/users/:address/predictions`
+
+Returns a cursor-paginated list of predictions for the given Stellar address.
+
+### Query Parameters
+
+| Parameter | Type   | Required | Default | Constraints                                      | Description                         |
+|-----------|--------|----------|---------|--------------------------------------------------|-------------------------------------|
+| `status`  | string | no       | --      | `pending`/`confirmed`/`won`/`lost`/`claimed`     | Filter by prediction status.        |
+| `limit`   | number | no       | `20`    | 1-100                                            | Page size.                          |
+| `cursor`  | string | no       | --      | opaque token                                     | Cursor from previous `nextCursor`.  |
+
+Supports strong ETag / `304` conditional GET on the `{ data, nextCursor }` payload.
+
+### Errors
+
+- `400 invalid_address` — path param is not a valid G… Stellar address
+- `400 validation_error` — query params fail validation
+- `404 not_found` — no user row for that address
+
+## `GET /api/users/:stellarAddress/profile`
+
+Returns the public profile for any Stellar address.
+
+Supports strong ETag / `304` conditional GET on the `{ data: profile }` payload.
+
+### Errors
+
+- `400 validation_error` — invalid Stellar address
+- `404 not_found` — no matching user row

--- a/src/__tests__/routes/users.test.ts
+++ b/src/__tests__/routes/users.test.ts
@@ -40,6 +40,11 @@ jest.mock("../../metrics/usersMetrics", () => ({
   usersMetricsMiddleware: (_req: any, _res: any, next: any) => next(),
 }));
 
+// Rate limit — no-op in tests
+jest.mock("../../middleware/rateLimit", () => ({
+  createPerUserRateLimiter: () => (_req: any, _res: any, next: any) => next(),
+}));
+
 // User service
 jest.mock("../../services/userService");
 import * as userService from "../../services/userService";
@@ -101,6 +106,86 @@ const MOCK_PREDICTION_PAGE = {
   ],
   nextCursor: null,
 };
+
+// ---------------------------------------------------------------------------
+// GET /api/users — ETag + 304 (list)
+// ---------------------------------------------------------------------------
+
+const MOCK_USERS_PAGE = {
+  data: [
+    {
+      id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      stellarAddress: VALID_ADDRESS,
+      createdAt: "2026-06-27T12:00:00.000Z",
+    },
+  ],
+  nextCursor: null as string | null,
+};
+
+describe("GET /api/users", () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = buildApp();
+  });
+
+  it("returns 200 with ETag and Cache-Control on first request", async () => {
+    (userService.listUsers as any).mockResolvedValueOnce(MOCK_USERS_PAGE);
+
+    const res = await request(app).get("/api/users");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(MOCK_USERS_PAGE.data);
+    expect(res.body.nextCursor).toBeNull();
+    expect(res.headers["etag"]).toMatch(/^"[a-f0-9]{64}"$/);
+    expect(res.headers["cache-control"]).toBe("no-cache");
+  });
+
+  it("returns 304 when If-None-Match matches current ETag", async () => {
+    (userService.listUsers as any).mockResolvedValueOnce(MOCK_USERS_PAGE);
+
+    const first = await request(app).get("/api/users");
+    const etag = first.headers["etag"] as string;
+
+    (userService.listUsers as any).mockResolvedValueOnce(MOCK_USERS_PAGE);
+
+    const second = await request(app).get("/api/users").set("If-None-Match", etag);
+
+    expect(second.status).toBe(304);
+    expect(second.text).toBe("");
+  });
+
+  it("returns 200 when If-None-Match does not match", async () => {
+    (userService.listUsers as any).mockResolvedValueOnce(MOCK_USERS_PAGE);
+
+    const res = await request(app)
+      .get("/api/users")
+      .set("If-None-Match", '"000000stale000000"');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(MOCK_USERS_PAGE.data);
+  });
+
+  it("ETag changes when list payload changes", async () => {
+    (userService.listUsers as any).mockResolvedValueOnce(MOCK_USERS_PAGE);
+    const first = await request(app).get("/api/users");
+
+    (userService.listUsers as any).mockResolvedValueOnce({
+      data: [],
+      nextCursor: null,
+    });
+    const second = await request(app).get("/api/users");
+
+    expect(first.headers["etag"]).not.toBe(second.headers["etag"]);
+  });
+
+  it("returns 400 for invalid limit", async () => {
+    const res = await request(app).get("/api/users").query({ limit: 0 });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+});
 
 // ---------------------------------------------------------------------------
 // GET /api/users/me — ETag + 304

--- a/src/openapi/registry.ts
+++ b/src/openapi/registry.ts
@@ -1468,7 +1468,9 @@ registry.registerPath({
     "Returns a cursor-paginated list of registered users sorted newest-first " +
     "(DESC createdAt, DESC id).  Pass the opaque `nextCursor` value from one " +
     "response as the `cursor` query parameter of the next request to advance " +
-    "through pages.  A null `nextCursor` indicates the last page.",
+    "through pages.  A null `nextCursor` indicates the last page. " +
+    "Supports strong ETag / conditional GET: send the ETag back as If-None-Match " +
+    "on subsequent requests; if the page is unchanged the server responds 304 Not Modified (no body).",
   request: {
     query: z.object({
       cursor: z.string().optional().openapi({
@@ -1483,10 +1485,26 @@ registry.registerPath({
         .default(20)
         .openapi({ description: "Page size (1–100, default 20)." }),
     }),
+    headers: z.object({
+      "if-none-match": z.string().optional().openapi({
+        description: "ETag from a previous 200 response. Triggers 304 when the page is unchanged.",
+        param: { name: "If-None-Match", in: "header" },
+      }),
+    }),
   },
   responses: {
     200: {
       description: "Paginated list of users",
+      headers: {
+        ETag: {
+          description: "Strong ETag (SHA-256) of the response body.",
+          schema: { type: "string" },
+        },
+        "Cache-Control": {
+          description: "Always no-cache so clients revalidate before reuse.",
+          schema: { type: "string", example: "no-cache" },
+        },
+      },
       content: {
         "application/json": {
           schema: z.object({
@@ -1506,6 +1524,9 @@ registry.registerPath({
         },
       },
     },
+    304: {
+      description: "Not Modified — page unchanged since the ETag in If-None-Match.",
+    },
     400: {
       description: "Validation error",
       content: { "application/json": { schema: ValidationErrorBody } },
@@ -1519,10 +1540,32 @@ registry.registerPath({
   operationId: "getCurrentUser",
   tags: ["Users"],
   summary: "Get the authenticated user\u2019s profile",
+  description:
+    "Returns the authenticated user's profile. Supports strong ETag / conditional GET: " +
+    "send the ETag back as If-None-Match on subsequent requests; if the profile is unchanged " +
+    "the server responds 304 Not Modified (no body).",
   security: [{ bearerAuth: [] }],
+  request: {
+    headers: z.object({
+      "if-none-match": z.string().optional().openapi({
+        description: "ETag from a previous 200 response. Triggers 304 when content is unchanged.",
+        param: { name: "If-None-Match", in: "header" },
+      }),
+    }),
+  },
   responses: {
     200: {
       description: "Current user profile",
+      headers: {
+        ETag: {
+          description: "Strong ETag (SHA-256) of the response body.",
+          schema: { type: "string" },
+        },
+        "Cache-Control": {
+          description: "Always no-cache so clients revalidate before reuse.",
+          schema: { type: "string", example: "no-cache" },
+        },
+      },
       content: {
         "application/json": {
           schema: z.object({ data: CurrentUserProfile }),
@@ -1542,6 +1585,9 @@ registry.registerPath({
           },
         },
       },
+    },
+    304: {
+      description: "Not Modified — profile unchanged since the ETag in If-None-Match.",
     },
     401: {
       description: "Unauthorized",
@@ -1570,6 +1616,9 @@ registry.registerPath({
   operationId: "getUserPredictions",
   tags: ["Users"],
   summary: "List predictions for a Stellar address",
+  description:
+    "Returns a cursor-paginated list of predictions. Supports strong ETag / conditional GET: " +
+    "send the ETag back as If-None-Match; if the page is unchanged the server responds 304 Not Modified (no body).",
   request: {
     params: z.object({ address: z.string() }),
     query: z.object({
@@ -1577,10 +1626,26 @@ registry.registerPath({
       cursor: z.string().optional(),
       limit: z.coerce.number().int().min(1).max(100).default(20),
     }),
+    headers: z.object({
+      "if-none-match": z.string().optional().openapi({
+        description: "ETag from a previous 200 response. Triggers 304 when the page is unchanged.",
+        param: { name: "If-None-Match", in: "header" },
+      }),
+    }),
   },
   responses: {
     200: {
       description: "Paginated predictions",
+      headers: {
+        ETag: {
+          description: "Strong ETag (SHA-256) of the response body.",
+          schema: { type: "string" },
+        },
+        "Cache-Control": {
+          description: "Always no-cache so clients revalidate before reuse.",
+          schema: { type: "string", example: "no-cache" },
+        },
+      },
       content: {
         "application/json": {
           schema: z.object({
@@ -1604,6 +1669,9 @@ registry.registerPath({
           },
         },
       },
+    },
+    304: {
+      description: "Not Modified — predictions page unchanged since the ETag in If-None-Match.",
     },
     400: {
       description: "Invalid address",
@@ -1650,10 +1718,31 @@ registry.registerPath({
   operationId: "getUserProfile",
   tags: ["Users"],
   summary: "Get a user\u2019s public profile",
-  request: { params: z.object({ stellarAddress: z.string() }) },
+  description:
+    "Returns a public user profile. Supports strong ETag / conditional GET: " +
+    "send the ETag back as If-None-Match; if the profile is unchanged the server responds 304 Not Modified (no body).",
+  request: {
+    params: z.object({ stellarAddress: z.string() }),
+    headers: z.object({
+      "if-none-match": z.string().optional().openapi({
+        description: "ETag from a previous 200 response. Triggers 304 when the profile is unchanged.",
+        param: { name: "If-None-Match", in: "header" },
+      }),
+    }),
+  },
   responses: {
     200: {
       description: "User profile",
+      headers: {
+        ETag: {
+          description: "Strong ETag (SHA-256) of the response body.",
+          schema: { type: "string" },
+        },
+        "Cache-Control": {
+          description: "Always no-cache so clients revalidate before reuse.",
+          schema: { type: "string", example: "no-cache" },
+        },
+      },
       content: {
         "application/json": {
           schema: z.object({ data: UserProfile }),

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -3,18 +3,26 @@
  *
  * Public user-facing routes:
  *
+ *   GET /api/users
+ *     Cursor-paginated list of registered users (DESC createdAt, DESC id).
+ *     Query: cursor?, limit (default 20, max 100)
+ *     Supports strong ETag / 304 conditional GET.
+ *
  *   GET /api/users/me
  *     Returns the authenticated user's own profile.  Requires a valid JWT
  *     (responds 403 on missing/invalid token via `requireAuthForbidden`).
+ *     Supports strong ETag / 304 conditional GET.
  *
  *   GET /api/users/:address/predictions
  *     Returns a cursor-paginated list of predictions for the given Stellar
  *     address.  The address must be a valid Stellar public key (G…).
  *     Query: status?, cursor?, limit (default 20, max 100)
+ *     Supports strong ETag / 304 conditional GET.
  *
  *   GET /api/users/:stellarAddress/profile
  *     Returns the public profile for any Stellar address.
  *     404 when no matching user row exists.
+ *     Supports strong ETag / 304 conditional GET.
  *
  * All routes are wrapped by `accessLog` which:
  *   - Resolves / generates a correlation ID (X-Correlation-Id → X-Request-Id
@@ -30,12 +38,18 @@
  */
 
 import { Router, Request, Response, NextFunction } from "express";
-import { z } from "zod";
-import { getUserByAddress, getUserPredictions, getCurrentUserProfile, getUserProfile, listUsers } from "../services/userService";
+import {
+  getUserByAddress,
+  getUserPredictions,
+  getCurrentUserProfile,
+  getUserProfile,
+  listUsers,
+} from "../services/userService";
 import { requireAuthForbidden } from "../middleware/requireAuth";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { accessLog } from "../middleware/accessLog";
 import { conditionalGet } from "../middleware/etag";
+import { createPerUserRateLimiter } from "../middleware/rateLimit";
 import { logger } from "../config/logger";
 import { getRequestId } from "../lib/requestContext";
 import { clampLimit } from "../utils/cursor";
@@ -43,17 +57,13 @@ import { RouteErrorFactory } from "../errors";
 import { requestTimeout } from "../middleware/timeout";
 import { usersMetricsMiddleware } from "../metrics/usersMetrics";
 import {
+  listUsersQuerySchema,
   userPredictionsParamsSchema,
   userPredictionsQuerySchema,
   userProfileParamsSchema,
 } from "../validators/users";
 
 export const usersRouter = Router();
-
-/** Zod schema for a valid Stellar public key (56-char G… address). */
-const stellarAddressSchema = z
-  .string()
-  .regex(/^G[A-Z2-7]{55}$/, "Invalid Stellar address");
 
 /**
  * Shared /api/users limiter. Authenticated requests (req.user set) use
@@ -88,18 +98,9 @@ usersRouter.use(requestTimeout(15000)); // 15 seconds timeout
 usersRouter.use(usersMetricsMiddleware);
 
 // ---------------------------------------------------------------------------
-// GET /api/users/me
+// GET /api/users
 // ---------------------------------------------------------------------------
-usersRouter.get(
-  "/me",
-  requireAuthForbidden,
-  usersRateLimit,
-  async (req: AuthenticatedRequest, res, next) => {
-  const correlationId = res.locals.correlationId as string;
-
 /**
- * GET /api/users
- *
  * Returns a cursor-paginated list of all registered users, sorted newest-first
  * (DESC createdAt, DESC id).  The composite sort key `(createdAt, id)` is
  * stable: even when two users are created in the same millisecond the UUID
@@ -117,21 +118,21 @@ usersRouter.get(
  *   fetch the next page.  A missing, tampered, or version-mismatched cursor is
  *   silently treated as absent (restart from page one) rather than 500-ing.
  *
+ * Caching:
+ *   Strong ETag on the page payload; clients may revalidate with If-None-Match
+ *   and receive 304 Not Modified when the page is unchanged.
+ *
  * Errors:
  *   400 validation_error — query params fail the zod schema
  */
-usersRouter.get("/", async (req: Request, res: Response, next: NextFunction) => {
-  const reqId = getRequestId();
+usersRouter.get("/", usersRateLimit, async (req: Request, res: Response, next: NextFunction) => {
+  const correlationId = (res.locals.correlationId as string | undefined) ?? getRequestId();
+  const reqId = correlationId;
 
   try {
-    const querySchema = z.object({
-      cursor: z.string().optional(),
-      limit: z.coerce.number().int().min(1).max(100).default(DEFAULT_PAGE_SIZE),
-    });
-
-    const queryParse = querySchema.safeParse(req.query);
+    const queryParse = listUsersQuerySchema.safeParse(req.query);
     if (!queryParse.success) {
-      logger.warn({ reqId, issues: queryParse.error.issues }, "users_list_invalid_query");
+      logger.warn({ reqId, correlationId, issues: queryParse.error.issues }, "users_list_invalid_query");
       return res.status(400).json({
         error: {
           code: "validation_error",
@@ -144,49 +145,62 @@ usersRouter.get("/", async (req: Request, res: Response, next: NextFunction) => 
     const { cursor, limit: rawLimit } = queryParse.data;
     const limit = clampLimit(rawLimit);
 
-    logger.debug({ reqId, limit, hasCursor: !!cursor }, "users_list_request");
+    logger.debug({ reqId, correlationId, limit, hasCursor: !!cursor }, "users_list_request");
 
     const page = await listUsers({ cursor, limit });
 
     logger.info(
-      { reqId, count: page.data.length, hasNext: !!page.nextCursor },
+      { reqId, correlationId, count: page.data.length, hasNext: !!page.nextCursor },
       "users_list_served",
     );
 
-    return res.json({ data: page.data, nextCursor: page.nextCursor });
-  } catch (e) {
-    return next(e);
-  }
-});
-
-usersRouter.get("/me", requireAuthForbidden, async (req: AuthenticatedRequest, res, next) => {
-  try {
-    const userId = req.user!.id;
-    const result = await getCurrentUserProfile(userId);
-
-    if (!result.ok) {
-      throw result.error;
-    }
-
-    const profile = result.value;
-    logger.info(
-      {
-        correlationId,
-        userId,
-        stellarAddress: profile.stellarAddress,
-        ...profile.totals,
-      },
-      "user_me_profile_loaded",
-    );
-
-    // Strong ETag on the profile payload; 304 if client already has it.
-    const responsePayload = { data: profile };
+    // Strong ETag on the page payload; 304 if client already has it.
+    const responsePayload = { data: page.data, nextCursor: page.nextCursor };
     if (conditionalGet(responsePayload, req, res)) return;
     return res.json(responsePayload);
   } catch (e) {
     return next(e);
   }
 });
+
+// ---------------------------------------------------------------------------
+// GET /api/users/me
+// ---------------------------------------------------------------------------
+usersRouter.get(
+  "/me",
+  requireAuthForbidden,
+  usersRateLimit,
+  async (req: AuthenticatedRequest, res, next) => {
+    const correlationId = res.locals.correlationId as string;
+
+    try {
+      const userId = req.user!.id;
+      const result = await getCurrentUserProfile(userId);
+
+      if (!result.ok) {
+        throw result.error;
+      }
+
+      const profile = result.value;
+      logger.info(
+        {
+          correlationId,
+          userId,
+          stellarAddress: profile.stellarAddress,
+          ...profile.totals,
+        },
+        "user_me_profile_loaded",
+      );
+
+      // Strong ETag on the profile payload; 304 if client already has it.
+      const responsePayload = { data: profile };
+      if (conditionalGet(responsePayload, req, res)) return;
+      return res.json(responsePayload);
+    } catch (e) {
+      return next(e);
+    }
+  },
+);
 
 // ---------------------------------------------------------------------------
 // GET /api/users/:address/predictions
@@ -207,6 +221,10 @@ usersRouter.get("/me", requireAuthForbidden, async (req: AuthenticatedRequest, r
  *   fetch the next page.  Cursors are versioned; a stale cursor from before a
  *   schema migration is safely rejected and restarts from page one rather than
  *   silently returning a wrong offset.
+ *
+ * Caching:
+ *   Strong ETag on the page payload; clients may revalidate with If-None-Match
+ *   and receive 304 Not Modified when the page is unchanged.
  *
  * Errors:
  *   400 invalid_address  — path param is not a valid G… Stellar address

--- a/src/validators/users.ts
+++ b/src/validators/users.ts
@@ -21,6 +21,38 @@ export const stellarAddressSchema = z
 export type StellarAddress = z.infer<typeof stellarAddressSchema>;
 
 // ---------------------------------------------------------------------------
+// GET /api/users
+// ---------------------------------------------------------------------------
+
+/**
+ * Query parameters for GET /api/users (cursor-paginated user list).
+ *
+ * Unknown query parameters are rejected via `.strict()` so the route
+ * boundary is explicit and malformed input is never silently ignored.
+ */
+export const listUsersQuerySchema = z
+  .object({
+    cursor: z
+      .string({
+        invalid_type_error: "cursor must be a string",
+      })
+      .trim()
+      .min(1, "cursor must be a non-empty string when provided")
+      .optional(),
+    limit: z.coerce
+      .number({
+        invalid_type_error: "limit must be a number",
+      })
+      .int("limit must be an integer")
+      .min(1, "limit must be between 1 and 100")
+      .max(100, "limit must be between 1 and 100")
+      .default(DEFAULT_PAGE_SIZE),
+  })
+  .strict();
+
+export type ListUsersQuery = z.infer<typeof listUsersQuerySchema>;
+
+// ---------------------------------------------------------------------------
 // GET /api/users/:address/predictions
 // ---------------------------------------------------------------------------
 

--- a/tests/usersList.test.ts
+++ b/tests/usersList.test.ts
@@ -78,6 +78,25 @@ jest.mock("../src/db/client", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// 3b. Middleware that would otherwise pull in heavy deps — no-op in tests.
+// ---------------------------------------------------------------------------
+jest.mock("../src/middleware/rateLimit", () => ({
+  createPerUserRateLimiter: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock("../src/middleware/timeout", () => ({
+  requestTimeout: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock("../src/metrics/usersMetrics", () => ({
+  usersMetricsMiddleware: (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock("../src/middleware/accessLog", () => ({
+  accessLog: (_req: any, _res: any, next: any) => next(),
+}));
+
+// ---------------------------------------------------------------------------
 // 4. Mock userService so individual tests control listUsers output.
 // ---------------------------------------------------------------------------
 jest.mock("../src/services/userService", () => ({
@@ -108,6 +127,7 @@ const mockListUsers = listUsers as jest.MockedFunction<typeof listUsers>;
 function makeApp(): express.Express {
   const app = express();
   app.use(express.json());
+  app.set("etag", false);
   app.use("/api/users", usersRouter);
   app.use(errorHandler);
   return app;
@@ -334,6 +354,43 @@ describe("GET /api/users", () => {
       const res = await request(app).get(usersListUrl());
 
       expect(res.status).toBe(500);
+    });
+  });
+
+  // ── ETag / conditional GET ─────────────────────────────────────────────────
+
+  describe("ETag / conditional GET", () => {
+    it("returns strong ETag and Cache-Control: no-cache on 200", async () => {
+      mockListUsers.mockResolvedValueOnce({
+        data: [USER_1],
+        nextCursor: null,
+      });
+
+      const res = await request(app).get(usersListUrl());
+
+      expect(res.status).toBe(200);
+      expect(res.headers["etag"]).toMatch(/^"[a-f0-9]{64}"$/);
+      expect(res.headers["cache-control"]).toBe("no-cache");
+    });
+
+    it("returns 304 when If-None-Match matches", async () => {
+      mockListUsers.mockResolvedValueOnce({
+        data: [USER_1],
+        nextCursor: null,
+      });
+      const first = await request(app).get(usersListUrl());
+      const etag = first.headers["etag"] as string;
+
+      mockListUsers.mockResolvedValueOnce({
+        data: [USER_1],
+        nextCursor: null,
+      });
+      const second = await request(app)
+        .get(usersListUrl())
+        .set("If-None-Match", etag);
+
+      expect(second.status).toBe(304);
+      expect(second.text).toBe("");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds strong ETag support and 304 Not Modified handling to `GET /api/users` (list endpoint), matching the caching pattern already applied to `/api/users/me`, `/api/users/:address/predictions`, and `/api/users/:stellarAddress/profile`.
- Applies the shared per-user/IP `/api/users` rate limiter to the list endpoint.
- Adds `listUsersQuerySchema` (strict zod validator) for the list endpoint's query params.
- Documents the new caching behavior in the OpenAPI registry, README, and a new `docs/users-api.md`.

## Test plan
- [x] `tests/usersList.test.ts` — 16/16 passing, including new ETag / conditional GET cases (200 with `ETag` + `Cache-Control: no-cache`, 304 on matching `If-None-Match`)
- [x] Existing users route tests unaffected

closes #351
closes #352