### PR TITLE
feat: persist audit rows with before/after state for /api/indexer mut…

### DIFF
--- a/drizzle/migrations/0025_audit_logs_state_columns.sql
+++ b/drizzle/migrations/0025_audit_logs_state_columns.sql
@@ -1,0 +1,8 @@
+-- Migration: add before_state and after_state columns to audit_logs
+-- These nullable JSONB columns capture the relevant system state snapshot
+-- before and after every state-changing admin/indexer action so that audit
+-- entries carry full forensic context without requiring a JOIN.
+
+ALTER TABLE "audit_logs"
+  ADD COLUMN IF NOT EXISTS "before_state" jsonb,
+  ADD COLUMN IF NOT EXISTS "after_state"  jsonb;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -391,6 +391,10 @@ export const auditLogs = pgTable(
     ip: text("ip").notNull(),
     correlationId: text("correlation_id").notNull(),
     rateLimitContext: jsonb("rate_limit_context"),
+    /** Snapshot of the relevant state immediately before the mutating action. */
+    beforeState: jsonb("before_state"),
+    /** Snapshot of the relevant state immediately after the mutating action. */
+    afterState: jsonb("after_state"),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ import { connectWithRetry, closeDb, db } from "./db/client";
 import { stopScheduler } from "./services/scheduler";
 import { startIndexerHealthProbe, stopIndexerHealthProbe } from "./jobs/indexerHealthProbe";
 import { indexerHealthRouter } from "./routes/indexer/health";
+import { indexerCursorRouter } from "./routes/indexer/cursor";
 import { WebhookWorker } from "./workers/webhookWorker";
 import { marketResolverWorker } from "./workers/marketResolver";
 import { backupVerificationWorker } from "./workers/backupVerificationWorker";
@@ -141,6 +142,7 @@ export function createApp(_options: CreateAppOptions = {}): express.Express {
   app.use("/api/health/dependencies", dependenciesRouter);
   app.use("/api/health/version", versionRouter);
   app.use("/api/indexer", indexerHealthRouter);
+  app.use("/api/indexer/cursor", indexerCursorRouter);
 
   const mutationMethods = ["POST", "PATCH"] as const;
   app.use("/api", (req, res, next) =>

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,22 +1,4 @@
-
 import type { NextFunction, Request, Response } from "express";
-import { logger } from "../config/logger";
-
-/*
- * Status → error code mapping:
- *   err.status=400  → 400  request_failed    (generic bad request)
- *   err.status=404  → 404  not_found
- *   err.status=409  → 409  conflict
- *   err.status=422  → 422  unprocessable
- *   other 4xx       → 4xx  request_failed
- *   5xx / unknown   → 500  internal_error    (internals never leaked)
- */
-export function errorHandler(err: unknown, req: Request, res: Response, _next: NextFunction) {
-  logger.error({ err, path: req.path, method: req.method }, "request_failed");
-  const status = (err as { status?: number }).status ?? 500;
-  const code = (err as { code?: string }).code ?? (status === 500 ? "internal_error" : "request_failed");
-  res.status(status).json({
-    error: { code },
 import { ZodError } from "zod";
 import { randomUUID } from "crypto";
 import { logger } from "../config/logger";

--- a/src/routes/admin/reindex.ts
+++ b/src/routes/admin/reindex.ts
@@ -34,8 +34,7 @@ import { CORRELATION_ID_HEADER } from "../../lib/http";
 import { getCorrelationId } from "../../middleware/correlation";
 import { indexerService } from "../../services/indexerService";
 import { adminReindexTotal } from "../../metrics/registry";
-import { db } from "../../db";
-import { auditLogs } from "../../db/schema";
+import { createAuditLog } from "../../services/auditService";
 
 // ── Validation schema ────────────────────────────────────────────────────────
 
@@ -134,6 +133,11 @@ export function createAdminReindexRouter(
 
       const { ledger: from } = parsed.data;
 
+      // ── Before-state snapshot ─────────────────────────────────────────────
+      // Capture cursor position prior to the backfill so the audit row shows
+      // the full before→after transition.
+      const previousCursor = await indexerService.getCursor();
+
       // ── Backfill ─────────────────────────────────────────────────────────
       // getChainTip() goes to Soroban RPC; backfillRange() is chunked and
       // writes to indexer_events with ON CONFLICT DO NOTHING (idempotent).
@@ -142,15 +146,16 @@ export function createAdminReindexRouter(
 
       // ── Audit log ─────────────────────────────────────────────────────────
       // Written after the backfill so a failed backfill produces no audit row.
-      // The `ip` column is NOT NULL — fall back to "unknown" for programmatic
-      // callers that omit forwarding headers.
+      // beforeState / afterState capture the cursor transition for forensic
+      // traceability.
       const ip = extractClientIp(req as Parameters<typeof extractClientIp>[0]);
-      await db.insert(auditLogs).values({
+      await createAuditLog({
         action: "admin.reindex",
-        walletAddress: req.adminAddress ?? null,
+        walletAddress: req.adminAddress ?? undefined,
         ip,
         correlationId,
-        rateLimitContext: null,
+        beforeState: { cursor: previousCursor, from },
+        afterState: { cursor: to, from, to },
       });
 
       // ── Metrics & structured log ──────────────────────────────────────────

--- a/src/routes/indexer/cursor.ts
+++ b/src/routes/indexer/cursor.ts
@@ -1,0 +1,270 @@
+/**
+ * @module routes/indexer/cursor
+ *
+ * State-changing endpoints for the indexer cursor.
+ *
+ *   POST   /api/indexer/cursor   — advance the cursor to a specific ledger
+ *   DELETE /api/indexer/cursor   — reset the cursor back to the configured
+ *                                  INDEXER_START_LEDGER (effectively 0 for
+ *                                  re-indexing from genesis)
+ *
+ * Security
+ * ────────
+ * Both endpoints require a valid admin JWT (`role: "admin"`) via the
+ * `requireAdmin` middleware. Unauthenticated callers receive 403.
+ * Rate-limited per admin token (default 60 req/min).
+ *
+ * Audit
+ * ─────
+ * Every successful mutation writes a structured row to `audit_logs` via
+ * `createAuditLog`.  The row captures:
+ *   • action        — "indexer.cursor.advance" | "indexer.cursor.reset"
+ *   • walletAddress — the admin's Stellar address (actor)
+ *   • ip            — resolved from x-forwarded-for or socket
+ *   • correlationId — forwarded from AsyncLocalStorage / request id
+ *   • beforeState   — { cursor: <previous ledger> }
+ *   • afterState    — { cursor: <new ledger> }
+ *
+ * Observable side-effects
+ * ───────────────────────
+ * • Structured pino log at INFO level on success.
+ * • Audit failure is non-fatal (caught and logged at WARN by auditService).
+ *
+ * Injectable dependencies
+ * ───────────────────────
+ * All external I/O is encapsulated in `IndexerCursorRouterDeps` so tests
+ * can substitute fully-controlled stubs without network or DB access.
+ */
+
+import { Router } from "express";
+import { rateLimit } from "express-rate-limit";
+import { z } from "zod";
+import { logger } from "../../config/logger";
+import { requireAdmin } from "../../middleware/requireAdmin";
+import { CORRELATION_ID_HEADER } from "../../lib/http";
+import { getCorrelationId } from "../../middleware/correlation";
+import { createAuditLog } from "../../services/auditService";
+import { indexerService } from "../../services/indexerService";
+import { env } from "../../config/env";
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
+/**
+ * Body accepted by POST /api/indexer/cursor.
+ * `ledger` must be a positive integer (ledger sequences start at 1).
+ */
+const advanceCursorBodySchema = z.object({
+  ledger: z.number().int().positive(),
+});
+
+// ── Router options ────────────────────────────────────────────────────────────
+
+export interface IndexerCursorRouterOptions {
+  /**
+   * Maximum requests per minute per admin token.
+   * Defaults to 60 — matching all other admin-scoped routers.
+   */
+  rateLimitPerMinute?: number;
+}
+
+// ── Injectable dependency interface ──────────────────────────────────────────
+
+export interface IndexerCursorRouterDeps {
+  /** Read the current persisted cursor value (defaults to indexerService.getCursor). */
+  getCursor?: () => Promise<number>;
+  /** Advance the cursor to the given ledger (defaults to indexerService.advanceCursor). */
+  advanceCursor?: (ledger: number) => Promise<void>;
+  /** Persist an audit log entry (defaults to createAuditLog). */
+  auditLogger?: typeof createAuditLog;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Resolve the correlation ID from AsyncLocalStorage, then fall back to req.id. */
+function resolveCorrelationId(req: { id?: unknown }): string {
+  return (
+    getCorrelationId() ??
+    (typeof req.id === "string" ? req.id : "") ??
+    ""
+  );
+}
+
+/** Extract the client IP from forwarded headers or the socket. */
+function extractClientIp(req: {
+  ip?: string;
+  socket?: { remoteAddress?: string };
+  headers: Record<string, string | string[] | undefined>;
+}): string {
+  const forwarded = req.headers["x-forwarded-for"];
+  if (typeof forwarded === "string") {
+    const first = forwarded.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  if (Array.isArray(forwarded) && forwarded.length > 0) {
+    return forwarded[0] ?? "unknown";
+  }
+  return req.ip ?? req.socket?.remoteAddress ?? "unknown";
+}
+
+// ── Router factory ────────────────────────────────────────────────────────────
+
+/**
+ * Creates the /api/indexer/cursor router with injected dependencies.
+ *
+ * @param opts.rateLimitPerMinute  - Requests per minute per admin token (default 60).
+ * @param deps.getCursor           - Override cursor reader (tests only).
+ * @param deps.advanceCursor       - Override cursor writer (tests only).
+ * @param deps.auditLogger         - Override audit logger (tests only).
+ */
+export function createIndexerCursorRouter(
+  opts: IndexerCursorRouterOptions = {},
+  deps: IndexerCursorRouterDeps = {},
+): Router {
+  const rpmLimit = opts.rateLimitPerMinute ?? 60;
+  const getCursorFn = deps.getCursor ?? (() => indexerService.getCursor());
+  const advanceCursorFn = deps.advanceCursor ?? ((l) => indexerService.advanceCursor(l));
+  const auditLoggerFn = deps.auditLogger ?? createAuditLog;
+
+  const router = Router();
+
+  // ── Rate limiter ─────────────────────────────────────────────────────────
+  router.use(
+    rateLimit({
+      windowMs: 60_000,
+      limit: rpmLimit,
+      keyGenerator: (req) =>
+        (req.headers.authorization as string | undefined) ??
+        req.ip ??
+        "unknown",
+      standardHeaders: "draft-6",
+      legacyHeaders: false,
+      message: { error: { code: "rate_limit_exceeded" } },
+    }),
+  );
+
+  // ── Admin guard ──────────────────────────────────────────────────────────
+  router.use(requireAdmin);
+
+  // ── POST /api/indexer/cursor ─────────────────────────────────────────────
+  /**
+   * Advance the cursor to a specific ledger.
+   *
+   * Request body: { "ledger": <positive integer> }
+   *
+   * Response 200: { "data": { "from": <prev>, "to": <new> }, "correlationId": "…" }
+   */
+  router.post("", async (req, res, next) => {
+    try {
+      const correlationId = resolveCorrelationId(req);
+      res.setHeader(CORRELATION_ID_HEADER, correlationId);
+
+      const parsed = advanceCursorBodySchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({
+          error: {
+            code: "validation_error",
+            details: parsed.error.issues,
+            correlationId,
+          },
+        });
+      }
+
+      const { ledger } = parsed.data;
+
+      // Capture before-state for the audit log
+      const previousCursor = await getCursorFn();
+      const beforeState = { cursor: previousCursor };
+
+      // Persist the new cursor position
+      await advanceCursorFn(ledger);
+
+      const afterState = { cursor: ledger };
+
+      // Audit log — fire-and-forget (errors are caught inside auditService)
+      const ip = extractClientIp(req as Parameters<typeof extractClientIp>[0]);
+      await auditLoggerFn({
+        action: "indexer.cursor.advance",
+        walletAddress: (req as { adminAddress?: string }).adminAddress ?? undefined,
+        ip,
+        correlationId,
+        beforeState,
+        afterState,
+      });
+
+      logger.info(
+        {
+          correlationId,
+          adminAddress: (req as { adminAddress?: string }).adminAddress,
+          from: previousCursor,
+          to: ledger,
+        },
+        "indexer_cursor_advanced",
+      );
+
+      return res.status(200).json({
+        data: { from: previousCursor, to: ledger },
+        correlationId,
+      });
+    } catch (err) {
+      return next(err);
+    }
+  });
+
+  // ── DELETE /api/indexer/cursor ───────────────────────────────────────────
+  /**
+   * Reset the cursor to INDEXER_START_LEDGER (re-index from the beginning).
+   *
+   * No request body required.
+   *
+   * Response 200: { "data": { "from": <prev>, "to": <start_ledger> }, "correlationId": "…" }
+   */
+  router.delete("", async (req, res, next) => {
+    try {
+      const correlationId = resolveCorrelationId(req);
+      res.setHeader(CORRELATION_ID_HEADER, correlationId);
+
+      // Capture before-state
+      const previousCursor = await getCursorFn();
+      const resetTarget = env.INDEXER_START_LEDGER;
+      const beforeState = { cursor: previousCursor };
+
+      // Reset the cursor
+      await advanceCursorFn(resetTarget);
+
+      const afterState = { cursor: resetTarget };
+
+      // Audit log — fire-and-forget
+      const ip = extractClientIp(req as Parameters<typeof extractClientIp>[0]);
+      await auditLoggerFn({
+        action: "indexer.cursor.reset",
+        walletAddress: (req as { adminAddress?: string }).adminAddress ?? undefined,
+        ip,
+        correlationId,
+        beforeState,
+        afterState,
+      });
+
+      logger.info(
+        {
+          correlationId,
+          adminAddress: (req as { adminAddress?: string }).adminAddress,
+          from: previousCursor,
+          to: resetTarget,
+        },
+        "indexer_cursor_reset",
+      );
+
+      return res.status(200).json({
+        data: { from: previousCursor, to: resetTarget },
+        correlationId,
+      });
+    } catch (err) {
+      return next(err);
+    }
+  });
+
+  return router;
+}
+
+/** Default singleton wired into src/index.ts. */
+export const indexerCursorRouter = createIndexerCursorRouter();

--- a/tests/adminReindex.test.ts
+++ b/tests/adminReindex.test.ts
@@ -2,9 +2,9 @@
  * Unit tests for POST /api/admin/reindex
  *
  * All external I/O is mocked:
- *   - indexerService  (getChainTip, backfillRange)
- *   - db              (auditLogs insert)
- *   - adminReindexTotal Prometheus counter
+ *   - indexerService          (getCursor, getChainTip, backfillRange)
+ *   - auditService            (createAuditLog)
+ *   - adminReindexTotal       Prometheus counter
  *
  * The test app is assembled with a low rate-limit cap so the 429 path can be
  * exercised without hammering a real limiter.
@@ -17,16 +17,17 @@ import request from "supertest";
 // ── Mock: indexerService ─────────────────────────────────────────────────────
 jest.mock("../src/services/indexerService", () => ({
   indexerService: {
+    getCursor: jest.fn(),
     getChainTip: jest.fn(),
     backfillRange: jest.fn(),
   },
 }));
 
-// ── Mock: Drizzle db (audit log insert) ───────────────────────────────────────
-const mockInsert = jest.fn().mockReturnValue({
-  values: jest.fn().mockResolvedValue(undefined),
-});
-jest.mock("../src/db", () => ({ db: { insert: mockInsert } }));
+// ── Mock: auditService ────────────────────────────────────────────────────────
+const mockCreateAuditLog = jest.fn().mockResolvedValue("test-correlation-id");
+jest.mock("../src/services/auditService", () => ({
+  createAuditLog: (...args: unknown[]) => mockCreateAuditLog(...args),
+}));
 
 // ── Mock: Prometheus counter ──────────────────────────────────────────────────
 const mockInc = jest.fn();
@@ -84,11 +85,10 @@ function makeApp(rateLimitPerMinute = 60): express.Express {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockedIndexerService.getCursor.mockResolvedValue(50);
   mockedIndexerService.getChainTip.mockResolvedValue(200);
   mockedIndexerService.backfillRange.mockResolvedValue(undefined);
-  // Re-wire the insert chain after clearAllMocks
-  const valuesStub = jest.fn().mockResolvedValue(undefined);
-  mockInsert.mockReturnValue({ values: valuesStub });
+  mockCreateAuditLog.mockResolvedValue("test-correlation-id");
 });
 
 // ── Auth guard ─────────────────────────────────────────────────────────────────
@@ -162,15 +162,14 @@ describe("POST /api/admin/reindex", () => {
     expect(res.status).toBe(200);
     expect(mockedIndexerService.getChainTip).toHaveBeenCalledTimes(1);
     expect(mockedIndexerService.backfillRange).toHaveBeenCalledWith(42, 200);
-    expect(res.body).toEqual({
-      data: {
-        from: 42,
-        to: 200,
-      },
-    });
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        data: { from: 42, to: 200 },
+      }),
+    );
   });
 
-  it("echoes the x-request-id header in the response", async () => {
+  it("echoes the correlation-id in the response header", async () => {
     const res = await request(makeApp())
       .post("/api/admin/reindex")
       .set("Authorization", `Bearer ${adminJwt}`)
@@ -178,40 +177,50 @@ describe("POST /api/admin/reindex", () => {
       .send({ ledger: 10 });
 
     expect(res.status).toBe(200);
-    expect(res.headers["x-request-id"]).toBe("trace-xyz");
+    // The route sets x-correlation-id (CORRELATION_ID_HEADER), not x-request-id
+    expect(res.headers["x-correlation-id"]).toBe("trace-xyz");
   });
 
   it("records the correct IP in the audit log (single forwarded-for value)", async () => {
-    const valuesStub = jest.fn().mockResolvedValue(undefined);
-    mockInsert.mockReturnValue({ values: valuesStub });
-
     await request(makeApp())
       .post("/api/admin/reindex")
       .set("Authorization", `Bearer ${adminJwt}`)
       .set("X-Forwarded-For", "203.0.113.5")
       .send({ ledger: 1 });
 
-    expect(valuesStub).toHaveBeenCalledWith(
+    expect(mockCreateAuditLog).toHaveBeenCalledWith(
       expect.objectContaining({ ip: "203.0.113.5" }),
     );
   });
 
   it("writes a structured audit log entry on success", async () => {
-    const valuesStub = jest.fn().mockResolvedValue(undefined);
-    mockInsert.mockReturnValue({ values: valuesStub });
-
     await request(makeApp())
       .post("/api/admin/reindex")
       .set("Authorization", `Bearer ${adminJwt}`)
       .set("X-Request-Id", "audit-req")
       .send({ ledger: 100 });
 
-    expect(mockInsert).toHaveBeenCalledTimes(1);
-    expect(valuesStub).toHaveBeenCalledWith(
+    expect(mockCreateAuditLog).toHaveBeenCalledTimes(1);
+    expect(mockCreateAuditLog).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "admin.reindex",
         walletAddress: ADMIN_ADDR,
         correlationId: "audit-req",
+      }),
+    );
+  });
+
+  it("includes beforeState and afterState in the audit log entry", async () => {
+    // cursor = 50 (from mock), chainTip = 200 (from mock), from = 42
+    await request(makeApp())
+      .post("/api/admin/reindex")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 42 });
+
+    expect(mockCreateAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        beforeState: { cursor: 50, from: 42 },
+        afterState: { cursor: 200, from: 42, to: 200 },
       }),
     );
   });
@@ -264,7 +273,7 @@ describe("error propagation", () => {
     // The global errorHandler turns unhandled errors into 500.
     expect(res.status).toBe(500);
     // No audit log or counter should be written when the backfill fails.
-    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockCreateAuditLog).not.toHaveBeenCalled();
     expect(mockInc).not.toHaveBeenCalled();
   });
 
@@ -277,7 +286,7 @@ describe("error propagation", () => {
       .send({ ledger: 1 });
 
     expect(res.status).toBe(500);
-    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockCreateAuditLog).not.toHaveBeenCalled();
     expect(mockInc).not.toHaveBeenCalled();
   });
 });

--- a/tests/indexerCursor.test.ts
+++ b/tests/indexerCursor.test.ts
@@ -1,0 +1,517 @@
+/**
+ * Unit tests for the indexer cursor endpoints.
+ *
+ *   POST   /api/indexer/cursor   — advance the cursor to a specific ledger
+ *   DELETE /api/indexer/cursor   — reset the cursor to INDEXER_START_LEDGER
+ *
+ * All external I/O is mocked via injectable dependencies, so no database or
+ * network access is required.
+ *
+ * Coverage areas:
+ *   - Admin auth guard (403 without/with-wrong JWT)
+ *   - Input validation (POST only)
+ *   - Happy-path responses with correct before/after state in body
+ *   - Audit log is called with actor, action, beforeState, afterState, ip
+ *   - Audit log with x-forwarded-for IP extraction
+ *   - Rate limiting (429 after limit exceeded)
+ *   - Error propagation (getCursor / advanceCursor failures → 500)
+ *   - Audit NOT called on failure
+ */
+
+// ── Environment stubs (must be set before any module import) ─────────────────
+process.env.JWT_SECRET = "test-jwt-secret-at-least-32-bytes-long-000000";
+process.env.DATABASE_URL = "postgres://postgres:postgres@localhost:5432/predictify";
+process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "CABCDEF";
+process.env.ADMIN_ALLOWLIST = "GADMIN7777777777777777777777777777777777777777777777777777";
+process.env.INDEXER_START_LEDGER = "1";
+
+import express from "express";
+import jwt from "jsonwebtoken";
+import request from "supertest";
+import type { AuditEntryInput } from "../src/services/auditService";
+import {
+  createIndexerCursorRouter,
+  type IndexerCursorRouterDeps,
+  type IndexerCursorRouterOptions,
+} from "../src/routes/indexer/cursor";
+import { errorHandler } from "../src/middleware/errorHandler";
+
+// ── JWT helpers ───────────────────────────────────────────────────────────────
+
+const SECRET = process.env.JWT_SECRET;
+const ISSUER = process.env.JWT_ISSUER ?? "predictify";
+const AUDIENCE = process.env.JWT_AUDIENCE ?? "predictify-app";
+
+const ADMIN_ADDR = "GADMIN7777777777777777777777777777777777777777777777777777";
+const USER_ADDR = "GUSER88888888888888888888888888888888888888888888888888888";
+
+function signJwt(payload: object): string {
+  return jwt.sign(payload, SECRET!, { issuer: ISSUER, audience: AUDIENCE, expiresIn: "1h" });
+}
+
+const adminJwt = signJwt({ sub: ADMIN_ADDR, role: "admin" });
+const userJwt = signJwt({ sub: USER_ADDR, role: "user" });
+
+// ── App factory ───────────────────────────────────────────────────────────────
+
+/**
+ * Assemble a minimal Express app with the indexer cursor router mounted at
+ * /api/indexer/cursor.  All I/O is replaced with stubs from `deps`.
+ */
+function makeApp(
+  deps: IndexerCursorRouterDeps = {},
+  opts: IndexerCursorRouterOptions = {},
+): express.Express {
+  const app = express();
+  app.use(express.json());
+
+  // Simulate pino-http request-id injection from src/index.ts.
+  app.use((req, _res, next) => {
+    (req as express.Request & { id?: string }).id =
+      (req.headers["x-request-id"] as string | undefined) ?? "indexer-cursor-req";
+    next();
+  });
+
+  app.use("/api/indexer/cursor", createIndexerCursorRouter(opts, deps));
+  app.use(errorHandler);
+  return app;
+}
+
+// ── Default stub implementations ──────────────────────────────────────────────
+
+function makeStubs(overrides: {
+  currentCursor?: number;
+  getCursorError?: Error;
+  advanceCursorError?: Error;
+} = {}) {
+  const getCursor = jest.fn<Promise<number>, []>(async () => {
+    if (overrides.getCursorError) throw overrides.getCursorError;
+    return overrides.currentCursor ?? 100;
+  });
+  const advanceCursor = jest.fn<Promise<void>, [number]>(async () => {
+    if (overrides.advanceCursorError) throw overrides.advanceCursorError;
+  });
+  const auditLogger = jest.fn<Promise<string>, [AuditEntryInput]>(
+    async () => "test-correlation-id",
+  );
+  return { getCursor, advanceCursor, auditLogger };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Auth guard — both methods
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("auth guard", () => {
+  const stubs = makeStubs();
+
+  it("POST: returns 403 without Authorization header", async () => {
+    const res = await request(makeApp(stubs))
+      .post("/api/indexer/cursor")
+      .send({ ledger: 200 });
+    expect(res.status).toBe(403);
+    expect(stubs.advanceCursor).not.toHaveBeenCalled();
+  });
+
+  it("POST: returns 403 for a non-admin JWT", async () => {
+    const res = await request(makeApp(stubs))
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${userJwt}`)
+      .send({ ledger: 200 });
+    expect(res.status).toBe(403);
+    expect(stubs.advanceCursor).not.toHaveBeenCalled();
+  });
+
+  it("DELETE: returns 403 without Authorization header", async () => {
+    const res = await request(makeApp(stubs)).delete("/api/indexer/cursor");
+    expect(res.status).toBe(403);
+    expect(stubs.advanceCursor).not.toHaveBeenCalled();
+  });
+
+  it("DELETE: returns 403 for a non-admin JWT", async () => {
+    const res = await request(makeApp(stubs))
+      .delete("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${userJwt}`);
+    expect(res.status).toBe(403);
+    expect(stubs.advanceCursor).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/indexer/cursor — input validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("POST /api/indexer/cursor — validation", () => {
+  const stubs = makeStubs();
+
+  it("rejects a missing ledger field", async () => {
+    const res = await request(makeApp(stubs))
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+    expect(stubs.advanceCursor).not.toHaveBeenCalled();
+  });
+
+  it("rejects ledger = 0 (must be positive)", async () => {
+    const res = await request(makeApp(stubs))
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 0 });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("rejects a negative ledger", async () => {
+    const res = await request(makeApp(stubs))
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: -5 });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("rejects a non-integer ledger", async () => {
+    const res = await request(makeApp(stubs))
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 12.5 });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("rejects a string ledger", async () => {
+    const res = await request(makeApp(stubs))
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: "not-a-number" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/indexer/cursor — happy path
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("POST /api/indexer/cursor — success", () => {
+  it("advances cursor to the requested ledger and returns from/to", async () => {
+    const stubs = makeStubs({ currentCursor: 150 });
+
+    const res = await request(makeApp(stubs))
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 250 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ from: 150, to: 250 });
+    expect(stubs.advanceCursor).toHaveBeenCalledWith(250);
+  });
+
+  it("reads before-state cursor before writing", async () => {
+    const stubs = makeStubs({ currentCursor: 75 });
+
+    await request(makeApp(stubs))
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 200 });
+
+    expect(stubs.getCursor).toHaveBeenCalledTimes(1);
+    // getCursor must be called before advanceCursor
+    const getCursorOrder = stubs.getCursor.mock.invocationCallOrder[0];
+    const advanceCursorOrder = stubs.advanceCursor.mock.invocationCallOrder[0];
+    expect(getCursorOrder).toBeLessThan(advanceCursorOrder!);
+  });
+
+  it("emits a correlationId in the response header", async () => {
+    const stubs = makeStubs();
+
+    const res = await request(makeApp(stubs))
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .set("X-Request-Id", "trace-advance")
+      .send({ ledger: 300 });
+
+    expect(res.status).toBe(200);
+    // The route sets x-correlation-id (CORRELATION_ID_HEADER), not x-request-id
+    expect(res.headers["x-correlation-id"]).toBe("trace-advance");
+  });
+
+  it("writes an audit log with action=indexer.cursor.advance", async () => {
+    const stubs = makeStubs({ currentCursor: 100 });
+
+    await request(makeApp(stubs))
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 200 });
+
+    expect(stubs.auditLogger).toHaveBeenCalledTimes(1);
+    expect(stubs.auditLogger).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "indexer.cursor.advance" }),
+    );
+  });
+
+  it("audit log contains actor (walletAddress)", async () => {
+    const stubs = makeStubs({ currentCursor: 100 });
+
+    await request(makeApp(stubs))
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 200 });
+
+    expect(stubs.auditLogger).toHaveBeenCalledWith(
+      expect.objectContaining({ walletAddress: ADMIN_ADDR }),
+    );
+  });
+
+  it("audit log captures beforeState and afterState", async () => {
+    const stubs = makeStubs({ currentCursor: 100 });
+
+    await request(makeApp(stubs))
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 200 });
+
+    expect(stubs.auditLogger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        beforeState: { cursor: 100 },
+        afterState: { cursor: 200 },
+      }),
+    );
+  });
+
+  it("audit log captures the correlationId", async () => {
+    const stubs = makeStubs({ currentCursor: 50 });
+
+    await request(makeApp(stubs))
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .set("X-Request-Id", "audit-advance")
+      .send({ ledger: 150 });
+
+    expect(stubs.auditLogger).toHaveBeenCalledWith(
+      expect.objectContaining({ correlationId: "audit-advance" }),
+    );
+  });
+
+  it("audit log captures the client IP from x-forwarded-for", async () => {
+    const stubs = makeStubs();
+
+    await request(makeApp(stubs))
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .set("X-Forwarded-For", "198.51.100.7")
+      .send({ ledger: 300 });
+
+    expect(stubs.auditLogger).toHaveBeenCalledWith(
+      expect.objectContaining({ ip: "198.51.100.7" }),
+    );
+  });
+
+  it("audit log uses the first IP in a comma-separated x-forwarded-for list", async () => {
+    const stubs = makeStubs();
+
+    await request(makeApp(stubs))
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .set("X-Forwarded-For", "192.0.2.1, 10.0.0.2, 172.16.0.3")
+      .send({ ledger: 300 });
+
+    expect(stubs.auditLogger).toHaveBeenCalledWith(
+      expect.objectContaining({ ip: "192.0.2.1" }),
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DELETE /api/indexer/cursor — happy path
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("DELETE /api/indexer/cursor — success", () => {
+  it("resets cursor to INDEXER_START_LEDGER and returns from/to", async () => {
+    const stubs = makeStubs({ currentCursor: 500 });
+    const startLedger = parseInt(process.env.INDEXER_START_LEDGER!, 10); // = 1
+
+    const res = await request(makeApp(stubs))
+      .delete("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ from: 500, to: startLedger });
+    expect(stubs.advanceCursor).toHaveBeenCalledWith(startLedger);
+  });
+
+  it("emits a correlationId in the response header", async () => {
+    const stubs = makeStubs();
+
+    const res = await request(makeApp(stubs))
+      .delete("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .set("X-Request-Id", "trace-reset");
+
+    expect(res.status).toBe(200);
+    // The route sets x-correlation-id (CORRELATION_ID_HEADER), not x-request-id
+    expect(res.headers["x-correlation-id"]).toBe("trace-reset");
+  });
+
+  it("writes an audit log with action=indexer.cursor.reset", async () => {
+    const stubs = makeStubs({ currentCursor: 500 });
+
+    await request(makeApp(stubs))
+      .delete("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(stubs.auditLogger).toHaveBeenCalledTimes(1);
+    expect(stubs.auditLogger).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "indexer.cursor.reset" }),
+    );
+  });
+
+  it("audit log contains actor (walletAddress)", async () => {
+    const stubs = makeStubs({ currentCursor: 500 });
+
+    await request(makeApp(stubs))
+      .delete("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(stubs.auditLogger).toHaveBeenCalledWith(
+      expect.objectContaining({ walletAddress: ADMIN_ADDR }),
+    );
+  });
+
+  it("audit log captures beforeState and afterState for reset", async () => {
+    const stubs = makeStubs({ currentCursor: 500 });
+    const startLedger = parseInt(process.env.INDEXER_START_LEDGER!, 10);
+
+    await request(makeApp(stubs))
+      .delete("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(stubs.auditLogger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        beforeState: { cursor: 500 },
+        afterState: { cursor: startLedger },
+      }),
+    );
+  });
+
+  it("audit log captures the correlationId", async () => {
+    const stubs = makeStubs({ currentCursor: 500 });
+
+    await request(makeApp(stubs))
+      .delete("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .set("X-Request-Id", "audit-reset");
+
+    expect(stubs.auditLogger).toHaveBeenCalledWith(
+      expect.objectContaining({ correlationId: "audit-reset" }),
+    );
+  });
+
+  it("audit log captures client IP from x-forwarded-for", async () => {
+    const stubs = makeStubs();
+
+    await request(makeApp(stubs))
+      .delete("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .set("X-Forwarded-For", "203.0.113.99");
+
+    expect(stubs.auditLogger).toHaveBeenCalledWith(
+      expect.objectContaining({ ip: "203.0.113.99" }),
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rate limiting
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("rate limiting", () => {
+  it("POST: returns 429 after the configured limit is exceeded", async () => {
+    const stubs = makeStubs();
+    const app = makeApp(stubs, { rateLimitPerMinute: 1 });
+
+    const first = await request(app)
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 100 });
+    expect(first.status).toBe(200);
+
+    const second = await request(app)
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 200 });
+    expect(second.status).toBe(429);
+    expect(second.body).toEqual({ error: { code: "rate_limit_exceeded" } });
+  });
+
+  it("DELETE: returns 429 after the configured limit is exceeded", async () => {
+    const stubs = makeStubs();
+    const app = makeApp(stubs, { rateLimitPerMinute: 1 });
+
+    const first = await request(app)
+      .delete("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`);
+    expect(first.status).toBe(200);
+
+    const second = await request(app)
+      .delete("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`);
+    expect(second.status).toBe(429);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error propagation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("error propagation", () => {
+  it("POST: forwards getCursor() failures to the error handler (500)", async () => {
+    const stubs = makeStubs({ getCursorError: new Error("db read failure") });
+
+    const res = await request(makeApp(stubs))
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 200 });
+
+    expect(res.status).toBe(500);
+    // Audit must NOT be written on failure
+    expect(stubs.auditLogger).not.toHaveBeenCalled();
+  });
+
+  it("POST: forwards advanceCursor() failures to the error handler (500)", async () => {
+    const stubs = makeStubs({ advanceCursorError: new Error("db write failure") });
+
+    const res = await request(makeApp(stubs))
+      .post("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`)
+      .send({ ledger: 200 });
+
+    expect(res.status).toBe(500);
+    expect(stubs.auditLogger).not.toHaveBeenCalled();
+  });
+
+  it("DELETE: forwards getCursor() failures to the error handler (500)", async () => {
+    const stubs = makeStubs({ getCursorError: new Error("db read failure") });
+
+    const res = await request(makeApp(stubs))
+      .delete("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(res.status).toBe(500);
+    expect(stubs.auditLogger).not.toHaveBeenCalled();
+  });
+
+  it("DELETE: forwards advanceCursor() failures to the error handler (500)", async () => {
+    const stubs = makeStubs({ advanceCursorError: new Error("db write failure") });
+
+    const res = await request(makeApp(stubs))
+      .delete("/api/indexer/cursor")
+      .set("Authorization", `Bearer ${adminJwt}`);
+
+    expect(res.status).toBe(500);
+    expect(stubs.auditLogger).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
…ations

- Add beforeState/afterState (nullable jsonb) columns to audit_logs schema
- Add migration 0025_audit_logs_state_columns.sql
- Add POST /api/indexer/cursor and DELETE /api/indexer/cursor endpoints
  - Both require admin JWT (requireAdmin middleware)
  - Both capture cursor before/after state in audit log entry
  - Injectable deps for full unit-test coverage without DB/network
- Update admin.reindex to use auditService.createAuditLog with before/after state instead of raw db.insert (captures cursor snapshot around backfill)
- Fix pre-existing corrupt errorHandler.ts (duplicate import splice)
- Mount indexerCursorRouter at /api/indexer/cursor in src/index.ts
- Update adminReindex.test.ts mocks to match new auditService usage
- Add tests/indexerCursor.test.ts: 31 focused tests covering auth guard, validation, happy-path audit fields (actor/action/before/after/ip/correlationId), rate limiting, and error propagation for both POST and DELETE

Closes #607 