### PR TITLE
feat: input validation markets

### DIFF
--- a/src/routes/markets/trending.ts
+++ b/src/routes/markets/trending.ts
@@ -1,16 +1,11 @@
 import { Router } from "express";
-import { z } from "zod";
 import { getTrending } from "../../services/trendingService";
 import { rateLimitAnon } from "../../middleware/rateLimitAnon";
+import { trendingQuerySchema } from "../../validators/markets";
 
 export const trendingRouter = Router();
 
 trendingRouter.use(rateLimitAnon);
-
-const trendingQuerySchema = z.object({
-  limit: z.coerce.number().int().positive().max(100).default(20),
-  offset: z.coerce.number().int().nonnegative().default(0),
-});
 
 // GET /api/markets/trending - Get trending markets
 trendingRouter.get("/", async (req, res, next) => {

--- a/src/validators/markets.ts
+++ b/src/validators/markets.ts
@@ -1,71 +1,176 @@
 import { z } from "zod";
 
 /**
- * Schema for GET /api/markets query parameters
+ * Schema for GET /api/markets query parameters.
+ *
+ * Unknown query parameters are rejected via `.strict()` to keep the route
+ * boundary explicit and to avoid silently ignoring malformed input.
  */
-export const listMarketsQuerySchema = z.object({
-  limit: z.coerce.number().int("Limit must be an integer").min(1, "Limit must be between 1 and 100").max(100, "Limit must be between 1 and 100").default(20),
-  cursor: z.string().optional(),
-  status: z.string().trim().optional(),
-  category: z.string().trim().optional(),
-  tag: z.string().trim().optional(),
-  sort: z.string().trim().optional(),
-  order: z.enum(["asc", "desc"]).optional(),
-});
+export const listMarketsQuerySchema = z
+  .object({
+    limit: z.coerce
+      .number({ invalid_type_error: "limit must be a number" })
+      .int("Limit must be an integer")
+      .min(1, "Limit must be between 1 and 100")
+      .max(100, "Limit must be between 1 and 100")
+      .default(20),
+    cursor: z
+      .string({ invalid_type_error: "cursor must be a string" })
+      .max(512, "cursor is too long")
+      .optional(),
+    status: z
+      .string({ invalid_type_error: "status must be a string" })
+      .trim()
+      .max(32, "status must be at most 32 characters")
+      .optional(),
+    category: z
+      .string({ invalid_type_error: "category must be a string" })
+      .trim()
+      .max(64, "category must be at most 64 characters")
+      .optional(),
+    tag: z
+      .string({ invalid_type_error: "tag must be a string" })
+      .trim()
+      .max(64, "tag must be at most 64 characters")
+      .optional(),
+    sort: z
+      .string({ invalid_type_error: "sort must be a string" })
+      .trim()
+      .max(32, "sort must be at most 32 characters")
+      .optional(),
+    order: z.enum(["asc", "desc"]).optional(),
+  })
+  .strict();
 
 export type ListMarketsQuery = z.infer<typeof listMarketsQuerySchema>;
 
 /**
- * Schema for GET /api/markets/search query parameters
+ * Schema for GET /api/markets/search query parameters.
+ *
+ * Unknown query parameters are rejected via `.strict()`.
  */
-export const searchMarketsQuerySchema = z.object({
-  q: z
-    .string({ required_error: "Search query parameter 'q' is required" })
-    .trim()
-    .min(1, "Search query parameter 'q' is required"),
-  limit: z.coerce.number().int("Limit must be an integer").min(1, "Limit must be between 1 and 100").max(100, "Limit must be between 1 and 100").default(20),
-  offset: z.coerce.number().int("Offset must be an integer").min(0, "Offset must be non-negative").optional(),
-  page: z.coerce.number().int("Page must be an integer").min(1, "Page must be at least 1").optional(),
-});
+export const searchMarketsQuerySchema = z
+  .object({
+    q: z
+      .string({
+        required_error: "Search query parameter 'q' is required",
+        invalid_type_error: "q must be a string",
+      })
+      .trim()
+      .min(1, "Search query parameter 'q' is required")
+      .max(256, "Search query must be at most 256 characters"),
+    limit: z.coerce
+      .number({ invalid_type_error: "limit must be a number" })
+      .int("Limit must be an integer")
+      .min(1, "Limit must be between 1 and 100")
+      .max(100, "Limit must be between 1 and 100")
+      .default(20),
+    offset: z.coerce
+      .number({ invalid_type_error: "offset must be a number" })
+      .int("Offset must be an integer")
+      .min(0, "Offset must be non-negative")
+      .optional(),
+    page: z.coerce
+      .number({ invalid_type_error: "page must be a number" })
+      .int("Page must be an integer")
+      .min(1, "Page must be at least 1")
+      .optional(),
+  })
+  .strict();
 
 export type SearchMarketsQuery = z.infer<typeof searchMarketsQuerySchema>;
 
 /**
- * Schema for GET /api/markets/featured query parameters
+ * Schema for GET /api/markets/featured query parameters.
+ *
+ * Unknown query parameters are rejected via `.strict()`.
  */
-export const featuredMarketsQuerySchema = z.object({
-  limit: z.coerce.number().int("limit must be an integer between 1 and 20").min(1, "limit must be an integer between 1 and 20").max(20, "limit must be an integer between 1 and 20").optional(),
-});
+export const featuredMarketsQuerySchema = z
+  .object({
+    limit: z.coerce
+      .number({ invalid_type_error: "limit must be a number" })
+      .int("limit must be an integer between 1 and 20")
+      .min(1, "limit must be an integer between 1 and 20")
+      .max(20, "limit must be an integer between 1 and 20")
+      .optional(),
+  })
+  .strict();
 
 export type FeaturedMarketsQuery = z.infer<typeof featuredMarketsQuerySchema>;
 
 /**
- * Schema for GET /api/markets/upcoming query parameters
+ * Schema for GET /api/markets/upcoming query parameters.
+ *
+ * Unknown query parameters are rejected via `.strict()`.
  */
-export const upcomingMarketsQuerySchema = z.object({
-  limit: z.coerce.number().int("limit must be between 1 and 100").min(1, "limit must be between 1 and 100").max(100, "limit must be between 1 and 100").default(50),
-});
+export const upcomingMarketsQuerySchema = z
+  .object({
+    limit: z.coerce
+      .number({ invalid_type_error: "limit must be a number" })
+      .int("limit must be between 1 and 100")
+      .min(1, "limit must be between 1 and 100")
+      .max(100, "limit must be between 1 and 100")
+      .default(50),
+  })
+  .strict();
 
 export type UpcomingMarketsQuery = z.infer<typeof upcomingMarketsQuerySchema>;
 
 /**
- * Schema for route parameters containing market ID (:id)
+ * Schema for GET /api/markets/trending query parameters.
+ *
+ * Unknown query parameters are rejected via `.strict()`.
+ */
+export const trendingQuerySchema = z
+  .object({
+    limit: z.coerce
+      .number({ invalid_type_error: "limit must be a number" })
+      .int("limit must be an integer")
+      .positive("limit must be positive")
+      .max(100, "limit must be at most 100")
+      .default(20),
+    offset: z.coerce
+      .number({ invalid_type_error: "offset must be a number" })
+      .int("offset must be an integer")
+      .nonnegative("offset must be non-negative")
+      .default(0),
+  })
+  .strict();
+
+export type TrendingQuery = z.infer<typeof trendingQuerySchema>;
+
+/**
+ * Schema for route parameters containing market ID (:id).
  */
 export const marketParamsSchema = z.object({
-  id: z.string().trim().min(1, "Market ID is required").max(255, "Market ID is too long"),
+  id: z
+    .string({ invalid_type_error: "market ID must be a string" })
+    .trim()
+    .min(1, "Market ID is required")
+    .max(255, "Market ID is too long"),
 });
 
 export type MarketParams = z.infer<typeof marketParamsSchema>;
 
 /**
- * Schema for PATCH /api/markets/:id body payload
+ * Schema for PATCH /api/markets/:id body payload.
+ *
+ * Uses `.strict()` to reject unexpected fields.
  */
 export const patchMarketBodySchema = z
   .object({
-    question: z.string().trim().min(1, "Question cannot be empty").optional(),
+    question: z
+      .string({ invalid_type_error: "question must be a string" })
+      .trim()
+      .min(1, "Question cannot be empty")
+      .max(512, "Question must be at most 512 characters")
+      .optional(),
     metadata: z.record(z.unknown()).optional(),
     expectedVersion: z
-      .number({ required_error: "expectedVersion is required" })
+      .number({
+        required_error: "expectedVersion is required",
+        invalid_type_error: "expectedVersion must be a number",
+      })
       .int("expectedVersion must be an integer")
       .nonnegative("expectedVersion must be non-negative"),
   })

--- a/tests/markets-validation.test.ts
+++ b/tests/markets-validation.test.ts
@@ -1,0 +1,589 @@
+/**
+ * Tests for market input validation schemas.
+ *
+ * Covers every exported schema in src/validators/markets.ts:
+ *  - listMarketsQuerySchema
+ *  - searchMarketsQuerySchema
+ *  - featuredMarketsQuerySchema
+ *  - upcomingMarketsQuerySchema
+ *  - trendingQuerySchema
+ *  - marketParamsSchema
+ *  - patchMarketBodySchema
+ *
+ * Tests exercise both happy paths and edge cases (boundary values,
+ * strict rejection, type coercion, max-length, empty/whitespace strings).
+ */
+
+import {
+  listMarketsQuerySchema,
+  searchMarketsQuerySchema,
+  featuredMarketsQuerySchema,
+  upcomingMarketsQuerySchema,
+  trendingQuerySchema,
+  marketParamsSchema,
+  patchMarketBodySchema,
+} from "../src/validators/markets";
+
+// ── listMarketsQuerySchema ───────────────────────────────────────────────────
+
+describe("listMarketsQuerySchema", () => {
+  it("accepts empty query (all defaults)", () => {
+    const result = listMarketsQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(20);
+    }
+  });
+
+  it("applies default limit of 20", () => {
+    const result = listMarketsQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(20);
+    }
+  });
+
+  it("accepts valid limit", () => {
+    const result = listMarketsQuerySchema.safeParse({ limit: 50 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(50);
+    }
+  });
+
+  it("accepts limit of 1 (min boundary)", () => {
+    const result = listMarketsQuerySchema.safeParse({ limit: 1 });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts limit of 100 (max boundary)", () => {
+    const result = listMarketsQuerySchema.safeParse({ limit: 100 });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects limit below 1", () => {
+    const result = listMarketsQuerySchema.safeParse({ limit: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects limit above 100", () => {
+    const result = listMarketsQuerySchema.safeParse({ limit: 101 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-numeric limit", () => {
+    const result = listMarketsQuerySchema.safeParse({ limit: "abc" });
+    expect(result.success).toBe(false);
+  });
+
+  it("coerces string limit to number", () => {
+    const result = listMarketsQuerySchema.safeParse({ limit: "10" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(10);
+    }
+  });
+
+  it("accepts valid cursor", () => {
+    const result = listMarketsQuerySchema.safeParse({ cursor: "abc123" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects cursor exceeding max length", () => {
+    const result = listMarketsQuerySchema.safeParse({ cursor: "x".repeat(513) });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts valid status", () => {
+    const result = listMarketsQuerySchema.safeParse({ status: "active" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.status).toBe("active");
+    }
+  });
+
+  it("trims whitespace from status", () => {
+    const result = listMarketsQuerySchema.safeParse({ status: "  active  " });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.status).toBe("active");
+    }
+  });
+
+  it("rejects status exceeding max length", () => {
+    const result = listMarketsQuerySchema.safeParse({ status: "x".repeat(33) });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts valid category", () => {
+    const result = listMarketsQuerySchema.safeParse({ category: "sports" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects category exceeding max length", () => {
+    const result = listMarketsQuerySchema.safeParse({ category: "x".repeat(65) });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts valid tag", () => {
+    const result = listMarketsQuerySchema.safeParse({ tag: "football" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects tag exceeding max length", () => {
+    const result = listMarketsQuerySchema.safeParse({ tag: "x".repeat(65) });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts valid sort", () => {
+    const result = listMarketsQuerySchema.safeParse({ sort: "createdAt" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects sort exceeding max length", () => {
+    const result = listMarketsQuerySchema.safeParse({ sort: "x".repeat(33) });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts valid order", () => {
+    expect(listMarketsQuerySchema.safeParse({ order: "asc" }).success).toBe(true);
+    expect(listMarketsQuerySchema.safeParse({ order: "desc" }).success).toBe(true);
+  });
+
+  it("rejects invalid order", () => {
+    expect(listMarketsQuerySchema.safeParse({ order: "random" }).success).toBe(false);
+  });
+
+  it("rejects extra/unknown query parameters (strict)", () => {
+    const result = listMarketsQuerySchema.safeParse({ unknownField: "value" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].code).toBe("unrecognized_keys");
+    }
+  });
+
+  it("rejects multiple extra fields", () => {
+    const result = listMarketsQuerySchema.safeParse({
+      limit: 10,
+      extra1: "a",
+      extra2: "b",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── searchMarketsQuerySchema ─────────────────────────────────────────────────
+
+describe("searchMarketsQuerySchema", () => {
+  it("rejects missing q parameter", () => {
+    const result = searchMarketsQuerySchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty q after trim", () => {
+    const result = searchMarketsQuerySchema.safeParse({ q: "   " });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts valid q", () => {
+    const result = searchMarketsQuerySchema.safeParse({ q: "bitcoin" });
+    expect(result.success).toBe(true);
+  });
+
+  it("trims whitespace from q", () => {
+    const result = searchMarketsQuerySchema.safeParse({ q: "  bitcoin  " });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.q).toBe("bitcoin");
+    }
+  });
+
+  it("rejects q exceeding max length", () => {
+    const result = searchMarketsQuerySchema.safeParse({ q: "x".repeat(257) });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts q at max length", () => {
+    const result = searchMarketsQuerySchema.safeParse({ q: "x".repeat(256) });
+    expect(result.success).toBe(true);
+  });
+
+  it("applies default limit of 20", () => {
+    const result = searchMarketsQuerySchema.safeParse({ q: "test" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(20);
+    }
+  });
+
+  it("accepts valid limit and offset", () => {
+    const result = searchMarketsQuerySchema.safeParse({
+      q: "test",
+      limit: 50,
+      offset: 10,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(50);
+      expect(result.data.offset).toBe(10);
+    }
+  });
+
+  it("accepts valid page", () => {
+    const result = searchMarketsQuerySchema.safeParse({ q: "test", page: 3 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.page).toBe(3);
+    }
+  });
+
+  it("rejects page below 1", () => {
+    const result = searchMarketsQuerySchema.safeParse({ q: "test", page: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative offset", () => {
+    const result = searchMarketsQuerySchema.safeParse({ q: "test", offset: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects limit above 100", () => {
+    const result = searchMarketsQuerySchema.safeParse({ q: "test", limit: 101 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects extra/unknown query parameters (strict)", () => {
+    const result = searchMarketsQuerySchema.safeParse({ q: "test", bad: true });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].code).toBe("unrecognized_keys");
+    }
+  });
+});
+
+// ── featuredMarketsQuerySchema ───────────────────────────────────────────────
+
+describe("featuredMarketsQuerySchema", () => {
+  it("accepts empty query", () => {
+    const result = featuredMarketsQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts valid limit", () => {
+    const result = featuredMarketsQuerySchema.safeParse({ limit: 10 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(10);
+    }
+  });
+
+  it("accepts limit of 1 (min boundary)", () => {
+    expect(featuredMarketsQuerySchema.safeParse({ limit: 1 }).success).toBe(true);
+  });
+
+  it("accepts limit of 20 (max boundary)", () => {
+    expect(featuredMarketsQuerySchema.safeParse({ limit: 20 }).success).toBe(true);
+  });
+
+  it("rejects limit of 0", () => {
+    expect(featuredMarketsQuerySchema.safeParse({ limit: 0 }).success).toBe(false);
+  });
+
+  it("rejects limit above 20", () => {
+    expect(featuredMarketsQuerySchema.safeParse({ limit: 21 }).success).toBe(false);
+  });
+
+  it("rejects non-numeric limit", () => {
+    expect(featuredMarketsQuerySchema.safeParse({ limit: "abc" }).success).toBe(false);
+  });
+
+  it("rejects extra/unknown query parameters (strict)", () => {
+    const result = featuredMarketsQuerySchema.safeParse({ extra: "nope" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── upcomingMarketsQuerySchema ───────────────────────────────────────────────
+
+describe("upcomingMarketsQuerySchema", () => {
+  it("accepts empty query (default limit 50)", () => {
+    const result = upcomingMarketsQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(50);
+    }
+  });
+
+  it("accepts valid limit", () => {
+    const result = upcomingMarketsQuerySchema.safeParse({ limit: 25 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(25);
+    }
+  });
+
+  it("accepts limit of 1 (min boundary)", () => {
+    expect(upcomingMarketsQuerySchema.safeParse({ limit: 1 }).success).toBe(true);
+  });
+
+  it("accepts limit of 100 (max boundary)", () => {
+    expect(upcomingMarketsQuerySchema.safeParse({ limit: 100 }).success).toBe(true);
+  });
+
+  it("rejects limit of 0", () => {
+    expect(upcomingMarketsQuerySchema.safeParse({ limit: 0 }).success).toBe(false);
+  });
+
+  it("rejects limit above 100", () => {
+    expect(upcomingMarketsQuerySchema.safeParse({ limit: 101 }).success).toBe(false);
+  });
+
+  it("rejects extra/unknown query parameters (strict)", () => {
+    const result = upcomingMarketsQuerySchema.safeParse({ extra: "nope" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── trendingQuerySchema ──────────────────────────────────────────────────────
+
+describe("trendingQuerySchema", () => {
+  it("accepts empty query (defaults: limit=20, offset=0)", () => {
+    const result = trendingQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(20);
+      expect(result.data.offset).toBe(0);
+    }
+  });
+
+  it("accepts valid limit and offset", () => {
+    const result = trendingQuerySchema.safeParse({ limit: 50, offset: 10 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(50);
+      expect(result.data.offset).toBe(10);
+    }
+  });
+
+  it("accepts limit of 1 (min boundary)", () => {
+    expect(trendingQuerySchema.safeParse({ limit: 1 }).success).toBe(true);
+  });
+
+  it("accepts limit of 100 (max boundary)", () => {
+    expect(trendingQuerySchema.safeParse({ limit: 100 }).success).toBe(true);
+  });
+
+  it("rejects limit of 0", () => {
+    expect(trendingQuerySchema.safeParse({ limit: 0 }).success).toBe(false);
+  });
+
+  it("rejects limit above 100", () => {
+    expect(trendingQuerySchema.safeParse({ limit: 101 }).success).toBe(false);
+  });
+
+  it("rejects negative offset", () => {
+    expect(trendingQuerySchema.safeParse({ offset: -1 }).success).toBe(false);
+  });
+
+  it("accepts offset of 0", () => {
+    expect(trendingQuerySchema.safeParse({ offset: 0 }).success).toBe(true);
+  });
+
+  it("rejects extra/unknown query parameters (strict)", () => {
+    const result = trendingQuerySchema.safeParse({ sort: "hot" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── marketParamsSchema ───────────────────────────────────────────────────────
+
+describe("marketParamsSchema", () => {
+  it("accepts valid market ID", () => {
+    const result = marketParamsSchema.safeParse({ id: "market-123" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe("market-123");
+    }
+  });
+
+  it("trims whitespace from ID", () => {
+    const result = marketParamsSchema.safeParse({ id: "  market-1  " });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe("market-1");
+    }
+  });
+
+  it("rejects empty ID", () => {
+    const result = marketParamsSchema.safeParse({ id: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects whitespace-only ID", () => {
+    const result = marketParamsSchema.safeParse({ id: "   " });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects ID exceeding max length", () => {
+    const result = marketParamsSchema.safeParse({ id: "x".repeat(256) });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts ID at max length", () => {
+    const result = marketParamsSchema.safeParse({ id: "x".repeat(255) });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing ID", () => {
+    const result = marketParamsSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-string ID", () => {
+    const result = marketParamsSchema.safeParse({ id: 123 });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── patchMarketBodySchema ────────────────────────────────────────────────────
+
+describe("patchMarketBodySchema", () => {
+  it("accepts valid question", () => {
+    const result = patchMarketBodySchema.safeParse({
+      question: "New question?",
+      expectedVersion: 1,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.question).toBe("New question?");
+    }
+  });
+
+  it("trims whitespace from question", () => {
+    const result = patchMarketBodySchema.safeParse({
+      question: "  New question?  ",
+      expectedVersion: 1,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.question).toBe("New question?");
+    }
+  });
+
+  it("rejects empty question after trim", () => {
+    const result = patchMarketBodySchema.safeParse({
+      question: "   ",
+      expectedVersion: 1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects question exceeding max length", () => {
+    const result = patchMarketBodySchema.safeParse({
+      question: "x".repeat(513),
+      expectedVersion: 1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts question at max length", () => {
+    const result = patchMarketBodySchema.safeParse({
+      question: "x".repeat(512),
+      expectedVersion: 1,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts valid metadata", () => {
+    const result = patchMarketBodySchema.safeParse({
+      metadata: { category: "crypto", tags: ["btc"] },
+      expectedVersion: 0,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts body with only expectedVersion", () => {
+    const result = patchMarketBodySchema.safeParse({
+      expectedVersion: 0,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing expectedVersion", () => {
+    const result = patchMarketBodySchema.safeParse({
+      question: "Updated?",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-integer expectedVersion", () => {
+    const result = patchMarketBodySchema.safeParse({
+      expectedVersion: 1.5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative expectedVersion", () => {
+    const result = patchMarketBodySchema.safeParse({
+      expectedVersion: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-numeric expectedVersion", () => {
+    const result = patchMarketBodySchema.safeParse({
+      expectedVersion: "not-a-number",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects extra/unknown fields (strict)", () => {
+    const result = patchMarketBodySchema.safeParse({
+      question: "Updated?",
+      expectedVersion: 1,
+      status: "resolved",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].code).toBe("unrecognized_keys");
+    }
+  });
+
+  it("rejects empty body", () => {
+    const result = patchMarketBodySchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── Schema type exports ──────────────────────────────────────────────────────
+
+describe("exported types", () => {
+  it("exports ListMarketsQuery type", () => {
+    // Type-level check: this test compiles if the type exists
+    const data: import("../src/validators/markets").ListMarketsQuery = {
+      limit: 10,
+      cursor: undefined,
+      status: undefined,
+      category: undefined,
+      tag: undefined,
+      sort: undefined,
+      order: undefined,
+    };
+    expect(data.limit).toBe(10);
+  });
+
+  it("exports TrendingQuery type", () => {
+    const data: import("../src/validators/markets").TrendingQuery = {
+      limit: 20,
+      offset: 0,
+    };
+    expect(data.limit).toBe(20);
+  });
+
+  it("exports MarketParams type", () => {
+    const data: import("../src/validators/markets").MarketParams = {
+      id: "market-1",
+    };
+    expect(data.id).toBe("market-1");
+  });
+});


### PR DESCRIPTION
## feat: input validation for markets

Adds Zod-validated input schemas for all market endpoints with `.strict()` mode, max-length constraints, explicit type error messages, and centralized trending schema.

### Changes

**`src/validators/markets.ts`**
- Added `.strict()` to all query schemas (`listMarketsQuerySchema`, `searchMarketsQuerySchema`, `featuredMarketsQuerySchema`, `upcomingMarketsQuerySchema`) to reject unknown/extra query parameters at the validation boundary
- Added `trendingQuerySchema` (centralized from inline definition in `trending.ts`)
- Added `invalid_type_error` messages on all `z.string()` and `z.coerce.number()` fields for clearer error responses
- Added max-length constraints: `cursor` → 512, `status` → 32, `category`/`tag` → 64, `sort` → 32, `q` → 256, `question` → 512
- Added `TrendingQuery` type export

**`src/routes/markets/trending.ts`**
- Replaced inline `trendingQuerySchema` with import from `src/validators/markets`

**`tests/markets-validation.test.ts`** (new)
- 85 tests covering all 8 schemas: happy paths, defaults, boundary values (min/max), `.strict()` rejection, max-length rejection, type coercion, missing required fields, empty/whitespace strings, and type export verification

### Validation approach

All schemas follow the established `predictions.ts` pattern:
- `.strict()` on all query/body schemas to reject unknown fields
- `z.coerce.number()` for query params with explicit `invalid_type_error`
- `z.string().trim().max(N)` for bounded string fields
- Global `errorHandler` maps `ZodError` to `400 { error: { type: "validation_error", details: [...] } }`

### Test results

Tests:       85 passed, 85 total
Test Suites: 1 passed, 1 total

Lint: 0 errors on all changed files.
Typecheck: 0 new type errors (pre-existing errors in unrelated files only).

### Breaking changes

- Query schemas now reject previously-accepted unknown parameters via `.strict()`. Any client sending extra query params (e.g. `?debug=true`) will receive a 400 instead of silently ignoring them.

### Checklist

- [x] Implementation matches the description
- [x] Tests added and passing (85 tests)
- [x] Code review approved
- [x] Code adheres to repo lint and style
- [x] Input validation at the boundary with standardized error envelope
- [x] Structured logging with correlation IDs (unchanged — existing pattern preserved)

Closes #343 