### PR TITLE
feat(security): add security header sweep for /api/subscriptions (#614)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -82,3 +82,41 @@ The test suite verifies:
 - `/health` (and by extension all `/api/*`) does **not** allow `'unsafe-inline'`
 - `/health` does **not** allow the Swagger CDN
 - The CSP header values for `/docs` and `/health` are not equal
+
+## Per-route header sweep: `/api/subscriptions`
+
+`GET /api/subscriptions` sets a dedicated, stricter header set on top of the
+global CSP, via [`src/middleware/securityHeaders.ts`](../src/middleware/securityHeaders.ts):
+
+| Header                     | Value                                                          |
+|----------------------------|-----------------------------------------------------------------|
+| `Content-Security-Policy`  | `default-src 'none'; frame-ancestors 'none'; base-uri 'none'`  |
+| `X-Content-Type-Options`   | `nosniff`                                                       |
+| `Referrer-Policy`          | `no-referrer`                                                   |
+
+This is intentionally stricter than the global CSP: `/api/subscriptions`
+returns JSON only and never needs to load any sub-resource, so `default-src
+'none'` denies everything rather than allowing `'self'` script/style
+loading the way the global policy does.
+
+`securityHeaders` is mounted **before** `requireAdmin` in
+[`src/routes/subscriptions.ts`](../src/routes/subscriptions.ts), so the
+headers are present on every response from this route — including the `403`
+returned for missing, invalid, or non-admin tokens.
+
+### Implementation reference
+
+- **Middleware**: [`src/middleware/securityHeaders.ts`](../src/middleware/securityHeaders.ts)
+- **Route definition**: [`src/routes/subscriptions.ts`](../src/routes/subscriptions.ts)
+- **Tests**: [`tests/securityHeaders.test.ts`](../tests/securityHeaders.test.ts),
+  [`tests/subscriptions.test.ts`](../tests/subscriptions.test.ts) — assert the
+  three headers on both a successful (200) response and the 403 returned by
+  `requireAdmin`.
+
+### Note: router mount status
+
+As of this change, `subscriptionsRouter` is not mounted in
+[`src/index.ts`](../src/index.ts) — it is currently exercised only via its
+test suite, which mounts it directly at `/api/subscriptions`. That gap
+predates this issue and is out of scope here; this document reflects the
+router's behavior once mounted, which is what the test suite exercises.

--- a/src/middleware/securityHeaders.ts
+++ b/src/middleware/securityHeaders.ts
@@ -1,0 +1,73 @@
+/**
+ * @module middleware/securityHeaders
+ *
+ * Sets a strict, JSON-API-appropriate set of security response headers:
+ * `Content-Security-Policy`, `X-Content-Type-Options`, and `Referrer-Policy`.
+ *
+ * Why a separate middleware from `middleware/csp.ts`
+ * ---------------------------------------------------
+ * `csp.ts` configures `helmet()` for HTML-serving surfaces (the Swagger docs
+ * page) that legitimately load scripts, styles, and fonts from a small
+ * allow-list of origins. Pure JSON API routes never render markup and never
+ * need to load any sub-resource, so they get a stricter, purpose-built
+ * policy instead of reusing the docs/browser-oriented one:
+ *
+ *   - `Content-Security-Policy: default-src 'none'; frame-ancestors 'none';
+ *     base-uri 'none'` — denies loading of any resource type and blocks the
+ *     response from ever being framed. Defence-in-depth: even though the
+ *     response is JSON and browsers won't execute it, this guarantees a
+ *     compliant client (or a browser tricked into rendering the body,
+ *     e.g. via a content-type confusion bug upstream) has zero capability.
+ *   - `X-Content-Type-Options: nosniff` — stops browsers from MIME-sniffing
+ *     the JSON body as HTML/script and executing it.
+ *   - `Referrer-Policy: no-referrer` — the request URL (which may embed
+ *     resource identifiers) is never leaked to a third party via the
+ *     `Referer` header on any outbound navigation/subrequest.
+ *
+ * Usage
+ * -----
+ *   import { securityHeaders } from "../middleware/securityHeaders";
+ *
+ *   // Mount first, before auth/business-logic middleware, so the headers
+ *   // are present on every response from this router — including 401/403s.
+ *   someRouter.use(securityHeaders);
+ */
+
+import type { NextFunction, Request, Response } from "express";
+import { logger } from "../config/logger";
+import { getCorrelationId } from "./correlation";
+
+/**
+ * The exact header/value pairs applied by {@link securityHeaders}.
+ * Exported so tests can assert against a single source of truth instead of
+ * duplicating literal strings.
+ */
+export const API_SECURITY_HEADERS: Readonly<Record<string, string>> = {
+  "Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'; base-uri 'none'",
+  "X-Content-Type-Options": "nosniff",
+  "Referrer-Policy": "no-referrer",
+};
+
+/**
+ * Express middleware — sets {@link API_SECURITY_HEADERS} on every response
+ * for the router it is mounted on, then calls `next()` unconditionally.
+ *
+ * Safe to mount as the very first middleware on any router: it never reads
+ * the request body, never throws, and never short-circuits the chain.
+ */
+export function securityHeaders(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  for (const [header, value] of Object.entries(API_SECURITY_HEADERS)) {
+    res.setHeader(header, value);
+  }
+
+  logger.debug(
+    { correlationId: getCorrelationId(), path: req.path },
+    "security_headers_applied",
+  );
+
+  next();
+}

--- a/src/routes/subscriptions.ts
+++ b/src/routes/subscriptions.ts
@@ -3,9 +3,14 @@ import { db } from "../db/client";
 import { webhookSubscriptions } from "../db/schema";
 import { conditionalGet } from "../middleware/etag";
 import { requireAdmin } from "../middleware/requireAdmin";
+import { securityHeaders } from "../middleware/securityHeaders";
 
 export const subscriptionsRouter = Router();
 
+// Mounted first so CSP / X-Content-Type-Options / Referrer-Policy are set
+// on every response from this router, including the 403 that requireAdmin
+// returns for unauthenticated/unauthorized callers.
+subscriptionsRouter.use(securityHeaders);
 subscriptionsRouter.use(requireAdmin);
 
 subscriptionsRouter.get("/", async (req, res, next) => {

--- a/tests/securityHeaders.test.ts
+++ b/tests/securityHeaders.test.ts
@@ -1,0 +1,48 @@
+process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
+process.env.JWT_SECRET = "abcdefghijklmnopqrstuvwxyz123456789012";
+process.env.SOROBAN_RPC_URL = "https://testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "test-contract-id";
+
+import express from "express";
+import request from "supertest";
+import {
+  securityHeaders,
+  API_SECURITY_HEADERS,
+} from "../src/middleware/securityHeaders";
+
+function makeApp() {
+  const app = express();
+  app.use("/probe", securityHeaders, (_req, res) => {
+    res.json({ ok: true });
+  });
+  return app;
+}
+
+describe("securityHeaders middleware", () => {
+  const app = makeApp();
+
+  it("sets Content-Security-Policy, X-Content-Type-Options, and Referrer-Policy", async () => {
+    const res = await request(app).get("/probe");
+
+    for (const [header, value] of Object.entries(API_SECURITY_HEADERS)) {
+      expect(res.headers[header.toLowerCase()]).toBe(value);
+    }
+  });
+
+  it("uses a deny-all CSP appropriate for a JSON-only endpoint", async () => {
+    const res = await request(app).get("/probe");
+    const csp = res.headers["content-security-policy"];
+
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("base-uri 'none'");
+  });
+
+  it("does not block the request — the handler still runs", async () => {
+    const res = await request(app).get("/probe");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+});

--- a/tests/subscriptions.test.ts
+++ b/tests/subscriptions.test.ts
@@ -1,0 +1,120 @@
+process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
+process.env.JWT_SECRET = "abcdefghijklmnopqrstuvwxyz123456789012";
+process.env.SOROBAN_RPC_URL = "https://testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "test-contract-id";
+
+/**
+ * Tests for GET /api/subscriptions
+ *
+ * Strategy:
+ *  - Mock src/db/client so no database is needed.
+ *  - Sign real JWTs with the test JWT_SECRET so requireAdmin executes its
+ *    full verification path (mirrors tests/adminUsers.test.ts).
+ *  - Mount subscriptionsRouter directly so securityHeaders and requireAdmin
+ *    run exactly as they do in the real app, in the real order.
+ */
+
+import request from "supertest";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { subscriptionsRouter } from "../src/routes/subscriptions";
+import { API_SECURITY_HEADERS } from "../src/middleware/securityHeaders";
+
+jest.mock("../src/db/client", () => {
+  const mDb = {
+    select: jest.fn().mockReturnThis(),
+    from: jest.fn(),
+  };
+  return { db: mDb };
+});
+
+import { db } from "../src/db/client";
+
+const SECRET = process.env.JWT_SECRET!;
+const ISSUER = process.env.JWT_ISSUER ?? "predictify";
+const AUDIENCE = process.env.JWT_AUDIENCE ?? "predictify-app";
+const ADMIN_ADDRESS = "GADMIN7777777777777777777777777777777777777777777777777777";
+
+function signJwt(payload: object): string {
+  return jwt.sign(payload, SECRET, { issuer: ISSUER, audience: AUDIENCE, expiresIn: "1h" });
+}
+
+const adminJwt = signJwt({ sub: ADMIN_ADDRESS, role: "admin" });
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/subscriptions", subscriptionsRouter);
+  return app;
+}
+
+const mockSubscriptions = [
+  {
+    id: "sub-1",
+    url: "https://example.com/webhook",
+    events: ["market.created"],
+    active: true,
+  },
+];
+
+function expectSecurityHeaders(res: request.Response) {
+  for (const [header, value] of Object.entries(API_SECURITY_HEADERS)) {
+    expect(res.headers[header.toLowerCase()]).toBe(value);
+  }
+}
+
+describe("GET /api/subscriptions", () => {
+  const app = makeApp();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns subscriptions for an authenticated admin", async () => {
+    (db.from as jest.Mock).mockResolvedValueOnce(mockSubscriptions);
+
+    const res = await request(app)
+      .get("/api/subscriptions")
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mockSubscriptions);
+  });
+
+  it("sets CSP, X-Content-Type-Options, and Referrer-Policy on a successful response", async () => {
+    (db.from as jest.Mock).mockResolvedValueOnce(mockSubscriptions);
+
+    const res = await request(app)
+      .get("/api/subscriptions")
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expectSecurityHeaders(res);
+  });
+
+  it("rejects an unauthenticated request with 403", async () => {
+    const res = await request(app).get("/api/subscriptions");
+
+    expect(res.status).toBe(403);
+  });
+
+  it("still sets the security headers on the 403 an unauthenticated request receives", async () => {
+    // securityHeaders is mounted ahead of requireAdmin, so the headers must
+    // be present even when auth rejects the request before it reaches the
+    // route handler / database.
+    const res = await request(app).get("/api/subscriptions");
+
+    expectSecurityHeaders(res);
+  });
+
+  it("still sets the security headers when a non-admin token is rejected with 403", async () => {
+    const userJwt = signJwt({ sub: "GUSER1", role: "user" });
+
+    const res = await request(app)
+      .get("/api/subscriptions")
+      .set("Authorization", `Bearer ${userJwt}`);
+
+    expect(res.status).toBe(403);
+    expectSecurityHeaders(res);
+  });
+});


### PR DESCRIPTION

Closes #614

Adds a dedicated securityHeaders middleware (Content-Security-Policy: default-src 'none', X-Content-Type-Options: nosniff, Referrer-Policy: no-referrer) to GET /api/subscriptions, stricter than the global CSP since this route is JSON-only. Mounted ahead of requireAdmin so headers apply even on the 403.

8 tests (unit + integration with real JWTs), 100% coverage on the new middleware. Documented in docs/security.md