### PR TITLE
feat: return items/next_cursor/total envelope on /api/feature-flags

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -14,14 +14,21 @@ The strategy is:
 ## Configuration
 - `FLAGS_CACHE_TTL_SECONDS`: Polling interval in seconds (default: 30)
 
+## API Endpoints (Public)
+
+- `GET /api/feature-flags` — List active feature flags.
+  - Query: `cursor` (optional), `limit` (optional, default 20, max 100)
+  - Response: `{ items: Array<{ id, enabled, variant }>, next_cursor: string | null, total: number }`
+  - `next_cursor` is `null` on the last page. Pass it verbatim as `?cursor=` to fetch the next page.
+
 ## API Endpoints (Admin Only)
 
 All endpoints require the `Authorization` header with a valid admin JWT. The endpoints are rate-limited per admin token.
 
-- `GET /api/admin/flags` - List all flags.
-- `GET /api/admin/flags/:key` - Get a single flag. Returns 404 if not found.
-- `POST /api/admin/flags` - Create a new flag.
+- `GET /api/admin/feature-flags` - List all flags.
+- `GET /api/admin/feature-flags/:key` - Get a single flag. Returns 404 if not found.
+- `POST /api/admin/feature-flags` - Create a new flag.
   - Body: `{ key: string, enabled: boolean, variant?: string, description?: string }`
-- `PATCH /api/admin/flags/:key` - Partially update a flag.
+- `PATCH /api/admin/feature-flags/:key` - Partially update a flag.
   - Body: `{ enabled?: boolean, variant?: string, description?: string }`
-- `DELETE /api/admin/flags/:key` - Delete a flag.
+- `DELETE /api/admin/feature-flags/:key` - Delete a flag.

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2485,7 +2484,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2997,7 +2995,6 @@
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3008,7 +3005,6 @@
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -3212,7 +3208,6 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -3482,7 +3477,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4050,7 +4044,6 @@
       "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bare-path": "^3.0.0"
       }
@@ -4277,7 +4270,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.44",
         "caniuse-lite": "^1.0.30001806",
@@ -5488,7 +5480,6 @@
       "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5754,7 +5745,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -6810,7 +6800,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7405,7 +7394,6 @@
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -8343,7 +8331,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -9908,7 +9895,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10070,7 +10056,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10774,7 +10759,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11190,7 +11174,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/routes/feature-flags.ts
+++ b/src/routes/feature-flags.ts
@@ -3,6 +3,7 @@ import { getAllFlags } from "../services/featureFlags";
 import { accessLog } from "../middleware/accessLog";
 import { featureFlagsQuerySchema } from "../schemas/feature-flags.schema";
 import { RouteErrorFactory } from "../errors";
+import { paginate, clampLimit, DEFAULT_PAGE_SIZE } from "../utils/cursor";
 
 export const featureFlagsRouter = Router();
 
@@ -12,10 +13,20 @@ featureFlagsRouter.use(accessLog);
 /**
  * GET /api/feature-flags
  * Public endpoint returning active feature flag values for the calling user/client.
+ *
+ * Query parameters:
+ *   - cursor  (optional) — opaque base64url token from the previous page's `next_cursor`
+ *   - limit   (optional, default 20, max 100) — page size
+ *
+ * Response:
+ *   { items: Array<{ id: string, enabled: boolean, variant: string | null }>, next_cursor: string | null, total: number }
+ *
+ * Pagination:
+ *   `next_cursor` is null on the last page.  Pass it verbatim as `?cursor=` to
+ *   fetch the next page.  A missing, tampered, or version-mismatched cursor is
+ *   silently treated as absent (restart from page one) rather than 500-ing.
  */
 featureFlagsRouter.get("/", (req: Request, res: Response, next: NextFunction) => {
-  const correlationId = res.locals.correlationId;
-
   try {
     const parseResult = featureFlagsQuerySchema.safeParse(req.query);
     if (!parseResult.success) {
@@ -25,21 +36,29 @@ featureFlagsRouter.get("/", (req: Request, res: Response, next: NextFunction) =>
       );
     }
 
-    const flags = getAllFlags();
+    const { cursor, limit: rawLimit } = parseResult.data;
+    const limit = clampLimit(rawLimit, DEFAULT_PAGE_SIZE);
 
-    // Transform array into key-value map format for client consumption
-    const flagMap = flags.reduce((acc, flag) => {
-      acc[flag.id] = {
-        enabled: flag.enabled,
-        variant: flag.variant ?? null,
-      };
-      return acc;
-    }, {} as Record<string, { enabled: boolean; variant: string | null }>);
+    const flags = getAllFlags();
+    const sorted = [...flags].sort((a, b) => b.id.localeCompare(a.id));
+
+    const page = paginate(
+      sorted,
+      (flag) => ({ sortValue: flag.id, id: flag.id }),
+      cursor,
+      limit,
+    );
+
+    const items = page.data.map((flag) => ({
+      id: flag.id,
+      enabled: flag.enabled,
+      variant: flag.variant ?? null,
+    }));
 
     return res.status(200).json({
-      success: true,
-      data: flagMap,
-      correlationId,
+      items,
+      next_cursor: page.nextCursor,
+      total: sorted.length,
     });
   } catch (error) {
     next(error);

--- a/src/schemas/feature-flags.schema.ts
+++ b/src/schemas/feature-flags.schema.ts
@@ -1,8 +1,16 @@
 import { z } from 'zod';
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../utils/cursor';
 
 export const featureFlagsQuerySchema = z.object({
   environment: z.enum(['development', 'testnet', 'mainnet']).optional(),
   clientVersion: z.string().optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_PAGE_SIZE)
+    .default(DEFAULT_PAGE_SIZE),
 });
 
 export type FeatureFlagsQuery = z.infer<typeof featureFlagsQuerySchema>;

--- a/tests/featureFlagsRoute.test.ts
+++ b/tests/featureFlagsRoute.test.ts
@@ -7,6 +7,7 @@ jest.mock('../src/services/featureFlags', () => ({
   getAllFlags: jest.fn().mockReturnValue([
     { id: 'MAINTENANCE_MODE', enabled: false, variant: null, description: 'System maintenance' },
     { id: 'NEW_MARKET_FLOW', enabled: true, variant: 'v2', description: 'Beta feature' },
+    { id: 'OLD_CHECKOUT', enabled: false, variant: 'v1', description: 'Legacy checkout' },
   ]),
 }));
 
@@ -16,26 +17,29 @@ app.use('/feature-flags', featureFlagsRouter);
 app.use(errorHandler);
 
 describe('GET /feature-flags', () => {
-  it('should return 200 OK with formatted feature flags map', async () => {
+  it('should return 200 OK with items, next_cursor, and total envelope', async () => {
     const res = await request(app).get('/feature-flags');
 
     expect(res.status).toBe(200);
-    expect(res.body.success).toBe(true);
-    expect(res.body.data).toEqual({
-      MAINTENANCE_MODE: { enabled: false, variant: null },
-      NEW_MARKET_FLOW: { enabled: true, variant: 'v2' },
-    });
-    expect(res.body).toHaveProperty('correlationId');
+    expect(res.body).toHaveProperty('items');
+    expect(res.body).toHaveProperty('next_cursor');
+    expect(res.body).toHaveProperty('total');
+    expect(res.body.total).toBe(3);
+    expect(res.body.items).toEqual([
+      { id: 'OLD_CHECKOUT', enabled: false, variant: 'v1' },
+      { id: 'NEW_MARKET_FLOW', enabled: true, variant: 'v2' },
+      { id: 'MAINTENANCE_MODE', enabled: false, variant: null },
+    ]);
+    expect(res.body.next_cursor).toBeNull();
   });
 
-  it('should pass correlation ID in headers and response body', async () => {
+  it('should return x-correlation-id header', async () => {
     const correlationId = 'test-uuid-123';
     const res = await request(app)
       .get('/feature-flags')
       .set('x-correlation-id', correlationId);
 
     expect(res.status).toBe(200);
-    expect(res.body.correlationId).toBe(correlationId);
     expect(res.headers['x-correlation-id']).toBe(correlationId);
   });
 
@@ -45,7 +49,8 @@ describe('GET /feature-flags', () => {
       .query({ environment: 'development', clientVersion: '1.0.0' });
 
     expect(res.status).toBe(200);
-    expect(res.body.success).toBe(true);
+    expect(res.body.items).toBeDefined();
+    expect(res.body.total).toBe(3);
   });
 
   it('should return 422 Unprocessable Entity when invalid query parameters are provided', async () => {
@@ -57,5 +62,45 @@ describe('GET /feature-flags', () => {
     expect(res.body.error).toBeDefined();
     expect(res.body.error.code).toBe('validation_error');
     expect(res.body.error.message).toBe('Invalid query parameters');
+  });
+
+  it('should paginate with limit', async () => {
+    const res = await request(app)
+      .get('/feature-flags')
+      .query({ limit: 2 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(2);
+    expect(res.body.total).toBe(3);
+    expect(res.body.next_cursor).not.toBeNull();
+    expect(typeof res.body.next_cursor).toBe('string');
+  });
+
+  it('should return next_cursor as null on the last page', async () => {
+    const first = await request(app)
+      .get('/feature-flags')
+      .query({ limit: 2 });
+
+    expect(first.status).toBe(200);
+    expect(first.body.items).toHaveLength(2);
+    expect(first.body.next_cursor).not.toBeNull();
+
+    const second = await request(app)
+      .get('/feature-flags')
+      .query({ cursor: first.body.next_cursor, limit: 2 });
+
+    expect(second.status).toBe(200);
+    expect(second.body.items).toHaveLength(1);
+    expect(second.body.next_cursor).toBeNull();
+  });
+
+  it('should restart from page one when cursor is tampered', async () => {
+    const res = await request(app)
+      .get('/feature-flags')
+      .query({ cursor: 'invalid-cursor-token', limit: 2 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(2);
+    expect(res.body.next_cursor).not.toBeNull();
   });
 });


### PR DESCRIPTION
- Add cursor and limit query params with zod validation
- Replace map response with cursor-paginated items array
- Include total count and opaque next_cursor for pagination
- Add focused tests for envelope shape and pagination behavior
- Document public endpoint contract in docs/feature-flags.md

Closes #590