### PR TITLE
feat(logging): add structured JSON access logs for /api/tags

### DIFF
--- a/src/middleware/accessLog.ts
+++ b/src/middleware/accessLog.ts
@@ -23,7 +23,8 @@
  * The log name is selected by route prefix so consumers can filter access logs
  * more easily: `/api/users` => `users_access_log`, `/api/auth` =>
  * `auth_access_log`, `/api/predictions` => `predictions_access_log`,
- * and `/api/markets` => `markets_access_log`.
+ * `/api/markets` => `markets_access_log`, and `/api/tags` =>
+ * `tags_access_log`.
  *
  * Usage
  * -----
@@ -96,8 +97,9 @@ function resolveIp(req: Request): string {
  * Express middleware — structured access logger with correlation IDs.
  *
  * Stamps `res.locals.correlationId` and hooks `res.on("finish")` to emit
- * a `users_access_log`, `auth_access_log`, `predictions_access_log`, or
- * `markets_access_log` log entry once the response has been flushed.
+ * a `users_access_log`, `auth_access_log`, `predictions_access_log`,
+ * `markets_access_log`, or `tags_access_log` log entry once the response
+ * has been flushed.
  * Always calls `next()` so it is safe to mount as the first middleware on
  * any router without affecting the handler chain.
  */
@@ -125,6 +127,8 @@ export function accessLog(req: Request, res: Response, next: NextFunction): void
       logName = "predictions_access_log";
     } else if (req.originalUrl.startsWith("/api/markets")) {
       logName = "markets_access_log";
+    } else if (req.originalUrl.startsWith("/api/tags")) {
+      logName = "tags_access_log";
     }
 
     const durationMs = Date.now() - startMs;

--- a/src/routes/tags.ts
+++ b/src/routes/tags.ts
@@ -1,6 +1,8 @@
 import { Router } from "express";
+import { accessLog } from "../middleware/accessLog";
 
 export const tagsRouter = Router();
+tagsRouter.use(accessLog);
 
 /**
  * @openapi

--- a/tests/routes/tags.test.ts
+++ b/tests/routes/tags.test.ts
@@ -12,7 +12,6 @@ describe("Tags API", () => {
   });
 
   afterAll(async () => {
-    // Clean up auth pool to avoid hanging tests
     await closeAuthPool();
   });
 
@@ -38,5 +37,22 @@ describe("Tags API", () => {
     const res = await request(app).get("/api/tags?limit=200");
     expect(res.status).toBe(400);
     expect(res.body).toHaveProperty("error.code", "invalid_input");
+  });
+
+  it("should return X-Correlation-Id header from accessLog middleware", async () => {
+    const res = await request(app)
+      .get("/api/tags")
+      .set("X-Correlation-Id", "test-corr-123");
+    expect(res.status).toBe(200);
+    expect(res.headers["x-correlation-id"]).toBe("test-corr-123");
+  });
+
+  it("should generate a correlation ID when none is supplied", async () => {
+    const res = await request(app).get("/api/tags");
+    expect(res.status).toBe(200);
+    expect(res.headers["x-correlation-id"]).toBeDefined();
+    expect(res.headers["x-correlation-id"]).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
   });
 });

--- a/tests/usersAccessLog.test.ts
+++ b/tests/usersAccessLog.test.ts
@@ -373,6 +373,37 @@ describe("accessLog middleware", () => {
     );
   });
 
+  it("emits a tags_access_log entry when originalUrl starts with /api/tags", async () => {
+    const req = makeReq({
+      headers: { "x-correlation-id": "tags-log-test-id" },
+      method: "GET",
+      path: "/api/tags",
+      ip: "10.0.0.4",
+    });
+    const res = makeRes();
+    const next: NextFunction = jest.fn();
+
+    accessLog(req, res, next);
+    await fireFinish(res);
+
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        correlationId: "tags-log-test-id",
+        method: "GET",
+        path: "/api/tags",
+        statusCode: 200,
+        ip: "10.0.0.4",
+        durationMs: expect.any(Number),
+        "req-id": "tags-log-test-id",
+        status: 200,
+        latency: expect.any(Number),
+        size: 0,
+        actor: "anonymous",
+      }),
+      "tags_access_log",
+    );
+  });
+
   it("logs the correct statusCode for a 400 response", async () => {
     const req = makeReq({ headers: { "x-correlation-id": "bad-req-id" } });
     const res = makeRes();


### PR DESCRIPTION
Closes #597

Implements structured JSON access logging for the `/api/tags` endpoint.

### Changes
- Added structured JSON access logs for `/api/tags`
- Included request correlation ID (`req-id`)
- Logged request latency
- Logged HTTP status code
- Logged response size
- Logged actor information where available
- Added focused unit/integration tests
- Updated documentation for the new logging behavior
- Ensured compliance with the project's logging conventions and middleware

### Validation
- Added focused tests covering the new logging behavior
- Verified standardized logging output
- Verified correlation IDs are propagated correctly
- Confirmed input validation and standardized error responses remain unchanged

### Checklist

- [x] Added structured JSON access logging
- [x] Included request ID, latency, status, response size, and actor
- [x] Added focused tests
- [x] Updated documentation
- [x] Followed repository linting and coding standards

