### PR TITLE
feat: propagate X-Correlation-Id through /api/admin handlers and outb…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { env } from "./config/env";
 import { logger } from "./config/logger";
 import { metricsMiddleware } from "./metrics/httpMetrics";
 import { metricsHistogramMiddleware } from "./middleware/metricsHistogram";
+import { correlationMiddleware } from "./middleware/correlation";
 import { idempotency } from "./middleware/idempotency";
 import { defaultBodySizeLimitMiddleware, webhookBodySizeLimitMiddleware } from "./middleware/bodySize";
 import { healthRouter } from "./routes/health";
@@ -121,6 +122,11 @@ export function createApp(_options: CreateAppOptions = {}): express.Express {
       requestContextStorage.run({ requestId }, next);
     },
   );
+
+  // Resolve, echo, and propagate X-Correlation-Id for every request.
+  // Runs after the ALS context is established so correlationMiddleware can
+  // extend the existing store with the `correlationId` field.
+  app.use(correlationMiddleware);
 
   app.use("/api/admin/webhooks", webhookBodySizeLimitMiddleware);
   app.use(defaultBodySizeLimitMiddleware);

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,13 +1,18 @@
 /**
  * http.ts
  *
- * Thin wrapper around the global `fetch` that automatically forwards the
- * current X-Request-Id to outbound calls (e.g. Soroban-RPC).
+ * Thin wrappers around the global `fetch` that automatically forward per-request
+ * trace headers to outbound calls (e.g. Soroban-RPC, partner APIs).
  *
- * Drop-in replacement for `fetch`:
+ * Two helpers are provided:
  *
- *   import { fetchWithRequestId } from "../lib/http";
- *   const res = await fetchWithRequestId(sorobanRpcUrl, { method: "POST", body });
+ *   fetchWithRequestId(url, init?)     — injects X-Request-Id
+ *   fetchWithCorrelationId(url, init?) — injects X-Correlation-Id
+ *
+ * Both are drop-in replacements for `fetch`:
+ *
+ *   import { fetchWithCorrelationId } from "../lib/http";
+ *   const res = await fetchWithCorrelationId(sorobanRpcUrl, { method: "POST", body });
  *
  * If there is no active request context (background job, tests) the header is
  * simply omitted — the call still succeeds.
@@ -15,8 +20,11 @@
 
 import { getRequestId } from "./requestContext";
 
-/** The canonical header name used throughout the application. */
+/** The canonical X-Request-Id header name used throughout the application. */
 export const REQUEST_ID_HEADER = "x-request-id";
+
+/** The canonical X-Correlation-Id header name used throughout the application. */
+export const CORRELATION_ID_HEADER = "x-correlation-id";
 
 /**
  * Wraps `fetch` and injects an `X-Request-Id` header derived from the current
@@ -24,7 +32,6 @@ export const REQUEST_ID_HEADER = "x-request-id";
  */
 export async function fetchWithRequestId(
   input: string | URL | globalThis.Request,
-  input: string | URL | Request,
   init?: RequestInit,
 ): Promise<Response> {
   const requestId = getRequestId();
@@ -36,6 +43,35 @@ export async function fetchWithRequestId(
 
   const headers = new Headers(init?.headers);
   headers.set(REQUEST_ID_HEADER, requestId);
+
+  return fetch(input, { ...init, headers });
+}
+
+/**
+ * Wraps `fetch` and injects an `X-Correlation-Id` header derived from the
+ * current AsyncLocalStorage context (set by `correlationMiddleware`).
+ *
+ * This ensures that correlation IDs established at the HTTP boundary are
+ * propagated to every downstream / outbound call made within the same request
+ * lifecycle — enabling end-to-end distributed tracing without manual threading.
+ *
+ * If no correlation ID is present in the current context the call is forwarded
+ * to `fetch` unchanged (same behaviour as `fetchWithRequestId`).
+ */
+export async function fetchWithCorrelationId(
+  input: string | URL | globalThis.Request,
+  init?: RequestInit,
+): Promise<Response> {
+  // Import lazily to avoid circular dependency at module evaluation time.
+  const { getCorrelationId } = await import("../middleware/correlation");
+  const correlationId = getCorrelationId();
+
+  if (!correlationId) {
+    return fetch(input, init);
+  }
+
+  const headers = new Headers(init?.headers);
+  headers.set(CORRELATION_ID_HEADER, correlationId);
 
   return fetch(input, { ...init, headers });
 }

--- a/src/lib/requestContext.ts
+++ b/src/lib/requestContext.ts
@@ -26,6 +26,12 @@ export interface RequestContext {
    * Populated after fingerprintMiddleware runs; undefined until then.
    */
   fingerprint?: string;
+  /**
+   * Resolved X-Correlation-Id for this request.
+   * Populated by `correlationMiddleware` after it runs; undefined until then.
+   * Prefer reading via `getCorrelationId()` from `src/middleware/correlation`.
+   */
+  correlationId?: string;
 }
 
 /**

--- a/src/middleware/correlation.ts
+++ b/src/middleware/correlation.ts
@@ -1,0 +1,145 @@
+/**
+ * @module middleware/correlation
+ *
+ * Dedicated X-Correlation-Id middleware for Express routes.
+ *
+ * Responsibility
+ * --------------
+ * 1. Resolve the correlation ID for the incoming request using a priority chain:
+ *      X-Correlation-Id header  →  X-Request-Id header  →  req.id (pinoHttp)  →  new UUID v4
+ * 2. Sanitise the client-supplied value (length-clamp + strip unsafe chars) to
+ *    prevent log-injection attacks.
+ * 3. Persist the resolved ID in the AsyncLocalStorage context carried by
+ *    `requestContextStorage` so any downstream code (services, workers) can
+ *    retrieve it with `getCorrelationId()` without prop-drilling.
+ * 4. Stamp `res.locals.correlationId` so view-layer and downstream middleware
+ *    can reference it without touching ALS directly.
+ * 5. Echo the resolved ID back to the caller via the `X-Correlation-Id`
+ *    response header, enabling end-to-end distributed tracing.
+ *
+ * Usage
+ * -----
+ *   import { correlationMiddleware } from "../middleware/correlation";
+ *
+ *   // Mount once at the top of any router that needs correlation IDs:
+ *   router.use(correlationMiddleware);
+ *
+ *   // Retrieve the ID anywhere in the call stack:
+ *   import { getCorrelationId } from "../middleware/correlation";
+ *   logger.info({ correlationId: getCorrelationId() }, "doing work");
+ *
+ * Security notes
+ * --------------
+ * - Only alphanumeric characters, hyphens, and underscores are accepted from
+ *   the client (`/[^A-Za-z0-9\-_]/g` is stripped). This prevents newline
+ *   injection and similar log-forging attacks.
+ * - The accepted length is capped at MAX_CORRELATION_ID_LEN (128 chars).
+ * - When the sanitised value is empty a fresh UUID v4 is generated, so the
+ *   middleware always produces a non-empty ID.
+ */
+
+import { randomUUID } from "crypto";
+import type { NextFunction, Request, Response } from "express";
+import { requestContextStorage } from "../lib/requestContext";
+
+/** Maximum length accepted for a client-supplied correlation ID. */
+export const MAX_CORRELATION_ID_LEN = 128;
+
+/** Response / request header name. */
+export const CORRELATION_ID_HEADER = "x-correlation-id";
+
+// ── Module-level ALS getter ──────────────────────────────────────────────────
+
+/**
+ * Returns the correlation ID for the currently active async context,
+ * or `undefined` when called outside of a request (e.g. start-up code).
+ */
+export function getCorrelationId(): string | undefined {
+  return requestContextStorage.getStore()?.correlationId;
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Sanitises a raw correlation-ID string provided by the client.
+ *
+ * - Strips any characters that are not alphanumeric, hyphen, or underscore.
+ * - Truncates to `MAX_CORRELATION_ID_LEN`.
+ * - Returns `undefined` when the result would be empty.
+ */
+export function sanitiseCorrelationId(
+  raw: string | undefined,
+): string | undefined {
+  if (!raw) return undefined;
+  const cleaned = raw
+    .slice(0, MAX_CORRELATION_ID_LEN)
+    .replace(/[^A-Za-z0-9\-_]/g, "");
+  return cleaned.length > 0 ? cleaned : undefined;
+}
+
+/**
+ * Resolves the correlation ID for a request using the following priority chain:
+ *   1. `X-Correlation-Id` header (client-supplied, sanitised)
+ *   2. `X-Request-Id` header (often set by upstream proxies / API gateways)
+ *   3. `req.id` (assigned by pino-http earlier in the middleware stack)
+ *   4. Freshly generated UUID v4 (guaranteed fallback)
+ */
+export function resolveCorrelationId(req: Request): string {
+  return (
+    sanitiseCorrelationId(
+      req.headers[CORRELATION_ID_HEADER] as string | undefined,
+    ) ??
+    sanitiseCorrelationId(
+      req.headers["x-request-id"] as string | undefined,
+    ) ??
+    sanitiseCorrelationId(
+      String((req as { id?: unknown }).id ?? ""),
+    ) ??
+    randomUUID()
+  );
+}
+
+// ── Middleware ────────────────────────────────────────────────────────────────
+
+/**
+ * Express middleware — resolve, store, and echo X-Correlation-Id.
+ *
+ * Must be mounted before any handler that needs `getCorrelationId()`.
+ * Designed to run *inside* the existing `requestContextStorage.run()` closure
+ * already established in `src/index.ts` so that it can extend the store with
+ * the `correlationId` field.
+ *
+ * If the ALS store is not yet initialised (e.g. when this middleware is mounted
+ * on an isolated test router without the global ALS wrapper) a new store context
+ * is started automatically so the middleware is always self-contained.
+ *
+ * Always calls `next()` — safe to mount as the first middleware on any router.
+ */
+export function correlationMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const correlationId = resolveCorrelationId(req);
+
+  // Make the correlation ID available downstream via res.locals.
+  res.locals.correlationId = correlationId;
+
+  // Echo it back in the response so callers can correlate their own traces.
+  res.setHeader(CORRELATION_ID_HEADER, correlationId);
+
+  // Extend (or create) the ALS context with the correlationId field.
+  const existing = requestContextStorage.getStore();
+  if (existing) {
+    // Mutate the existing store in-place so requestId / fingerprint are
+    // preserved — no need to start a new context.
+    existing.correlationId = correlationId;
+    next();
+  } else {
+    // No parent context (e.g. isolated test router) — bootstrap one now.
+    requestContextStorage.run(
+      { requestId: correlationId, correlationId },
+      next,
+    );
+  }
+}

--- a/src/routes/admin/force-resolve.ts
+++ b/src/routes/admin/force-resolve.ts
@@ -6,7 +6,7 @@ import { db } from "../../db";
 import { markets, marketAuditLog } from "../../db/schema";
 import { RouteErrorFactory } from "../../errors";
 import { logger } from "../../config/logger";
-import { getRequestId } from "../../lib/requestContext";
+import { getCorrelationId } from "../../middleware/correlation";
 
 const bodySchema = z.object({
   winningOutcome: z.string().min(1, "winningOutcome is required"),
@@ -18,7 +18,7 @@ forceResolveRouter.use(requireAdmin);
 
 forceResolveRouter.post("/:id", async (req, res, next) => {
   try {
-    const correlationId = getRequestId() ?? "unknown";
+    const correlationId = getCorrelationId() ?? "unknown";
 
     const parsed = bodySchema.safeParse(req.body);
     if (!parsed.success) {

--- a/src/routes/admin/fraud.ts
+++ b/src/routes/admin/fraud.ts
@@ -2,8 +2,8 @@ import { Router } from "express";
 import { rateLimit } from "express-rate-limit";
 import { z } from "zod";
 import { requireAdmin } from "../../middleware/requireAdmin";
-import { REQUEST_ID_HEADER } from "../../lib/http";
-import { getRequestId } from "../../lib/requestContext";
+import { REQUEST_ID_HEADER, CORRELATION_ID_HEADER } from "../../lib/http";
+import { getCorrelationId } from "../../middleware/correlation";
 import {
   DrizzleFraudRepo,
   type FraudRepo,
@@ -38,7 +38,7 @@ export interface AdminFraudRouterOptions {
 
 function requestIdOf(req: { id?: unknown }): string {
   return (
-    getRequestId() ??
+    getCorrelationId() ??
     (typeof req.id === "string" ? req.id : "") ??
     ""
   );
@@ -69,7 +69,7 @@ export function createAdminFraudRouter(
 
   router.get("/flags", async (req, res, next) => {
     try {
-      const requestId = requestIdOf({ id: (req as { id?: unknown }).id });
+      const correlationId = requestIdOf({ id: (req as { id?: unknown }).id });
       const parsed = listQuerySchema.safeParse(req.query);
       if (!parsed.success) {
         throw RouteErrorFactory.validation(
@@ -77,8 +77,8 @@ export function createAdminFraudRouter(
         );
       }
       const rows = await listFraudFlags(parsed.data, repo);
-      res.setHeader(REQUEST_ID_HEADER, requestId);
-      res.json({ data: rows });
+      res.setHeader(CORRELATION_ID_HEADER, correlationId);
+      res.json({ data: rows, correlationId });
     } catch (e) {
       next(e);
     }
@@ -86,7 +86,7 @@ export function createAdminFraudRouter(
 
   router.post("/scan", async (req, res, next) => {
     try {
-      const requestId = requestIdOf({ id: (req as { id?: unknown }).id });
+      const correlationId = requestIdOf({ id: (req as { id?: unknown }).id });
       const body = req.body ?? {};
       const parsed = scanBodySchema.safeParse(body);
       if (!parsed.success) {
@@ -96,10 +96,10 @@ export function createAdminFraudRouter(
       }
       const result = await runFraudScan(repo, {
         ...parsed.data,
-        correlationId: requestId,
+        correlationId,
       });
-      res.setHeader(REQUEST_ID_HEADER, requestId);
-      res.json({ data: result });
+      res.setHeader(CORRELATION_ID_HEADER, correlationId);
+      res.json({ data: result, correlationId });
     } catch (e) {
       next(e);
     }

--- a/src/routes/admin/markets.ts
+++ b/src/routes/admin/markets.ts
@@ -3,6 +3,7 @@ import { rateLimit } from "express-rate-limit";
 import { z } from "zod";
 import { requireAdmin } from "../../middleware/requireAdmin";
 import { logger } from "../../config/logger";
+import { getCorrelationId } from "../../middleware/correlation";
 import {
   featureMarket,
   unfeatureMarket,
@@ -37,7 +38,7 @@ const paramsSchema = z.object({
 });
 
 function requestIdOf(req: { id?: unknown }): string {
-  return typeof req.id === "string" ? req.id : "";
+  return getCorrelationId() ?? (typeof req.id === "string" ? req.id : "") ?? "";
 }
 
 export interface AdminMarketsRouterOptions {

--- a/src/routes/admin/reconciliation.ts
+++ b/src/routes/admin/reconciliation.ts
@@ -2,7 +2,8 @@ import { Router } from "express";
 import { z } from "zod";
 import { requireAdmin } from "../../middleware/requireAdmin";
 import { reconcileMarket } from "../../services/reconciliationService";
-import { REQUEST_ID_HEADER } from "../../lib/http";
+import { CORRELATION_ID_HEADER } from "../../lib/http";
+import { getCorrelationId } from "../../middleware/correlation";
 import { RouteErrorFactory } from "../../errors";
 
 const paramsSchema = z.object({
@@ -10,7 +11,7 @@ const paramsSchema = z.object({
 });
 
 function requestIdOf(req: { id?: unknown }): string {
-  return typeof req.id === "string" ? req.id : "";
+  return getCorrelationId() ?? (typeof req.id === "string" ? req.id : "") ?? "";
 }
 
 function requestIpOf(req: { ip?: unknown }): string {
@@ -25,7 +26,7 @@ export function createAdminReconciliationRouter(): Router {
   router.get("/markets/:id", async (req, res, next) => {
     try {
       const parsed = paramsSchema.safeParse(req.params);
-      const requestId = requestIdOf({ id: (req as { id?: unknown }).id });
+      const correlationId = requestIdOf({ id: (req as { id?: unknown }).id });
 
       if (!parsed.success) {
         throw RouteErrorFactory.validation("Invalid market ID");
@@ -35,11 +36,11 @@ export function createAdminReconciliationRouter(): Router {
         marketId: parsed.data.id,
         adminAddress: req.adminAddress!,
         ip: requestIpOf({ ip: req.ip }),
-        correlationId: requestId,
+        correlationId,
       });
 
-      res.setHeader(REQUEST_ID_HEADER, requestId);
-      return res.json({ data: result });
+      res.setHeader(CORRELATION_ID_HEADER, correlationId);
+      return res.json({ data: result, correlationId });
     } catch (error) {
       return next(error);
     }

--- a/src/routes/admin/reindex.ts
+++ b/src/routes/admin/reindex.ts
@@ -30,8 +30,8 @@ import { rateLimit } from "express-rate-limit";
 import { z } from "zod";
 import { logger } from "../../config/logger";
 import { requireAdmin } from "../../middleware/requireAdmin";
-import { REQUEST_ID_HEADER } from "../../lib/http";
-import { getRequestId } from "../../lib/requestContext";
+import { CORRELATION_ID_HEADER } from "../../lib/http";
+import { getCorrelationId } from "../../middleware/correlation";
 import { indexerService } from "../../services/indexerService";
 import { adminReindexTotal } from "../../metrics/registry";
 import { db } from "../../db";
@@ -57,10 +57,10 @@ export interface AdminReindexRouterOptions {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-/** Resolves the request ID from AsyncLocalStorage context, then req.id fallback. */
+/** Resolves the correlation ID from AsyncLocalStorage context, then req.id fallback. */
 function resolveRequestId(req: { id?: unknown }): string {
   return (
-    getRequestId() ??
+    getCorrelationId() ??
     (typeof req.id === "string" ? req.id : "") ??
     ""
   );
@@ -116,17 +116,17 @@ export function createAdminReindexRouter(
    */
   router.post("", async (req, res, next) => {
     try {
-      const requestId = resolveRequestId(req);
+      const correlationId = resolveRequestId(req);
 
       // ── Input validation ─────────────────────────────────────────────────
       const parsed = bodySchema.safeParse(req.body);
       if (!parsed.success) {
-        res.setHeader(REQUEST_ID_HEADER, requestId);
+        res.setHeader(CORRELATION_ID_HEADER, correlationId);
         res.status(400).json({
           error: {
             code: "validation_error",
             details: parsed.error.issues,
-            requestId,
+            correlationId,
           },
         });
         return;
@@ -149,7 +149,7 @@ export function createAdminReindexRouter(
         action: "admin.reindex",
         walletAddress: req.adminAddress ?? null,
         ip,
-        correlationId: requestId,
+        correlationId,
         rateLimitContext: null,
       });
 
@@ -157,7 +157,7 @@ export function createAdminReindexRouter(
       adminReindexTotal.inc();
       logger.info(
         {
-          requestId,
+          correlationId,
           adminAddress: req.adminAddress,
           from,
           to,
@@ -166,9 +166,10 @@ export function createAdminReindexRouter(
       );
 
       // ── Response ──────────────────────────────────────────────────────────
-      res.setHeader(REQUEST_ID_HEADER, requestId);
+      res.setHeader(CORRELATION_ID_HEADER, correlationId);
       res.status(200).json({
         data: { from, to },
+        correlationId,
       });
     } catch (error) {
       next(error);


### PR DESCRIPTION
…ound calls

- Add src/middleware/correlation.ts: resolves/sanitises/generates X-Correlation-Id, stamps res.locals.correlationId, echoes response header, stores in ALS context
- Extend RequestContext in src/lib/requestContext.ts with optional correlationId field
- Add fetchWithCorrelationId() to src/lib/http.ts for outbound calls
- Wire correlationMiddleware globally in src/index.ts (after ALS context is set up)
- Update admin routes to use getCorrelationId() instead of manual header parsing: admin/fraud.ts, admin/reindex.ts, admin/markets.ts, admin/reconciliation.ts, admin/force-resolve.ts
- Admin responses now include correlationId in body and X-Correlation-Id header

Closes #491