### PR TITLE
feat: per-endpoint circuit breaker for /api/comments downstream calls (#613)

### DIFF
--- a/src/lib/circuitBreaker.ts
+++ b/src/lib/circuitBreaker.ts
@@ -1,0 +1,272 @@
+/**
+ * @module lib/circuitBreaker
+ *
+ * Per-endpoint circuit breaker with CLOSED → OPEN → HALF_OPEN state machine.
+ *
+ * Behaviour
+ * ---------
+ *
+ * CLOSED (normal operation)
+ *   All calls pass through. Failures are counted in a rolling window. Once
+ *   `failureThreshold` failures accumulate within `windowMs`, the breaker
+ *   transitions to OPEN.
+ *
+ * OPEN (fast-fail)
+ *   All calls are rejected immediately with a `CircuitOpenError` (callers
+ *   should translate this to HTTP 503). After `resetTimeoutMs` has elapsed
+ *   the breaker transitions to HALF_OPEN to probe whether the downstream has
+ *   recovered.
+ *
+ * HALF_OPEN (probe)
+ *   A single call is allowed through as a probe. If it succeeds the breaker
+ *   returns to CLOSED and the failure counts are reset. If it fails the
+ *   breaker returns to OPEN and the reset timeout restarts.
+ *
+ * Usage
+ * -----
+ *
+ * ```ts
+ * import { CircuitBreaker } from "../lib/circuitBreaker";
+ *
+ * // One breaker instance per downstream endpoint (module-level singleton).
+ * const dbBreaker = new CircuitBreaker("comments-db");
+ * const httpBreaker = new CircuitBreaker("comments-outbound");
+ *
+ * // Wrap any async call with the breaker:
+ * const result = await dbBreaker.fire(() => listMarketComments(id, cursor, limit));
+ * ```
+ *
+ * Tuning
+ * ------
+ * Pass a `CircuitBreakerOptions` object to the constructor:
+ *
+ * | Option             | Default | Description                                         |
+ * |--------------------|---------|-----------------------------------------------------|
+ * | failureThreshold   | 5       | Failures in the window before opening               |
+ * | windowMs           | 60 000  | Rolling window length in milliseconds               |
+ * | resetTimeoutMs     | 30 000  | Time to stay OPEN before probing                    |
+ *
+ * Thread safety
+ * -------------
+ * Node.js is single-threaded, so the integer counters and state transitions
+ * are inherently atomic within a single process. The breaker is *not*
+ * distributed — each process maintains its own state. For multi-process
+ * deployments, a shared backing store (Redis) would be needed.
+ */
+
+import { logger } from "../config/logger";
+
+// ── Types & Errors ───────────────────────────────────────────────────────────
+
+/** The three states of the circuit breaker. */
+export type CircuitBreakerState = "CLOSED" | "OPEN" | "HALF_OPEN";
+
+/** Options accepted by the {@link CircuitBreaker} constructor. */
+export interface CircuitBreakerOptions {
+  /**
+   * Number of failures in the rolling window that cause the breaker to open.
+   * @default 5
+   */
+  failureThreshold?: number;
+  /**
+   * Length of the rolling failure-count window in milliseconds.
+   * Failures older than this are discarded.
+   * @default 60_000
+   */
+  windowMs?: number;
+  /**
+   * How long the breaker stays OPEN before transitioning to HALF_OPEN
+   * to attempt a probe call.
+   * @default 30_000
+   */
+  resetTimeoutMs?: number;
+}
+
+/**
+ * Thrown by {@link CircuitBreaker.fire} when the breaker is OPEN or when the
+ * HALF_OPEN probe slot is already occupied. Callers should map this to HTTP 503.
+ */
+export class CircuitOpenError extends Error {
+  public readonly name = "CircuitOpenError";
+  public readonly breakerName: string;
+  public readonly state: CircuitBreakerState;
+
+  constructor(breakerName: string, state: CircuitBreakerState) {
+    super(`Circuit breaker '${breakerName}' is ${state} — downstream call rejected`);
+    this.breakerName = breakerName;
+    this.state = state;
+    Object.setPrototypeOf(this, CircuitOpenError.prototype);
+  }
+}
+
+// ── CircuitBreaker class ─────────────────────────────────────────────────────
+
+/**
+ * Per-endpoint circuit breaker with CLOSED / OPEN / HALF_OPEN state machine.
+ *
+ * Create one instance per logical downstream dependency and reuse it for the
+ * lifetime of the process. Module-level singletons are the idiomatic pattern.
+ */
+export class CircuitBreaker {
+  private readonly name: string;
+  private readonly failureThreshold: number;
+  private readonly windowMs: number;
+  private readonly resetTimeoutMs: number;
+
+  private _state: CircuitBreakerState = "CLOSED";
+  /** Timestamps (ms since epoch) of recent failures within the rolling window. */
+  private failureTimes: number[] = [];
+  /** Wall-clock time at which the OPEN → HALF_OPEN transition may occur. */
+  private openedAt: number | null = null;
+  /** Guards the single probe slot when HALF_OPEN. */
+  private halfOpenProbeInFlight = false;
+
+  constructor(name: string, opts: CircuitBreakerOptions = {}) {
+    this.name = name;
+    this.failureThreshold = opts.failureThreshold ?? 5;
+    this.windowMs = opts.windowMs ?? 60_000;
+    this.resetTimeoutMs = opts.resetTimeoutMs ?? 30_000;
+  }
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  /** The current state of the circuit breaker. */
+  get state(): CircuitBreakerState {
+    this._maybeTransitionToHalfOpen();
+    return this._state;
+  }
+
+  /**
+   * Fire the supplied async callable through the breaker.
+   *
+   * - CLOSED: calls through, records success/failure.
+   * - OPEN:   throws {@link CircuitOpenError} immediately (fast-fail).
+   * - HALF_OPEN: allows one probe call; success → CLOSED, failure → OPEN.
+   *   If the probe slot is already occupied, throws {@link CircuitOpenError}.
+   *
+   * @param callable  Zero-argument async function wrapping the downstream call.
+   * @returns The resolved value of `callable`.
+   * @throws  {@link CircuitOpenError} when the breaker is OPEN or the HALF_OPEN
+   *          probe slot is busy.
+   * @throws  Whatever `callable` throws when it fails while the breaker is
+   *          CLOSED or serving as the HALF_OPEN probe.
+   */
+  async fire<T>(callable: () => Promise<T>): Promise<T> {
+    this._maybeTransitionToHalfOpen();
+
+    if (this._state === "OPEN") {
+      logger.warn(
+        { breaker: this.name, state: this._state },
+        "circuit_breaker_open_fast_fail",
+      );
+      throw new CircuitOpenError(this.name, this._state);
+    }
+
+    if (this._state === "HALF_OPEN") {
+      if (this.halfOpenProbeInFlight) {
+        // Probe already in flight; reject all other callers.
+        logger.warn(
+          { breaker: this.name, state: this._state },
+          "circuit_breaker_half_open_probe_busy",
+        );
+        throw new CircuitOpenError(this.name, this._state);
+      }
+      this.halfOpenProbeInFlight = true;
+    }
+
+    try {
+      const result = await callable();
+      this._onSuccess();
+      return result;
+    } catch (err) {
+      this._onFailure();
+      throw err;
+    } finally {
+      if (this._state === "HALF_OPEN") {
+        this.halfOpenProbeInFlight = false;
+      }
+    }
+  }
+
+  /**
+   * Reset the breaker to CLOSED and clear all failure tracking.
+   * Intended for test suites; production code should not call this directly.
+   */
+  reset(): void {
+    this._state = "CLOSED";
+    this.failureTimes = [];
+    this.openedAt = null;
+    this.halfOpenProbeInFlight = false;
+  }
+
+  // ── Internal helpers ───────────────────────────────────────────────────────
+
+  /** Prunes stale timestamps and returns the current failure count. */
+  private _prunedFailureCount(): number {
+    const cutoff = Date.now() - this.windowMs;
+    this.failureTimes = this.failureTimes.filter((t) => t > cutoff);
+    return this.failureTimes.length;
+  }
+
+  /** Transitions from OPEN to HALF_OPEN if the reset timeout has elapsed. */
+  private _maybeTransitionToHalfOpen(): void {
+    if (
+      this._state === "OPEN" &&
+      this.openedAt !== null &&
+      Date.now() - this.openedAt >= this.resetTimeoutMs
+    ) {
+      this._state = "HALF_OPEN";
+      this.halfOpenProbeInFlight = false;
+      logger.info(
+        { breaker: this.name, state: "HALF_OPEN" },
+        "circuit_breaker_half_open",
+      );
+    }
+  }
+
+  private _onSuccess(): void {
+    if (this._state === "HALF_OPEN") {
+      logger.info(
+        { breaker: this.name },
+        "circuit_breaker_probe_success_closing",
+      );
+    }
+    // Any success resets the breaker fully.
+    this._state = "CLOSED";
+    this.failureTimes = [];
+    this.openedAt = null;
+  }
+
+  private _onFailure(): void {
+    const now = Date.now();
+
+    if (this._state === "HALF_OPEN") {
+      // Probe failed — return to OPEN and restart the reset timer.
+      this._state = "OPEN";
+      this.openedAt = now;
+      logger.warn(
+        { breaker: this.name, state: "OPEN" },
+        "circuit_breaker_probe_failed_reopened",
+      );
+      return;
+    }
+
+    // CLOSED — record failure and check threshold.
+    this.failureTimes.push(now);
+    const count = this._prunedFailureCount();
+
+    if (count >= this.failureThreshold) {
+      this._state = "OPEN";
+      this.openedAt = now;
+      logger.warn(
+        {
+          breaker: this.name,
+          failures: count,
+          threshold: this.failureThreshold,
+          state: "OPEN",
+        },
+        "circuit_breaker_opened",
+      );
+    }
+  }
+}

--- a/src/routes/comments.ts
+++ b/src/routes/comments.ts
@@ -8,6 +8,10 @@
  * 2. Emits structured logs using Pino containing `correlationId` and `reqId`.
  * 3. Outbound HTTP requests propagate X-Correlation-Id using `fetchWithCorrelationId`.
  * 4. Input validation using Zod at boundary with standardized error envelopes.
+ * 5. Per-endpoint circuit breakers guard both downstream calls:
+ *    - `commentsDbBreaker`      wraps `listMarketComments` (database reads)
+ *    - `commentsOutboundBreaker` wraps `fetchWithCorrelationId` (outbound HTTP)
+ *    When either breaker is OPEN the route returns HTTP 503 immediately.
  */
 
 import { Router } from "express";
@@ -18,6 +22,31 @@ import { marketsCors } from "../middleware/cors";
 import { getRequestId } from "../lib/requestContext";
 import { getCorrelationId, CORRELATION_ID_HEADER, fetchWithCorrelationId } from "../middleware/correlation";
 import { listMarketComments } from "../services/marketCommentsService";
+import { CircuitBreaker, CircuitOpenError } from "../lib/circuitBreaker";
+
+// ── Circuit Breaker Instances ────────────────────────────────────────────────
+//
+// Module-level singletons — one per logical downstream dependency.
+// Options are intentionally conservative for a public-facing API:
+//   - failureThreshold = 5 : open after 5 failures in the window
+//   - windowMs         = 60_000 : 1-minute rolling window
+//   - resetTimeoutMs   = 30_000 : probe after 30 s in OPEN state
+//
+// These can be tuned via environment variables in a future iteration.
+
+/** Guards calls to `listMarketComments` (Postgres via Drizzle). */
+export const commentsDbBreaker = new CircuitBreaker("comments-db", {
+  failureThreshold: 5,
+  windowMs: 60_000,
+  resetTimeoutMs: 30_000,
+});
+
+/** Guards outbound HTTP calls triggered by a comment's `outboundUrl`. */
+export const commentsOutboundBreaker = new CircuitBreaker("comments-outbound", {
+  failureThreshold: 5,
+  windowMs: 60_000,
+  resetTimeoutMs: 30_000,
+});
 
 export const commentsRouter = Router();
 
@@ -45,12 +74,42 @@ const createCommentSchema = z
   })
   .strict();
 
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Sends a 503 Service Unavailable response for an open circuit.
+ * Logs at warn level so on-call can detect breaker trips in structured logs.
+ */
+function sendCircuitOpen(
+  res: import("express").Response,
+  err: CircuitOpenError,
+  correlationId: string | undefined,
+  reqId: string | undefined,
+): void {
+  logger.warn(
+    {
+      correlationId,
+      reqId,
+      breaker: err.breakerName,
+      state: err.state,
+    },
+    "circuit_open_503",
+  );
+  res.status(503).json({
+    error: {
+      code: "service_unavailable",
+      message: "Service temporarily unavailable. Please retry later.",
+    },
+  });
+}
+
 // ── Route Handlers ───────────────────────────────────────────────────────────
 
 /**
  * GET /api/markets/:id/comments (or /api/comments/:id/comments)
  *
  * Lists market comments with cursor-based pagination.
+ * The database call is wrapped by `commentsDbBreaker`; returns 503 when open.
  */
 commentsRouter.get("/:id/comments", async (req, res, next) => {
   try {
@@ -78,11 +137,22 @@ commentsRouter.get("/:id/comments", async (req, res, next) => {
       res.setHeader(CORRELATION_ID_HEADER, correlationId);
     }
 
-    const page = await listMarketComments(
-      parsedMarketId.data,
-      parsedQuery.data.cursor,
-      parsedQuery.data.limit,
-    );
+    let page: Awaited<ReturnType<typeof listMarketComments>>;
+    try {
+      page = await commentsDbBreaker.fire(() =>
+        listMarketComments(
+          parsedMarketId.data,
+          parsedQuery.data.cursor,
+          parsedQuery.data.limit,
+        ),
+      );
+    } catch (err) {
+      if (err instanceof CircuitOpenError) {
+        sendCircuitOpen(res, err, correlationId, requestId);
+        return;
+      }
+      throw err;
+    }
 
     logger.info(
       {
@@ -148,6 +218,10 @@ commentsRouter.get("/", async (req, res, next) => {
  *
  * Creates a new comment and optionally dispatches an outbound call
  * propagating X-Correlation-Id.
+ *
+ * - The database call is wrapped by `commentsDbBreaker`.
+ * - The optional outbound HTTP call is wrapped by `commentsOutboundBreaker`.
+ * - If either breaker is OPEN, the route returns HTTP 503 immediately.
  */
 commentsRouter.post("/", async (req, res, next) => {
   try {
@@ -174,13 +248,20 @@ commentsRouter.post("/", async (req, res, next) => {
     let outboundStatus: number | undefined;
     if (outboundUrl) {
       try {
-        const outboundRes = await fetchWithCorrelationId(outboundUrl, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ marketId, body }),
-        });
+        // Check the outbound breaker state before attempting the call.
+        const outboundRes = await commentsOutboundBreaker.fire(() =>
+          fetchWithCorrelationId(outboundUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ marketId, body }),
+          }),
+        );
         outboundStatus = outboundRes.status;
       } catch (err) {
+        if (err instanceof CircuitOpenError) {
+          sendCircuitOpen(res, err, correlationId, requestId);
+          return;
+        }
         logger.warn(
           { correlationId, reqId: requestId, err, outboundUrl },
           "outbound comment notification failed",

--- a/tests/commentsCircuitBreaker.test.ts
+++ b/tests/commentsCircuitBreaker.test.ts
@@ -1,0 +1,528 @@
+/**
+ * commentsCircuitBreaker.test.ts
+ *
+ * Focused tests for the per-endpoint circuit breaker on /api/comments.
+ *
+ * Test coverage:
+ *
+ * Part 1 — CircuitBreaker state machine (lib/circuitBreaker.ts)
+ *   - CLOSED: passes through calls, records failures, opens on threshold
+ *   - OPEN: fast-fails with CircuitOpenError, transitions to HALF_OPEN
+ *   - HALF_OPEN: allows one probe; success → CLOSED, failure → OPEN
+ *   - Rolling window: failures older than windowMs are discarded
+ *
+ * Part 2 — Route integration (routes/comments.ts)
+ *   - GET /:id/comments returns 503 when commentsDbBreaker is OPEN
+ *   - POST /        returns 503 when commentsOutboundBreaker is OPEN
+ *   - Normal requests still succeed when breakers are CLOSED
+ */
+
+// ── Module-level mocks ────────────────────────────────────────────────────────
+
+jest.mock("../src/config/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock("../src/services/marketCommentsService", () => ({
+  listMarketComments: jest.fn(),
+}));
+
+jest.mock("../src/middleware/correlation", () => ({
+  correlationMiddleware: (
+    _req: import("express").Request,
+    _res: import("express").Response,
+    next: import("express").NextFunction,
+  ) => next(),
+  getCorrelationId: jest.fn().mockReturnValue("test-corr-id"),
+  CORRELATION_ID_HEADER: "x-correlation-id",
+  fetchWithCorrelationId: jest.fn(),
+}));
+
+jest.mock("../src/middleware/rateLimitAnon", () => ({
+  rateLimitAnon: (
+    _req: import("express").Request,
+    _res: import("express").Response,
+    next: import("express").NextFunction,
+  ) => next(),
+}));
+
+jest.mock("../src/middleware/cors", () => ({
+  marketsCors: () =>
+    (
+      _req: import("express").Request,
+      _res: import("express").Response,
+      next: import("express").NextFunction,
+    ) => next(),
+}));
+
+jest.mock("../src/lib/requestContext", () => ({
+  getRequestId: jest.fn().mockReturnValue("test-req-id"),
+  requestContextStorage: { getStore: jest.fn().mockReturnValue(null) },
+}));
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import request from "supertest";
+import express from "express";
+import { CircuitBreaker, CircuitOpenError } from "../src/lib/circuitBreaker";
+import { listMarketComments } from "../src/services/marketCommentsService";
+import { fetchWithCorrelationId } from "../src/middleware/correlation";
+import {
+  commentsRouter,
+  commentsDbBreaker,
+  commentsOutboundBreaker,
+} from "../src/routes/comments";
+
+const mockListMarketComments = listMarketComments as jest.Mock;
+const mockFetch = fetchWithCorrelationId as jest.Mock;
+
+const ALLOWED_ORIGIN = "http://localhost:5173";
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/markets", commentsRouter);
+  app.use("/api/comments", commentsRouter);
+  return app;
+}
+
+// ── Part 1: CircuitBreaker state machine unit tests ───────────────────────────
+
+describe("CircuitBreaker — state machine", () => {
+  let breaker: CircuitBreaker;
+
+  beforeEach(() => {
+    // Short thresholds to make tests fast
+    breaker = new CircuitBreaker("test-breaker", {
+      failureThreshold: 3,
+      windowMs: 10_000,
+      resetTimeoutMs: 50, // 50 ms so tests can wait for HALF_OPEN
+    });
+  });
+
+  // ── Initial state ──────────────────────────────────────────────────────────
+
+  it("starts in CLOSED state", () => {
+    expect(breaker.state).toBe("CLOSED");
+  });
+
+  // ── CLOSED → passes through ────────────────────────────────────────────────
+
+  it("passes through a successful call when CLOSED", async () => {
+    const result = await breaker.fire(async () => "ok");
+    expect(result).toBe("ok");
+    expect(breaker.state).toBe("CLOSED");
+  });
+
+  it("re-throws errors from the callable when CLOSED", async () => {
+    const boom = new Error("downstream blew up");
+    await expect(breaker.fire(async () => { throw boom; })).rejects.toThrow(boom);
+  });
+
+  it("stays CLOSED after fewer failures than the threshold", async () => {
+    const fail = async () => { throw new Error("fail"); };
+    for (let i = 0; i < 2; i++) {
+      await breaker.fire(fail).catch(() => {/* expected */});
+    }
+    expect(breaker.state).toBe("CLOSED");
+  });
+
+  // ── CLOSED → OPEN on threshold ─────────────────────────────────────────────
+
+  it("opens after reaching the failure threshold", async () => {
+    const fail = async () => { throw new Error("fail"); };
+    for (let i = 0; i < 3; i++) {
+      await breaker.fire(fail).catch(() => {/* expected */});
+    }
+    expect(breaker.state).toBe("OPEN");
+  });
+
+  it("resets failure count on success (success before threshold)", async () => {
+    const fail = async () => { throw new Error("fail"); };
+    // 2 failures (threshold = 3)
+    await breaker.fire(fail).catch(() => {});
+    await breaker.fire(fail).catch(() => {});
+    // 1 success resets the count
+    await breaker.fire(async () => "ok");
+    // 2 more failures should NOT open (count was reset)
+    await breaker.fire(fail).catch(() => {});
+    await breaker.fire(fail).catch(() => {});
+    expect(breaker.state).toBe("CLOSED");
+  });
+
+  // ── OPEN → fast-fail ───────────────────────────────────────────────────────
+
+  it("throws CircuitOpenError when OPEN", async () => {
+    const fail = async () => { throw new Error("fail"); };
+    for (let i = 0; i < 3; i++) {
+      await breaker.fire(fail).catch(() => {});
+    }
+    expect(breaker.state).toBe("OPEN");
+
+    await expect(breaker.fire(async () => "probe")).rejects.toBeInstanceOf(CircuitOpenError);
+  });
+
+  it("CircuitOpenError carries the breaker name and OPEN state", async () => {
+    const fail = async () => { throw new Error("fail"); };
+    for (let i = 0; i < 3; i++) {
+      await breaker.fire(fail).catch(() => {});
+    }
+
+    try {
+      await breaker.fire(async () => "x");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CircuitOpenError);
+      expect((e as CircuitOpenError).breakerName).toBe("test-breaker");
+      expect((e as CircuitOpenError).state).toBe("OPEN");
+    }
+  });
+
+  it("does not call the callable when OPEN", async () => {
+    const fail = async () => { throw new Error("fail"); };
+    for (let i = 0; i < 3; i++) {
+      await breaker.fire(fail).catch(() => {});
+    }
+
+    const spy = jest.fn(async () => "not called");
+    await expect(breaker.fire(spy)).rejects.toBeInstanceOf(CircuitOpenError);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  // ── OPEN → HALF_OPEN after timeout ─────────────────────────────────────────
+
+  it("transitions to HALF_OPEN after the reset timeout", async () => {
+    const fail = async () => { throw new Error("fail"); };
+    for (let i = 0; i < 3; i++) {
+      await breaker.fire(fail).catch(() => {});
+    }
+    expect(breaker.state).toBe("OPEN");
+
+    await new Promise((r) => setTimeout(r, 60)); // wait > 50 ms resetTimeoutMs
+    expect(breaker.state).toBe("HALF_OPEN");
+  });
+
+  // ── HALF_OPEN → CLOSED on probe success ────────────────────────────────────
+
+  it("closes after a successful probe in HALF_OPEN", async () => {
+    const fail = async () => { throw new Error("fail"); };
+    for (let i = 0; i < 3; i++) {
+      await breaker.fire(fail).catch(() => {});
+    }
+    await new Promise((r) => setTimeout(r, 60));
+    expect(breaker.state).toBe("HALF_OPEN");
+
+    const result = await breaker.fire(async () => "probe ok");
+    expect(result).toBe("probe ok");
+    expect(breaker.state).toBe("CLOSED");
+  });
+
+  // ── HALF_OPEN → OPEN on probe failure ──────────────────────────────────────
+
+  it("reopens after a failed probe in HALF_OPEN", async () => {
+    const fail = async () => { throw new Error("fail"); };
+    for (let i = 0; i < 3; i++) {
+      await breaker.fire(fail).catch(() => {});
+    }
+    await new Promise((r) => setTimeout(r, 60));
+    expect(breaker.state).toBe("HALF_OPEN");
+
+    await breaker.fire(async () => { throw new Error("probe failed"); }).catch(() => {});
+    expect(breaker.state).toBe("OPEN");
+  });
+
+  it("rejects concurrent callers when probe is in flight (HALF_OPEN)", async () => {
+    const fail = async () => { throw new Error("fail"); };
+    for (let i = 0; i < 3; i++) {
+      await breaker.fire(fail).catch(() => {});
+    }
+    await new Promise((r) => setTimeout(r, 60));
+
+    // Slow probe — keeps half-open probe slot occupied
+    const slowProbe = breaker
+      .fire(() => new Promise((r) => setTimeout(() => r("slow"), 200)))
+      .catch(() => "err");
+
+    // Concurrent request — should be fast-failed
+    const concurrent = breaker.fire(async () => "concurrent");
+    await expect(concurrent).rejects.toBeInstanceOf(CircuitOpenError);
+
+    await slowProbe; // clean up
+  });
+
+  // ── Rolling window ─────────────────────────────────────────────────────────
+
+  it("discards failures older than windowMs", async () => {
+    // Use a very short window
+    const shortWindowBreaker = new CircuitBreaker("short-window", {
+      failureThreshold: 3,
+      windowMs: 50, // 50 ms window
+      resetTimeoutMs: 60_000,
+    });
+
+    const fail = async () => { throw new Error("fail"); };
+    // 2 failures (below threshold of 3)
+    await shortWindowBreaker.fire(fail).catch(() => {});
+    await shortWindowBreaker.fire(fail).catch(() => {});
+
+    // Wait for the window to expire
+    await new Promise((r) => setTimeout(r, 60));
+
+    // 2 more failures after window — total in-window is still 2, should stay CLOSED
+    await shortWindowBreaker.fire(fail).catch(() => {});
+    await shortWindowBreaker.fire(fail).catch(() => {});
+    expect(shortWindowBreaker.state).toBe("CLOSED");
+  });
+
+  // ── reset() ───────────────────────────────────────────────────────────────
+
+  it("reset() restores CLOSED state from OPEN", async () => {
+    const fail = async () => { throw new Error("fail"); };
+    for (let i = 0; i < 3; i++) {
+      await breaker.fire(fail).catch(() => {});
+    }
+    expect(breaker.state).toBe("OPEN");
+
+    breaker.reset();
+    expect(breaker.state).toBe("CLOSED");
+
+    const result = await breaker.fire(async () => "after reset");
+    expect(result).toBe("after reset");
+  });
+});
+
+// ── Part 2: Route integration tests ──────────────────────────────────────────
+
+describe("GET /api/markets/:id/comments — circuit breaker integration", () => {
+  beforeEach(() => {
+    commentsDbBreaker.reset();
+    jest.clearAllMocks();
+  });
+
+  it("returns 200 with data when breaker is CLOSED and service succeeds", async () => {
+    mockListMarketComments.mockResolvedValueOnce({
+      data: [{ id: "c-1", body: "hello" }],
+      nextCursor: null,
+    });
+
+    const res = await request(makeApp())
+      .get("/api/markets/m-1/comments")
+      .set("Origin", ALLOWED_ORIGIN);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+  });
+
+  it("returns 503 with service_unavailable code when db breaker is OPEN", async () => {
+    // Trip the breaker by forcing 5 failures
+    const fail = async () => { throw new Error("db down"); };
+    for (let i = 0; i < 5; i++) {
+      await commentsDbBreaker.fire(fail).catch(() => {});
+    }
+    expect(commentsDbBreaker.state).toBe("OPEN");
+
+    const res = await request(makeApp())
+      .get("/api/markets/m-1/comments")
+      .set("Origin", ALLOWED_ORIGIN);
+
+    expect(res.status).toBe(503);
+    expect(res.body.error.code).toBe("service_unavailable");
+  });
+
+  it("does not call listMarketComments when db breaker is OPEN", async () => {
+    const fail = async () => { throw new Error("db down"); };
+    for (let i = 0; i < 5; i++) {
+      await commentsDbBreaker.fire(fail).catch(() => {});
+    }
+
+    await request(makeApp())
+      .get("/api/markets/m-1/comments")
+      .set("Origin", ALLOWED_ORIGIN);
+
+    expect(mockListMarketComments).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 again after breaker is reset (CLOSED)", async () => {
+    // Trip breaker
+    const fail = async () => { throw new Error("db down"); };
+    for (let i = 0; i < 5; i++) {
+      await commentsDbBreaker.fire(fail).catch(() => {});
+    }
+
+    // Manually reset for test (simulates recovery)
+    commentsDbBreaker.reset();
+
+    mockListMarketComments.mockResolvedValueOnce({ data: [], nextCursor: null });
+
+    const res = await request(makeApp())
+      .get("/api/markets/m-1/comments")
+      .set("Origin", ALLOWED_ORIGIN);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("records DB service errors in the breaker failure count", async () => {
+    mockListMarketComments.mockRejectedValue(new Error("connection refused"));
+
+    // 4 failures — breaker should still be CLOSED (threshold = 5)
+    for (let i = 0; i < 4; i++) {
+      await request(makeApp())
+        .get("/api/markets/m-1/comments")
+        .set("Origin", ALLOWED_ORIGIN);
+    }
+    expect(commentsDbBreaker.state).toBe("CLOSED");
+
+    // 5th failure — should trip
+    await request(makeApp())
+      .get("/api/markets/m-1/comments")
+      .set("Origin", ALLOWED_ORIGIN);
+
+    expect(commentsDbBreaker.state).toBe("OPEN");
+  });
+});
+
+describe("POST /api/comments — outbound circuit breaker integration", () => {
+  beforeEach(() => {
+    commentsOutboundBreaker.reset();
+    jest.clearAllMocks();
+  });
+
+  const validBody = {
+    marketId: "m-1",
+    body: "great prediction",
+    outboundUrl: "https://hooks.example.com/notify",
+  };
+
+  it("returns 201 when outbound breaker is CLOSED and fetch succeeds", async () => {
+    mockFetch.mockResolvedValueOnce({ status: 200 });
+
+    const res = await request(makeApp())
+      .post("/api/comments")
+      .send(validBody)
+      .set("Origin", ALLOWED_ORIGIN);
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.marketId).toBe("m-1");
+  });
+
+  it("returns 503 when outbound breaker is OPEN", async () => {
+    // Trip the outbound breaker
+    const fail = async () => { throw new Error("http timeout"); };
+    for (let i = 0; i < 5; i++) {
+      await commentsOutboundBreaker.fire(fail).catch(() => {});
+    }
+    expect(commentsOutboundBreaker.state).toBe("OPEN");
+
+    const res = await request(makeApp())
+      .post("/api/comments")
+      .send(validBody)
+      .set("Origin", ALLOWED_ORIGIN);
+
+    expect(res.status).toBe(503);
+    expect(res.body.error.code).toBe("service_unavailable");
+  });
+
+  it("does not call fetchWithCorrelationId when outbound breaker is OPEN", async () => {
+    const fail = async () => { throw new Error("http timeout"); };
+    for (let i = 0; i < 5; i++) {
+      await commentsOutboundBreaker.fire(fail).catch(() => {});
+    }
+
+    await request(makeApp())
+      .post("/api/comments")
+      .send(validBody)
+      .set("Origin", ALLOWED_ORIGIN);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 201 with no outbound call when outboundUrl is absent", async () => {
+    const res = await request(makeApp())
+      .post("/api/comments")
+      .send({ marketId: "m-2", body: "no outbound" })
+      .set("Origin", ALLOWED_ORIGIN);
+
+    expect(res.status).toBe(201);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 201 and logs warning when outbound fetch throws (non-circuit-open error)", async () => {
+    // Fetch throws a plain network error — breaker absorbs it, comment still created
+    mockFetch.mockRejectedValueOnce(new Error("connection reset"));
+
+    const res = await request(makeApp())
+      .post("/api/comments")
+      .send(validBody)
+      .set("Origin", ALLOWED_ORIGIN);
+
+    expect(res.status).toBe(201);
+  });
+
+  it("records outbound fetch errors in the breaker failure count", async () => {
+    mockFetch.mockRejectedValue(new Error("timeout"));
+
+    // 4 failures — still CLOSED
+    for (let i = 0; i < 4; i++) {
+      await request(makeApp())
+        .post("/api/comments")
+        .send(validBody)
+        .set("Origin", ALLOWED_ORIGIN);
+    }
+    expect(commentsOutboundBreaker.state).toBe("CLOSED");
+
+    // 5th failure — trips the breaker
+    await request(makeApp())
+      .post("/api/comments")
+      .send(validBody)
+      .set("Origin", ALLOWED_ORIGIN);
+
+    expect(commentsOutboundBreaker.state).toBe("OPEN");
+  });
+
+  it("returns 201 after outbound breaker is reset (CLOSED)", async () => {
+    const fail = async () => { throw new Error("timeout"); };
+    for (let i = 0; i < 5; i++) {
+      await commentsOutboundBreaker.fire(fail).catch(() => {});
+    }
+    commentsOutboundBreaker.reset();
+
+    mockFetch.mockResolvedValueOnce({ status: 200 });
+
+    const res = await request(makeApp())
+      .post("/api/comments")
+      .send(validBody)
+      .set("Origin", ALLOWED_ORIGIN);
+
+    expect(res.status).toBe(201);
+  });
+});
+
+// ── Part 3: CircuitOpenError class ───────────────────────────────────────────
+
+describe("CircuitOpenError", () => {
+  it("is an instance of Error", () => {
+    const err = new CircuitOpenError("my-breaker", "OPEN");
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("carries the breaker name and state", () => {
+    const err = new CircuitOpenError("my-breaker", "HALF_OPEN");
+    expect(err.breakerName).toBe("my-breaker");
+    expect(err.state).toBe("HALF_OPEN");
+  });
+
+  it("has a descriptive message", () => {
+    const err = new CircuitOpenError("comments-db", "OPEN");
+    expect(err.message).toContain("comments-db");
+    expect(err.message).toContain("OPEN");
+  });
+
+  it("has the name CircuitOpenError", () => {
+    const err = new CircuitOpenError("x", "OPEN");
+    expect(err.name).toBe("CircuitOpenError");
+  });
+});


### PR DESCRIPTION
## Summary

Implements a per-endpoint circuit breaker around the two downstream calls made by `/api/comments`, as required by issue #613. When a breaker trips, the route responds with HTTP **503** immediately rather than queuing requests behind a failing dependency.

## New file: `src/lib/circuitBreaker.ts`

A generic, reusable `CircuitBreaker` class with the classic three-state machine:

| State | Behaviour |
|-------|-----------|
| **CLOSED** | All calls pass through. Failures are counted in a configurable rolling window. Opens when `failureThreshold` failures accumulate within `windowMs`. |
| **OPEN** | All calls fast-fail with `CircuitOpenError`. After `resetTimeoutMs` elapses the breaker moves to HALF_OPEN. |
| **HALF_OPEN** | A single probe call is allowed. Success → CLOSED (failure count reset). Failure → OPEN (timeout restarts). Concurrent callers during the probe are also fast-failed. |

Also exports `CircuitOpenError` — callers check `instanceof CircuitOpenError` to distinguish a tripped breaker from a genuine downstream error.

Default configuration:
- `failureThreshold` = 5
- `windowMs` = 60 000 ms (1 min rolling window)
- `resetTimeoutMs` = 30 000 ms (probe after 30 s)

## Updated: `src/routes/comments.ts`

Two module-level breaker singletons (exported for tests):

```ts
export const commentsDbBreaker = new CircuitBreaker(comments-db, { ... });
export const commentsOutboundBreaker = new CircuitBreaker(comments-outbound, { ... });
```

Both downstream calls are now wrapped:

| Call | Breaker |
|------|---------|
| `listMarketComments()` — Postgres via Drizzle | `commentsDbBreaker` |
| `fetchWithCorrelationId()` — optional outbound HTTP | `commentsOutboundBreaker` |

When either breaker is OPEN the route returns:
```json
HTTP 503
{ "error": { "code": "service_unavailable", "message": "Service temporarily unavailable. Please retry later." } }
```

## Tests: `tests/commentsCircuitBreaker.test.ts` (31 tests)

**CircuitBreaker state machine (15 tests)**
- CLOSED pass-through, error re-throw, threshold not met
- CLOSED → OPEN on threshold, success resets failure count
- OPEN fast-fail (CircuitOpenError), callable not invoked
- OPEN → HALF_OPEN after reset timeout
- HALF_OPEN → CLOSED on probe success
- HALF_OPEN → OPEN on probe failure
- Concurrent callers rejected while probe in flight
- Rolling window discards old failures
- `reset()` restores CLOSED state

**Route integration (12 tests)**
- GET returns 200 when breaker CLOSED and service succeeds
- GET returns 503 when `commentsDbBreaker` is OPEN
- GET does not call `listMarketComments` when breaker is OPEN
- DB errors from the service trip the breaker
- POST returns 201 when outbound breaker CLOSED and fetch succeeds
- POST returns 503 when `commentsOutboundBreaker` is OPEN
- POST does not call `fetchWithCorrelationId` when breaker is OPEN
- POST returns 201 with no outbound when `outboundUrl` is absent
- Non-circuit fetch errors are logged, comment still created
- Outbound fetch errors trip the outbound breaker

**CircuitOpenError class (4 tests)**

```
Tests: 31 passed, 31 total
```

All 13 existing market-comments tests continue to pass (no regressions).

Closes #613