### PR TITLE
feat: add structured access logs for /api/feature-flags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { usersHealthRouter } from "./routes/users/health";
 import { userPortfolioRouter } from "./routes/users/portfolio";
 import { userStatsRouter } from "./routes/users/stats";
 import { devicesRouter } from "./routes/devices";
+import { featureFlagsRouter } from "./routes/feature-flags";
 import { adminFeatureFlagsRouter } from "./routes/admin/featureFlags";
 import { adminUsersRouter } from "./routes/adminUsers";
 import { adminNotesRouter } from "./routes/admin/users/notes";
@@ -176,6 +177,7 @@ export function createApp(_options: CreateAppOptions = {}): express.Express {
   app.use("/api/audit/counts", auditCountsRouter);
   app.use("/api/admin/users", adminUsersRouter);
   app.use("/api/admin/users", adminNotesRouter);
+  app.use("/api/feature-flags", featureFlagsRouter);
   app.use("/api/admin/feature-flags", adminFeatureFlagsRouter);
   app.use("/api/admin/markets", adminMarketsRouter);
   app.use("/api/admin/schema-versions", adminSchemaVersionsRouter);

--- a/src/middleware/accessLog.ts
+++ b/src/middleware/accessLog.ts
@@ -125,6 +125,8 @@ export function accessLog(req: Request, res: Response, next: NextFunction): void
       logName = "predictions_access_log";
     } else if (req.originalUrl.startsWith("/api/markets")) {
       logName = "markets_access_log";
+    } else if (req.originalUrl.startsWith("/api/feature-flags")) {
+      logName = "feature_flags_access_log";
     }
 
     const durationMs = Date.now() - startMs;

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,22 +1,4 @@
-
 import type { NextFunction, Request, Response } from "express";
-import { logger } from "../config/logger";
-
-/*
- * Status → error code mapping:
- *   err.status=400  → 400  request_failed    (generic bad request)
- *   err.status=404  → 404  not_found
- *   err.status=409  → 409  conflict
- *   err.status=422  → 422  unprocessable
- *   other 4xx       → 4xx  request_failed
- *   5xx / unknown   → 500  internal_error    (internals never leaked)
- */
-export function errorHandler(err: unknown, req: Request, res: Response, _next: NextFunction) {
-  logger.error({ err, path: req.path, method: req.method }, "request_failed");
-  const status = (err as { status?: number }).status ?? 500;
-  const code = (err as { code?: string }).code ?? (status === 500 ? "internal_error" : "request_failed");
-  res.status(status).json({
-    error: { code },
 import { ZodError } from "zod";
 import { randomUUID } from "crypto";
 import { logger } from "../config/logger";

--- a/src/routes/feature-flags.ts
+++ b/src/routes/feature-flags.ts
@@ -1,0 +1,47 @@
+import { Router, type Request, type Response, type NextFunction } from "express";
+import { getAllFlags } from "../services/featureFlags";
+import { accessLog } from "../middleware/accessLog";
+import { featureFlagsQuerySchema } from "../schemas/feature-flags.schema";
+import { RouteErrorFactory } from "../errors";
+
+export const featureFlagsRouter = Router();
+
+// Mount the access log middleware so every request to /api/feature-flags gets logged
+featureFlagsRouter.use(accessLog);
+
+/**
+ * GET /api/feature-flags
+ * Public endpoint returning active feature flag values for the calling user/client.
+ */
+featureFlagsRouter.get("/", (req: Request, res: Response, next: NextFunction) => {
+  const correlationId = res.locals.correlationId;
+
+  try {
+    const parseResult = featureFlagsQuerySchema.safeParse(req.query);
+    if (!parseResult.success) {
+      throw RouteErrorFactory.validation(
+        "Invalid query parameters",
+        parseResult.error.flatten().fieldErrors as Record<string, string[]>,
+      );
+    }
+
+    const flags = getAllFlags();
+
+    // Transform array into key-value map format for client consumption
+    const flagMap = flags.reduce((acc, flag) => {
+      acc[flag.id] = {
+        enabled: flag.enabled,
+        variant: flag.variant ?? null,
+      };
+      return acc;
+    }, {} as Record<string, { enabled: boolean; variant: string | null }>);
+
+    return res.status(200).json({
+      success: true,
+      data: flagMap,
+      correlationId,
+    });
+  } catch (error) {
+    next(error);
+  }
+});

--- a/src/routes/markets/watchers.ts
+++ b/src/routes/markets/watchers.ts
@@ -15,9 +15,9 @@
 
 import { Router } from "express";
 import { logger } from "../../config/logger";
-import { NotFoundError } from "../../errors";
 import { getRequestId } from "../../lib/requestContext";
-import { AuthenticatedRequest, requireAuth } from "../../middleware/auth";
+import { AuthenticatedRequest } from "../../middleware/auth";
+import { requireAuth } from "../../middleware/requireAuth";
 import {
   listMarketWatchers,
   addMarketWatcher,

--- a/src/services/featureFlags.ts
+++ b/src/services/featureFlags.ts
@@ -1,47 +1,151 @@
-import { Router, Request, Response } from 'express';
-import { getAllFlags } from '../services/featureFlags';
-import { logger } from '../config/logger';
-import { getRequestId } from '../lib/requestContext';
+import { eq } from "drizzle-orm";
+import { db } from "../db/client";
+import { featureFlags } from "../db/schema";
+import { env } from "../config/env";
+import { logger } from "../config/logger";
+import { getRequestId } from "../lib/requestContext";
 
-export const featureFlagsRouter = Router();
+export interface FeatureFlag {
+  id: string;
+  enabled: boolean;
+  variant?: string | null;
+  description?: string | null;
+}
+
+// In-memory cache
+const flagsCache = new Map<string, FeatureFlag>();
+let refreshInterval: NodeJS.Timeout | null = null;
 
 /**
- * GET /feature-flags
- * Public endpoint returning active feature flag values for the calling user/client.
+ * Loads all flags from Postgres into the in-memory map.
  */
-featureFlagsRouter.get('/', (req: Request, res: Response) => {
-  const reqId = getRequestId() || (req.headers['x-correlation-id'] as string) || crypto.randomUUID();
-
-  logger.info({ reqId, path: req.originalUrl }, 'Fetching public feature flags');
-
+async function loadFlags() {
+  const start = Date.now();
   try {
-    const flags = getAllFlags();
-
-    // Transform array into key-value map format for client consumption
-    const flagMap = flags.reduce((acc, flag) => {
-      acc[flag.id] = {
-        enabled: flag.enabled,
-        variant: flag.variant ?? null,
-      };
-      return acc;
-    }, {} as Record<string, { enabled: boolean; variant: string | null }>);
-
-    res.setHeader('x-correlation-id', reqId);
-    return res.status(200).json({
-      success: true,
-      data: flagMap,
-      correlationId: reqId,
-    });
+    const rows = await db.select().from(featureFlags);
+    flagsCache.clear();
+    for (const row of rows) {
+      flagsCache.set(row.id, {
+        id: row.id,
+        enabled: row.enabled,
+        variant: row.variant,
+        description: row.description,
+      });
+    }
+    const duration = Date.now() - start;
+    logger.info(
+      { count: rows.length, duration, reqId: getRequestId() },
+      "Feature flags cache refreshed",
+    );
   } catch (error) {
-    logger.error({ err: error, reqId }, 'Failed to fetch public feature flags');
-
-    return res.status(500).json({
-      success: false,
-      error: {
-        code: 'INTERNAL_SERVER_ERROR',
-        message: 'An error occurred while retrieving feature flags',
-      },
-      correlationId: reqId,
-    });
+    logger.error(
+      { err: error, reqId: getRequestId() },
+      "Failed to refresh feature flags cache, continuing with stale cache",
+    );
   }
-});
+}
+
+/**
+ * Initializes the feature flags service.
+ * Loads the initial state and starts the refresh interval.
+ *
+ * Cache invalidation strategy:
+ * - We rely on a periodic background refresh (default 30s) to sync all instances.
+ * - This provides eventual consistency across multiple nodes.
+ * - Local mutations immediately write-through to Postgres and update the local map,
+ *   so the writer immediately sees their own changes.
+ */
+export async function initFeatureFlags() {
+  await loadFlags();
+  const ttlMs = env.FLAGS_CACHE_TTL_SECONDS * 1000;
+  refreshInterval = setInterval(() => {
+    loadFlags().catch((err) => {
+      logger.error({ err, reqId: getRequestId() }, "Unhandled error in loadFlags background task");
+    });
+  }, ttlMs);
+}
+
+/** Stop the polling loop, mainly for tests/shutdown. */
+export function stopFeatureFlags() {
+  if (refreshInterval) {
+    clearInterval(refreshInterval);
+    refreshInterval = null;
+  }
+}
+
+export function getFlag(key: string): { enabled: boolean; variant?: string } | undefined {
+  const flag = flagsCache.get(key);
+  if (!flag) return undefined;
+  return { enabled: flag.enabled, variant: flag.variant ?? undefined };
+}
+
+export function getAllFlags(): FeatureFlag[] {
+  return Array.from(flagsCache.values());
+}
+
+export async function createFlag(data: {
+  key: string;
+  enabled: boolean;
+  variant?: string | null;
+  description?: string | null;
+}): Promise<FeatureFlag> {
+  const [row] = await db.insert(featureFlags)
+    .values({
+      id: data.key,
+      enabled: data.enabled,
+      variant: data.variant,
+      description: data.description,
+    })
+    .returning();
+
+  const flag = {
+    id: row.id,
+    enabled: row.enabled,
+    variant: row.variant,
+    description: row.description,
+  };
+  
+  flagsCache.set(data.key, flag);
+  logger.info({ action: "create_flag", key: data.key, reqId: getRequestId() }, "Feature flag created");
+  return flag;
+}
+
+export async function updateFlag(key: string, data: Partial<{ enabled: boolean; variant: string | null; description: string | null }>): Promise<FeatureFlag | undefined> {
+  const updateData: Record<string, unknown> = { updatedAt: new Date() };
+  if (data.enabled !== undefined) updateData.enabled = data.enabled;
+  if (data.variant !== undefined) updateData.variant = data.variant;
+  if (data.description !== undefined) updateData.description = data.description;
+
+  const [row] = await db.update(featureFlags)
+    .set(updateData)
+    .where(eq(featureFlags.id, key))
+    .returning();
+
+  if (!row) {
+    return undefined;
+  }
+
+  const flag = {
+    id: row.id,
+    enabled: row.enabled,
+    variant: row.variant,
+    description: row.description,
+  };
+
+  flagsCache.set(key, flag);
+  logger.info({ action: "update_flag", key, reqId: getRequestId() }, "Feature flag updated");
+  return flag;
+}
+
+export async function deleteFlag(key: string): Promise<boolean> {
+  const [row] = await db.delete(featureFlags)
+    .where(eq(featureFlags.id, key))
+    .returning();
+
+  if (row) {
+    flagsCache.delete(key);
+    logger.info({ action: "delete_flag", key, reqId: getRequestId() }, "Feature flag deleted");
+    return true;
+  }
+  return false;
+}

--- a/tests/featureFlagsAccessLog.test.ts
+++ b/tests/featureFlagsAccessLog.test.ts
@@ -1,0 +1,130 @@
+/**
+ * tests/featureFlagsAccessLog.test.ts
+ *
+ * Focused unit tests for access logging of /api/feature-flags using src/middleware/accessLog.ts
+ */
+
+process.env.NODE_ENV = "test";
+process.env.PORT = "3001";
+process.env.LOG_LEVEL = "fatal";
+process.env.DATABASE_URL = "postgres://localhost/test";
+process.env.JWT_SECRET = "access-log-test-secret-at-least-32-bytes!!";
+process.env.JWT_ISSUER = "predictify";
+process.env.JWT_AUDIENCE = "predictify-app";
+process.env.JWT_TTL_SECONDS = "3600";
+process.env.STELLAR_NETWORK = "testnet";
+process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "CABCDEF";
+
+// Mock pg & drizzle-orm to prevent actual DB socket calls during test setup
+jest.mock("pg", () => {
+  const Pool = jest.fn().mockImplementation(() => ({
+    connect: jest.fn(),
+    query: jest.fn(),
+    end: jest.fn(),
+    on: jest.fn(),
+  }));
+  return { Pool };
+});
+
+jest.mock("drizzle-orm/node-postgres", () => ({
+  drizzle: jest.fn(() => ({})),
+}));
+
+import * as loggerModule from "../src/config/logger";
+const loggerInfoSpy = jest.spyOn(loggerModule.logger, "info").mockImplementation(() => {});
+
+import type { Request, Response, NextFunction } from "express";
+import { EventEmitter } from "events";
+import { accessLog } from "../src/middleware/accessLog";
+
+function makeReq(overrides: Partial<{
+  headers: Record<string, string>;
+  id: string;
+  method: string;
+  path: string;
+  ip: string;
+}> = {}): Request {
+  return {
+    headers: overrides.headers ?? {},
+    id: overrides.id,
+    method: overrides.method ?? "GET",
+    path: overrides.path ?? "/api/feature-flags",
+    originalUrl: overrides.path ?? "/api/feature-flags",
+    ip: overrides.ip ?? "127.0.0.1",
+  } as unknown as Request;
+}
+
+function makeRes(): Response & { _headers: Record<string, string>; locals: Record<string, unknown> } {
+  const emitter = new EventEmitter();
+  const headers: Record<string, string> = {};
+
+  const res = Object.assign(emitter, {
+    locals: {} as Record<string, unknown>,
+    statusCode: 200,
+    setHeader(name: string, value: string) {
+      headers[name] = value;
+    },
+    getHeader(name: string) {
+      return headers[name] ?? headers[name.toLowerCase()];
+    },
+    get(name: string) {
+      return this.getHeader(name);
+    },
+    _headers: headers,
+  });
+
+  return res as unknown as Response & { _headers: Record<string, string>; locals: Record<string, unknown> };
+}
+
+async function fireFinish(res: EventEmitter): Promise<void> {
+  res.emit("finish");
+  await Promise.resolve();
+}
+
+describe("Feature Flags Access Log", () => {
+  beforeEach(() => {
+    loggerInfoSpy.mockClear();
+  });
+
+  it("emits a feature_flags_access_log entry on response finish with all required fields", async () => {
+    const req = makeReq({
+      headers: { "x-correlation-id": "ff-test-correlation-id" },
+      method: "GET",
+      path: "/api/feature-flags",
+      ip: "192.168.1.1",
+    });
+    // Set a user on req to verify actor is captured
+    (req as any).user = { id: "test-actor-id" };
+
+    const res = makeRes();
+    res.setHeader("Content-Length", "100");
+    res.statusCode = 200;
+
+    const next: NextFunction = jest.fn();
+
+    accessLog(req, res, next);
+    await fireFinish(res);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(loggerInfoSpy).toHaveBeenCalledTimes(1);
+
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "req-id": "ff-test-correlation-id",
+        correlationId: "ff-test-correlation-id",
+        method: "GET",
+        path: "/api/feature-flags",
+        statusCode: 200,
+        status: 200,
+        durationMs: expect.any(Number),
+        latency: expect.any(Number),
+        ip: "192.168.1.1",
+        size: 100,
+        actor: "test-actor-id",
+      }),
+      "feature_flags_access_log",
+    );
+  });
+});

--- a/tests/featureFlagsRoute.test.ts
+++ b/tests/featureFlagsRoute.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import express from 'express';
-import { featureFlagsRouter } from '../src/routes/featureFlags';
+import { featureFlagsRouter } from '../src/routes/feature-flags';
+import { errorHandler } from '../src/middleware/errorHandler';
 
 jest.mock('../src/services/featureFlags', () => ({
   getAllFlags: jest.fn().mockReturnValue([
@@ -12,6 +13,7 @@ jest.mock('../src/services/featureFlags', () => ({
 const app = express();
 app.use(express.json());
 app.use('/feature-flags', featureFlagsRouter);
+app.use(errorHandler);
 
 describe('GET /feature-flags', () => {
   it('should return 200 OK with formatted feature flags map', async () => {
@@ -35,5 +37,25 @@ describe('GET /feature-flags', () => {
     expect(res.status).toBe(200);
     expect(res.body.correlationId).toBe(correlationId);
     expect(res.headers['x-correlation-id']).toBe(correlationId);
+  });
+
+  it('should return 200 OK when valid query parameters are provided', async () => {
+    const res = await request(app)
+      .get('/feature-flags')
+      .query({ environment: 'development', clientVersion: '1.0.0' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('should return 422 Unprocessable Entity when invalid query parameters are provided', async () => {
+    const res = await request(app)
+      .get('/feature-flags')
+      .query({ environment: 'invalid-env' });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBeDefined();
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.message).toBe('Invalid query parameters');
   });
 });


### PR DESCRIPTION
Closes #617

I have successfully resolved the issue by restoring the broken service file, introducing the public /api/feature-flags route, validating input query parameters, mapping request logging under feature_flags_access_log, and writing automated tests to verify the behavior.

Changes Made
Restored Service
featureFlags.ts
: Restored the database-backed and cache-backed feature flags service code that was mistakenly overwritten.
Route & Controller
feature-flags.ts
 [NEW]: Implemented the router for public feature flags evaluation. Built with boundary query validation via featureFlagsQuerySchema and mapped to use the accessLog middleware.
index.ts
: Imported and mounted the public /api/feature-flags route in the Express application.
Logging Configuration
accessLog.ts
: Updated the access logging middleware to identify requests starting with /api/feature-flags and log under the structured name feature_flags_access_log.
Error & Import Fixes
errorHandler.ts
: Cleared duplicate/garbled imports and function signature remnants at the top of the file to fix a compilation syntax error.
watchers.ts
: Fixed the incorrect import path for requireAuth (changing import target from middleware/auth to middleware/requireAuth) to make unrelated market-watcher tests compile and pass.
Tests
featureFlagsRoute.test.ts
: Updated import path and added test scenarios validating successful queries and structured 422 validation errors.
featureFlagsAccessLog.test.ts
 [NEW]: Added a unit test verifying the accessLog middleware resolves matching URLs to feature_flags_access_log and correctly populates fields like req-id, latency, status, size, and actor.
Verification Results
All feature flag tests run and pass completely:

tests/featureFlags.test.ts:

PASS tests/featureFlags.test.ts (25.936 s)
  Feature Flags Service
    √ loads flags on init and caches them (44 ms)
    √ refreshes cache on interval and handles error gracefully (43 ms)
    √ creates a flag and updates cache (2 ms)
    √ updates a flag and updates cache (2 ms)
    √ deletes a flag and updates cache (1 ms)
tests/featureFlagsRoute.test.ts:

PASS tests/featureFlagsRoute.test.ts (17.03 s)
  GET /feature-flags
    √ should return 200 OK with formatted feature flags map (48 ms)
    √ should pass correlation ID in headers and response body (10 ms)
    √ should return 200 OK when valid query parameters are provided (10 ms)
    √ should return 422 Unprocessable Entity when invalid query parameters are provided (12 ms)
tests/featureFlagsAccessLog.test.ts:

PASS tests/featureFlagsAccessLog.test.ts (20.464 s)
  Feature Flags Access Log
    √ emits a feature_flags_access_log entry on response finish with all required fields (63 ms)