### PR TITLE
feat(leaderboard): add ETag/304 caching on /api/leaderboard

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -46,7 +46,7 @@ module.exports = {
     "^.*/config/redis$": "<rootDir>/src/config/redis.ts",
     "^.*/cache/marketsCache$": "<rootDir>/src/cache/marketsCache.ts",
   },
-  testMatch: ["**/tests/**/*.test.ts"],
+  testMatch: ["**/tests/**/*.test.ts", "**/src/__tests__/**/*.test.ts"],
   globals: {
     "ts-jest": {
       // Use the test-specific tsconfig so ts-jest can find both src/ and

--- a/src/__tests__/routes/leaderboard.test.ts
+++ b/src/__tests__/routes/leaderboard.test.ts
@@ -8,6 +8,16 @@ import * as leaderboardService from "../../services/leaderboardService";
 // Mock the service
 jest.mock("../../services/leaderboardService");
 
+// Mock the logger to avoid noise in test output
+jest.mock("../../config/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), debug: jest.fn(), error: jest.fn() },
+}));
+
+// Helper to extract bare ETag hash
+function etagHash(etag: string): string {
+  return etag.replace(/^"|"$/g, "");
+}
+
 describe("Leaderboard Routes", () => {
   let app: express.Application;
 
@@ -347,6 +357,172 @@ describe("Leaderboard Routes", () => {
         altAddress,
         "all-time",
       );
+    });
+  });
+
+  describe("ETag / 304 conditional GET for GET /api/leaderboard", () => {
+    it("returns 200 with ETag and Cache-Control on first request", async () => {
+      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
+        mockLeaderboardEntry,
+      ]);
+
+      const res = await request(app).get("/api/leaderboard");
+
+      expect(res.status).toBe(200);
+      expect(res.headers["etag"]).toMatch(/^"[a-f0-9]{64}"$/);
+      expect(res.headers["cache-control"]).toBe("no-cache");
+    });
+
+    it("returns 304 when If-None-Match matches current ETag", async () => {
+      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
+        mockLeaderboardEntry,
+      ]);
+
+      const first = await request(app).get("/api/leaderboard");
+      const etag = first.headers["etag"] as string;
+
+      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
+        mockLeaderboardEntry,
+      ]);
+
+      const second = await request(app)
+        .get("/api/leaderboard")
+        .set("If-None-Match", etag);
+
+      expect(second.status).toBe(304);
+      expect(second.text).toBe("");
+    });
+
+    it("returns 200 when If-None-Match does not match", async () => {
+      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
+        mockLeaderboardEntry,
+      ]);
+
+      const res = await request(app)
+        .get("/api/leaderboard")
+        .set("If-None-Match", '"00000000stale00000000"');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual([mockLeaderboardEntry]);
+    });
+
+    it("returns 304 with unquoted (bare hash) If-None-Match", async () => {
+      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
+        mockLeaderboardEntry,
+      ]);
+
+      const first = await request(app).get("/api/leaderboard");
+      const bareHash = etagHash(first.headers["etag"] as string);
+
+      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
+        mockLeaderboardEntry,
+      ]);
+
+      const second = await request(app)
+        .get("/api/leaderboard")
+        .set("If-None-Match", bareHash);
+
+      expect(second.status).toBe(304);
+    });
+
+    it("ETag is stable across repeated requests for the same data", async () => {
+      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
+        mockLeaderboardEntry,
+      ]);
+      const r1 = await request(app).get("/api/leaderboard");
+
+      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
+        mockLeaderboardEntry,
+      ]);
+      const r2 = await request(app).get("/api/leaderboard");
+
+      expect(r1.headers["etag"]).toBe(r2.headers["etag"]);
+    });
+
+    it("ETag changes when leaderboard data changes", async () => {
+      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
+        mockLeaderboardEntry,
+      ]);
+      const r1 = await request(app).get("/api/leaderboard");
+
+      const changedEntry = { ...mockLeaderboardEntry, total_predictions: 200 };
+      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
+        changedEntry,
+      ]);
+      const r2 = await request(app).get("/api/leaderboard");
+
+      expect(r1.headers["etag"]).not.toBe(r2.headers["etag"]);
+    });
+
+    it("304 still includes ETag header", async () => {
+      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
+        mockLeaderboardEntry,
+      ]);
+
+      const first = await request(app).get("/api/leaderboard");
+      const etag = first.headers["etag"] as string;
+
+      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
+        mockLeaderboardEntry,
+      ]);
+
+      const second = await request(app)
+        .get("/api/leaderboard")
+        .set("If-None-Match", etag);
+
+      expect(second.status).toBe(304);
+      expect(second.headers["etag"]).toBe(etag);
+    });
+  });
+
+  describe("ETag / 304 conditional GET for GET /api/leaderboard/user/:stellarAddress", () => {
+    it("returns 200 with ETag and Cache-Control on first request", async () => {
+      (
+        leaderboardService.getUserLeaderboardEntry as jest.Mock
+      ).mockResolvedValueOnce(mockLeaderboardEntry);
+
+      const res = await request(app).get(
+        `/api/leaderboard/user/${mockLeaderboardEntry.stellar_address}`,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.headers["etag"]).toMatch(/^"[a-f0-9]{64}"$/);
+      expect(res.headers["cache-control"]).toBe("no-cache");
+    });
+
+    it("returns 304 when If-None-Match matches", async () => {
+      (
+        leaderboardService.getUserLeaderboardEntry as jest.Mock
+      ).mockResolvedValueOnce(mockLeaderboardEntry);
+
+      const first = await request(app).get(
+        `/api/leaderboard/user/${mockLeaderboardEntry.stellar_address}`,
+      );
+      const etag = first.headers["etag"] as string;
+
+      (
+        leaderboardService.getUserLeaderboardEntry as jest.Mock
+      ).mockResolvedValueOnce(mockLeaderboardEntry);
+
+      const second = await request(app)
+        .get(`/api/leaderboard/user/${mockLeaderboardEntry.stellar_address}`)
+        .set("If-None-Match", etag);
+
+      expect(second.status).toBe(304);
+      expect(second.text).toBe("");
+    });
+
+    it("returns 200 when If-None-Match does not match", async () => {
+      (
+        leaderboardService.getUserLeaderboardEntry as jest.Mock
+      ).mockResolvedValueOnce(mockLeaderboardEntry);
+
+      const res = await request(app)
+        .get(`/api/leaderboard/user/${mockLeaderboardEntry.stellar_address}`)
+        .set("If-None-Match", '"00000000stale00000000"');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual(mockLeaderboardEntry);
     });
   });
 

--- a/src/routes/leaderboard.ts
+++ b/src/routes/leaderboard.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { z } from "zod";
 import { getLeaderboard, getLeaderboardWithRefresh, getUserLeaderboardEntry } from "../services/leaderboardService";
 import { rateLimitAnon } from "../middleware/rateLimitAnon";
+import { conditionalGet } from "../middleware/etag";
 import { RouteErrorFactory } from "../errors";
 import { abortableRace, requestTimeout, RequestAbortedError } from "../middleware/timeout";
 import { logger } from "../config/logger";
@@ -50,7 +51,7 @@ leaderboardRouter.get("/", async (req, res, next) => {
       : getLeaderboard(limit, offset, period);
     const data = await abortableRace(fetch, signal);
 
-    res.json({
+    const payload = {
       data,
       meta: {
         limit,
@@ -59,7 +60,11 @@ leaderboardRouter.get("/", async (req, res, next) => {
         refresh,
         period,
       }
-    });
+    };
+
+    // Strong ETag on the leaderboard payload; 304 if client already has it.
+    if (conditionalGet(payload, req, res)) return;
+    res.json(payload);
   } catch (e) {
     if (e instanceof RequestAbortedError) {
       // The timeout middleware already sent (or the client already dropped)
@@ -85,7 +90,11 @@ leaderboardRouter.get("/user/:stellarAddress", async (req, res, next) => {
     if (!entry) {
       throw RouteErrorFactory.notFound("Leaderboard entry not found");
     }
-    res.json({ data: entry });
+
+    // Strong ETag on the entry payload; 304 if client already has it.
+    const payload = { data: entry };
+    if (conditionalGet(payload, req, res)) return;
+    res.json(payload);
   } catch (e) {
     if (e instanceof RequestAbortedError) {
       logger.warn(


### PR DESCRIPTION
## Overview

This PR adds strong ETag support to both `/api/leaderboard` endpoints (`GET /` and `GET /user/:stellarAddress`) to enable conditional GET responses — cutting bandwidth on repeat reads via 304 Not Modified.

## Related Issue

Closes #635

## Changes

### Routes

* **[MODIFY]** `src/routes/leaderboard.ts` — added `conditionalGet` to `GET /` and `GET /user/:stellarAddress`:
  - Every 200 response now includes `ETag` (SHA-256 of the JSON payload) and `Cache-Control: no-cache` headers
  - When the client sends `If-None-Match` matching the current ETag, responds with **304 Not Modified** (no body)
  - Bare-hash (unquoted) `If-None-Match` values are handled correctly via existing middleware normalization

### Tests

* **[ADD]** `src/__tests__/routes/leaderboard.test.ts` — 10 new integration tests covering:
  - `ETag` and `Cache-Control` headers on first request
  - 304 when `If-None-Match` matches
  - 200 when ETag is stale
  - 304 with unquoted (bare hash) `If-None-Match`
  - ETag stability across identical payloads
  - ETag changes when payload changes
  - 304 response includes ETag header
  - Same coverage for the user-specific endpoint

### Config

* **[MODIFY]** `jest.config.js` — added `src/__tests__/**/*.test.ts` to test match pattern so co-located tests are discovered

## Verification Results

```
npm test -- src/__tests__/routes/leaderboard.test.ts -t "ETag"
✅ 10/10 passed

PASS src/__tests__/routes/leaderboard.test.ts (19.6s)
  Leaderboard Routes
    ETag / 304 conditional GET for GET /api/leaderboard
      ✓ returns 200 with ETag and Cache-Control on first request
      ✓ returns 304 when If-None-Match matches current ETag
      ✓ returns 200 when If-None-Match does not match
      ✓ returns 304 with unquoted (bare hash) If-None-Match
      ✓ ETag is stable across repeated requests for the same data
      ✓ ETag changes when leaderboard data changes
      ✓ 304 still includes ETag header
    ETag / 304 conditional GET for GET /api/leaderboard/user/:stellarAddress
      ✓ returns 200 with ETag and Cache-Control on first request
      ✓ returns 304 when If-None-Match matches
      ✓ returns 200 when If-None-Match does not match
```

| Acceptance Criteria | Status |
| --- | --- |
| ETag emitted on `GET /api/leaderboard` | ✅ Strong ETag via SHA-256 hash of JSON payload |
| ETag emitted on `GET /api/leaderboard/user/:stellarAddress` | ✅ Strong ETag via SHA-256 hash of JSON payload |
| 304 returned when `If-None-Match` matches | ✅ Both endpoints return 304 with no body |
| `Cache-Control: no-cache` on every response | ✅ Clients may cache but must revalidate |
| Deterministic ETags (sorted keys) | ✅ Uses `sortedReplacer` from existing `etag.ts` middleware |
| 10 focused tests added | ✅ All pass |