### PR TITLE
feat(#641): add zod input validation for /api/subscriptions

### DIFF
--- a/src/__tests__/routes/subscriptions.test.ts
+++ b/src/__tests__/routes/subscriptions.test.ts
@@ -1,3 +1,19 @@
+/**
+ * src/__tests__/routes/subscriptions.test.ts
+ *
+ * Integration tests for the subscriptions router.
+ *
+ * Coverage targets
+ * ────────────────
+ *   GET    /api/subscriptions          — list, ETag, 304, DB error
+ *   POST   /api/subscriptions          — create (valid), validation errors (url, events), DB error
+ *   GET    /api/subscriptions/:id      — fetch existing, 404, invalid UUID
+ *   PATCH  /api/subscriptions/:id      — update (valid), validation errors, 404, empty body
+ *   DELETE /api/subscriptions/:id      — delete existing, 404, invalid UUID
+ *   Validator schemas                  — unit-level checks for createSubscriptionBodySchema,
+ *                                        patchSubscriptionBodySchema, subscriptionIdParamSchema
+ */
+
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 import request from "supertest";
 import express from "express";
@@ -5,88 +21,682 @@ import type { Request, Response, NextFunction } from "express";
 import { subscriptionsRouter } from "../../routes/subscriptions";
 import { db } from "../../db/client";
 import { generateETag } from "../../middleware/etag";
+import {
+  createSubscriptionBodySchema,
+  patchSubscriptionBodySchema,
+  subscriptionIdParamSchema,
+  eventTypeSchema,
+  webhookUrlSchema,
+} from "../../validators/subscriptions";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
 
 jest.mock("../../middleware/requireAdmin", () => ({
   requireAdmin: (_req: Request, _res: Response, next: NextFunction) => next(),
 }));
 
-jest.mock("../../db/client", () => {
-  const mDb = {
-    select: jest.fn().mockReturnThis(),
-    from: jest.fn(),
+jest.mock("../../config/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// Build a fluent db mock that supports: select/insert/update/delete chains
+const mockReturning = jest.fn();
+const mockWhere = jest.fn();
+const mockFrom = jest.fn();
+const mockSet = jest.fn(() => ({ where: mockWhere }));
+const mockValues = jest.fn(() => ({ returning: mockReturning }));
+const mockInsert = jest.fn(() => ({ values: mockValues }));
+const mockUpdate = jest.fn(() => ({ set: mockSet }));
+const mockDelete = jest.fn(() => ({ where: mockWhere }));
+const mockSelect = jest.fn(() => ({ from: mockFrom }));
+
+jest.mock("../../db/client", () => ({
+  db: {
+    select: (...args: unknown[]) => mockSelect(...args),
+    insert: (...args: unknown[]) => mockInsert(...args),
+    update: (...args: unknown[]) => mockUpdate(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const VALID_UUID = "123e4567-e89b-12d3-a456-426614174000";
+const ANOTHER_UUID = "987fcdeb-51d3-12d3-a456-426614174999";
+
+const mockSubscription = {
+  id: VALID_UUID,
+  url: "https://example.com/webhook",
+  secret: "super-secret-hmac-key",
+  events: ["market.created", "prediction.settled"],
+  active: true,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+};
+
+// Public-facing serialisation omits the secret field
+const publicSubscription = (() => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { secret: _s, ...pub } = mockSubscription;
+  return pub;
+})();
+
+// ---------------------------------------------------------------------------
+// App factory
+// ---------------------------------------------------------------------------
+
+function makeApp(): express.Application {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/subscriptions", subscriptionsRouter);
+  // Attach the real errorHandler so ZodErrors produce 400 responses
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { errorHandler } = require("../../middleware/errorHandler") as {
+    errorHandler: (
+      err: unknown,
+      req: Request,
+      res: Response,
+      next: NextFunction,
+    ) => void;
   };
-  return { db: mDb };
-});
+  app.use(errorHandler);
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 describe("Subscriptions Routes", () => {
   let app: express.Application;
 
-  const mockSubscriptions = [
-    {
-      id: "sub-1",
-      url: "https://example.com/webhook",
-      secret: "secret123",
-      events: ["market.created"],
-      active: true,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    },
-  ];
-
   beforeEach(() => {
     jest.clearAllMocks();
-    app = express();
-    app.use(express.json());
-    app.use("/api/subscriptions", subscriptionsRouter);
+    app = makeApp();
+
+    // Reset mock chain defaults
+    mockFrom.mockResolvedValue([]);
+    mockWhere.mockResolvedValue([]);
+    mockReturning.mockResolvedValue([]);
   });
 
+  // ────────────────────────────────────────────────────────────────────────
+  // GET /api/subscriptions
+  // ────────────────────────────────────────────────────────────────────────
   describe("GET /api/subscriptions", () => {
-    it("should return subscriptions and strong ETag", async () => {
-      (db.from as jest.Mock).mockResolvedValueOnce(mockSubscriptions);
+    it("returns 200 with data and a strong ETag", async () => {
+      const subscriptions = [mockSubscription];
+      mockFrom.mockResolvedValueOnce(subscriptions);
 
-      const response = await request(app).get("/api/subscriptions");
+      const res = await request(app).get("/api/subscriptions");
 
-      expect(response.status).toBe(200);
-      expect(response.body.data).toEqual(JSON.parse(JSON.stringify(mockSubscriptions)));
-      
-      const expectedEtag = generateETag(mockSubscriptions);
-      expect(response.headers.etag).toBe(expectedEtag);
-      expect(response.headers["cache-control"]).toBe("no-cache");
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual(JSON.parse(JSON.stringify(subscriptions)));
+      const expectedEtag = generateETag(subscriptions);
+      expect(res.headers.etag).toBe(expectedEtag);
+      expect(res.headers["cache-control"]).toBe("no-cache");
     });
 
-    it("should return 304 if If-None-Match matches ETag", async () => {
-      (db.from as jest.Mock).mockResolvedValue(mockSubscriptions);
-      
-      const expectedEtag = generateETag(mockSubscriptions);
-      const response = await request(app)
+    it("returns 304 when If-None-Match matches the ETag", async () => {
+      mockFrom.mockResolvedValue([mockSubscription]);
+      const expectedEtag = generateETag([mockSubscription]);
+
+      const res = await request(app)
         .get("/api/subscriptions")
         .set("If-None-Match", expectedEtag);
 
-      expect(response.status).toBe(304);
-      expect(response.body).toEqual({});
+      expect(res.status).toBe(304);
+      expect(res.body).toEqual({});
     });
 
-    it("should return 200 if If-None-Match does not match ETag", async () => {
-      (db.from as jest.Mock).mockResolvedValueOnce(mockSubscriptions);
-      
-      const response = await request(app)
+    it("returns 200 when If-None-Match does not match", async () => {
+      mockFrom.mockResolvedValueOnce([mockSubscription]);
+
+      const res = await request(app)
         .get("/api/subscriptions")
-        .set("If-None-Match", '"non-matching-etag"');
+        .set("If-None-Match", '"stale-etag-value"');
 
-      expect(response.status).toBe(200);
-      expect(response.body.data).toEqual(JSON.parse(JSON.stringify(mockSubscriptions)));
+      expect(res.status).toBe(200);
     });
 
-    it("should handle db errors", async () => {
-      (db.from as jest.Mock).mockRejectedValueOnce(new Error("Database error"));
-      // Mute the express default error handler output in tests
-      app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
-        res.status(500).json({ error: "Internal Error" });
+    it("returns 200 with empty array when no subscriptions exist", async () => {
+      mockFrom.mockResolvedValueOnce([]);
+
+      const res = await request(app).get("/api/subscriptions");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual([]);
+    });
+
+    it("propagates DB errors to error handler", async () => {
+      mockFrom.mockRejectedValueOnce(new Error("DB connection lost"));
+
+      const res = await request(app).get("/api/subscriptions");
+
+      expect(res.status).toBe(500);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // POST /api/subscriptions
+  // ────────────────────────────────────────────────────────────────────────
+  describe("POST /api/subscriptions", () => {
+    const validBody = {
+      url: "https://example.com/webhook",
+      events: ["market.created", "prediction.settled"],
+    };
+
+    it("creates a subscription and returns 201 with secret", async () => {
+      mockReturning.mockResolvedValueOnce([mockSubscription]);
+
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send(validBody);
+
+      expect(res.status).toBe(201);
+      expect(res.body.data.id).toBe(VALID_UUID);
+      // Secret must be present exactly once at creation time
+      expect(typeof res.body.data.secret).toBe("string");
+      expect(res.body.data.secret.length).toBeGreaterThan(0);
+      expect(res.body.data.url).toBe(validBody.url);
+      expect(res.body.data.events).toEqual(
+        expect.arrayContaining(validBody.events),
+      );
+    });
+
+    it("deduplicates events in the request", async () => {
+      const capturedValues: unknown[] = [];
+      mockValues.mockImplementationOnce((vals: unknown) => {
+        capturedValues.push(vals);
+        return { returning: mockReturning };
       });
+      mockReturning.mockResolvedValueOnce([mockSubscription]);
 
-      const response = await request(app).get("/api/subscriptions");
+      await request(app)
+        .post("/api/subscriptions")
+        .send({ url: validBody.url, events: ["market.created", "market.created"] });
 
-      expect(response.status).toBe(500);
+      // The values written to DB should have deduplicated events
+      const written = capturedValues[0] as {
+        events: string[];
+      };
+      expect(written.events).toHaveLength(1);
+      expect(written.events[0]).toBe("market.created");
     });
+
+    it("returns 400 when url is missing", async () => {
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send({ events: ["market.created"] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 when url is not a valid URL", async () => {
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send({ url: "not-a-url", events: ["market.created"] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 when url uses HTTP (non-localhost)", async () => {
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send({ url: "http://example.com/hook", events: ["market.created"] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("accepts http://localhost URLs", async () => {
+      mockReturning.mockResolvedValueOnce([{ ...mockSubscription, url: "http://localhost:3000/hook" }]);
+
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send({ url: "http://localhost:3000/hook", events: ["market.created"] });
+
+      expect(res.status).toBe(201);
+    });
+
+    it("returns 400 when events is missing", async () => {
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send({ url: "https://example.com/hook" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 when events is an empty array", async () => {
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send({ url: "https://example.com/hook", events: [] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 when events contains an invalid event type", async () => {
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send({ url: "https://example.com/hook", events: ["not-valid-format"] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 for unknown body fields (strict mode)", async () => {
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send({ ...validBody, unknownField: "should-fail" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("propagates DB errors to error handler", async () => {
+      mockValues.mockImplementationOnce(() => ({
+        returning: jest.fn().mockRejectedValueOnce(new Error("insert failed")),
+      }));
+
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send(validBody);
+
+      expect(res.status).toBe(500);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // GET /api/subscriptions/:id
+  // ────────────────────────────────────────────────────────────────────────
+  describe("GET /api/subscriptions/:id", () => {
+    it("returns 200 with subscription data (secret stripped)", async () => {
+      mockWhere.mockResolvedValueOnce([mockSubscription]);
+
+      const res = await request(app).get(`/api/subscriptions/${VALID_UUID}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.id).toBe(VALID_UUID);
+      expect(res.body.data.secret).toBeUndefined();
+    });
+
+    it("returns 404 when subscription does not exist", async () => {
+      mockWhere.mockResolvedValueOnce([]);
+
+      const res = await request(app).get(`/api/subscriptions/${VALID_UUID}`);
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 for a non-UUID id", async () => {
+      const res = await request(app).get("/api/subscriptions/not-a-uuid");
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // PATCH /api/subscriptions/:id
+  // ────────────────────────────────────────────────────────────────────────
+  describe("PATCH /api/subscriptions/:id", () => {
+    const updatedSub = {
+      ...mockSubscription,
+      url: "https://new.example.com/hook",
+      updatedAt: new Date(),
+    };
+
+    it("updates url and returns 200", async () => {
+      // Existence check
+      mockWhere
+        .mockResolvedValueOnce([mockSubscription])
+        // Update returning
+        .mockResolvedValueOnce([updatedSub]);
+
+      const res = await request(app)
+        .patch(`/api/subscriptions/${VALID_UUID}`)
+        .send({ url: "https://new.example.com/hook" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.url).toBe("https://new.example.com/hook");
+      expect(res.body.data.secret).toBeUndefined();
+    });
+
+    it("updates active flag and returns 200", async () => {
+      mockWhere
+        .mockResolvedValueOnce([mockSubscription])
+        .mockResolvedValueOnce([{ ...mockSubscription, active: false }]);
+
+      const res = await request(app)
+        .patch(`/api/subscriptions/${VALID_UUID}`)
+        .send({ active: false });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.active).toBe(false);
+    });
+
+    it("updates events array and returns 200", async () => {
+      const newEvents = ["market.resolved"];
+      mockWhere
+        .mockResolvedValueOnce([mockSubscription])
+        .mockResolvedValueOnce([{ ...mockSubscription, events: newEvents }]);
+
+      const res = await request(app)
+        .patch(`/api/subscriptions/${VALID_UUID}`)
+        .send({ events: newEvents });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.events).toEqual(newEvents);
+    });
+
+    it("returns 404 when subscription does not exist", async () => {
+      mockWhere.mockResolvedValueOnce([]);
+
+      const res = await request(app)
+        .patch(`/api/subscriptions/${VALID_UUID}`)
+        .send({ active: false });
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 when body is empty (no fields provided)", async () => {
+      const res = await request(app)
+        .patch(`/api/subscriptions/${VALID_UUID}`)
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 for invalid url in patch body", async () => {
+      const res = await request(app)
+        .patch(`/api/subscriptions/${VALID_UUID}`)
+        .send({ url: "ftp://bad-protocol.com" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 for unknown fields (strict mode)", async () => {
+      const res = await request(app)
+        .patch(`/api/subscriptions/${VALID_UUID}`)
+        .send({ active: true, surprise: "field" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 for non-UUID id", async () => {
+      const res = await request(app)
+        .patch("/api/subscriptions/bad-id")
+        .send({ active: true });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // DELETE /api/subscriptions/:id
+  // ────────────────────────────────────────────────────────────────────────
+  describe("DELETE /api/subscriptions/:id", () => {
+    it("returns 204 when subscription is deleted", async () => {
+      mockWhere.mockResolvedValueOnce({ rowCount: 1 });
+
+      const res = await request(app).delete(
+        `/api/subscriptions/${VALID_UUID}`,
+      );
+
+      expect(res.status).toBe(204);
+      expect(res.body).toEqual({});
+    });
+
+    it("returns 404 when subscription does not exist", async () => {
+      mockWhere.mockResolvedValueOnce({ rowCount: 0 });
+
+      const res = await request(app).delete(
+        `/api/subscriptions/${ANOTHER_UUID}`,
+      );
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 for non-UUID id", async () => {
+      const res = await request(app).delete("/api/subscriptions/not-a-uuid");
+
+      expect(res.status).toBe(400);
+    });
+  });
+});
+
+// ============================================================================
+// Validator unit tests
+// ============================================================================
+
+describe("createSubscriptionBodySchema", () => {
+  const VALID = {
+    url: "https://example.com/hook",
+    events: ["market.created"],
+  };
+
+  it("accepts a valid body", () => {
+    const r = createSubscriptionBodySchema.safeParse(VALID);
+    expect(r.success).toBe(true);
+  });
+
+  it("deduplicates duplicate event types", () => {
+    const r = createSubscriptionBodySchema.safeParse({
+      ...VALID,
+      events: ["market.created", "market.created", "prediction.settled"],
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.events).toHaveLength(2);
+    }
+  });
+
+  it("rejects missing url", () => {
+    const r = createSubscriptionBodySchema.safeParse({ events: ["market.created"] });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.path.includes("url"))).toBe(true);
+    }
+  });
+
+  it("rejects missing events", () => {
+    const r = createSubscriptionBodySchema.safeParse({ url: VALID.url });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.path.includes("events"))).toBe(true);
+    }
+  });
+
+  it("rejects empty events array", () => {
+    const r = createSubscriptionBodySchema.safeParse({ ...VALID, events: [] });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects unknown keys (strict)", () => {
+    const r = createSubscriptionBodySchema.safeParse({ ...VALID, extra: "x" });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.code === "unrecognized_keys")).toBe(true);
+    }
+  });
+
+  it("rejects non-https url (non-localhost)", () => {
+    const r = createSubscriptionBodySchema.safeParse({
+      url: "http://example.com/hook",
+      events: VALID.events,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts http://localhost", () => {
+    const r = createSubscriptionBodySchema.safeParse({
+      url: "http://localhost:9000/hook",
+      events: VALID.events,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts up to 50 distinct event types", () => {
+    const events = Array.from({ length: 50 }, (_, i) => `market.event${i}`);
+    const r = createSubscriptionBodySchema.safeParse({ ...VALID, events });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects more than 50 distinct event types", () => {
+    const events = Array.from({ length: 51 }, (_, i) => `market.event${i}`);
+    const r = createSubscriptionBodySchema.safeParse({ ...VALID, events });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("patchSubscriptionBodySchema", () => {
+  it("accepts updating only url", () => {
+    const r = patchSubscriptionBodySchema.safeParse({
+      url: "https://new.example.com/hook",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts updating only active", () => {
+    const r = patchSubscriptionBodySchema.safeParse({ active: false });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts updating only events", () => {
+    const r = patchSubscriptionBodySchema.safeParse({
+      events: ["prediction.settled"],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts updating all fields at once", () => {
+    const r = patchSubscriptionBodySchema.safeParse({
+      url: "https://example.com/hook",
+      events: ["market.created"],
+      active: true,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects empty object (at least one field required)", () => {
+    const r = patchSubscriptionBodySchema.safeParse({});
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects unknown keys (strict)", () => {
+    const r = patchSubscriptionBodySchema.safeParse({
+      active: true,
+      surprise: "field",
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.code === "unrecognized_keys")).toBe(true);
+    }
+  });
+
+  it("rejects invalid url in patch", () => {
+    const r = patchSubscriptionBodySchema.safeParse({ url: "not-a-url" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects non-boolean active value", () => {
+    const r = patchSubscriptionBodySchema.safeParse({ active: "yes" });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("subscriptionIdParamSchema", () => {
+  it("accepts a valid UUID", () => {
+    const r = subscriptionIdParamSchema.safeParse({
+      id: "123e4567-e89b-12d3-a456-426614174000",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a non-UUID string", () => {
+    const r = subscriptionIdParamSchema.safeParse({ id: "not-a-uuid" });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues[0]?.path).toEqual(["id"]);
+    }
+  });
+
+  it("rejects missing id", () => {
+    const r = subscriptionIdParamSchema.safeParse({});
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("eventTypeSchema", () => {
+  it.each([
+    "market.created",
+    "prediction.settled",
+    "market_order.placed",
+    "webhook-delivery.failed",
+  ])("accepts valid event type: %s", (event) => {
+    expect(eventTypeSchema.safeParse(event).success).toBe(true);
+  });
+
+  it.each([
+    "no-dot",
+    ".leading-dot",
+    "trailing-dot.",
+    "two..dots",
+    "has space.here",
+    "",
+  ])("rejects invalid event type: %s", (event) => {
+    expect(eventTypeSchema.safeParse(event).success).toBe(false);
+  });
+});
+
+describe("webhookUrlSchema", () => {
+  it("accepts https URLs", () => {
+    expect(
+      webhookUrlSchema.safeParse("https://example.com/webhook").success,
+    ).toBe(true);
+  });
+
+  it("accepts http://localhost", () => {
+    expect(
+      webhookUrlSchema.safeParse("http://localhost:3000/hook").success,
+    ).toBe(true);
+  });
+
+  it("rejects http non-localhost", () => {
+    expect(
+      webhookUrlSchema.safeParse("http://example.com/hook").success,
+    ).toBe(false);
+  });
+
+  it("rejects ftp protocol", () => {
+    expect(webhookUrlSchema.safeParse("ftp://example.com/hook").success).toBe(
+      false,
+    );
+  });
+
+  it("rejects plain strings", () => {
+    expect(webhookUrlSchema.safeParse("not-a-url").success).toBe(false);
+  });
+
+  it("trims whitespace before validation", () => {
+    expect(
+      webhookUrlSchema.safeParse("  https://example.com/hook  ").success,
+    ).toBe(true);
   });
 });

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,22 +1,4 @@
-
 import type { NextFunction, Request, Response } from "express";
-import { logger } from "../config/logger";
-
-/*
- * Status → error code mapping:
- *   err.status=400  → 400  request_failed    (generic bad request)
- *   err.status=404  → 404  not_found
- *   err.status=409  → 409  conflict
- *   err.status=422  → 422  unprocessable
- *   other 4xx       → 4xx  request_failed
- *   5xx / unknown   → 500  internal_error    (internals never leaked)
- */
-export function errorHandler(err: unknown, req: Request, res: Response, _next: NextFunction) {
-  logger.error({ err, path: req.path, method: req.method }, "request_failed");
-  const status = (err as { status?: number }).status ?? 500;
-  const code = (err as { code?: string }).code ?? (status === 500 ? "internal_error" : "request_failed");
-  res.status(status).json({
-    error: { code },
 import { ZodError } from "zod";
 import { randomUUID } from "crypto";
 import { logger } from "../config/logger";
@@ -24,7 +6,13 @@ import { AppError, ErrorCodes, isRouteError, HTTP_STATUS, toErrorEnvelope } from
 import { getRequestId } from "../lib/requestContext";
 
 function requestIdFrom(req: Request, fallback: string): string {
-  return getRequestId() ?? (typeof (req as { id?: unknown }).id === "string" ? (req as { id?: string }).id : undefined) ?? fallback;
+  return (
+    getRequestId() ??
+    (typeof (req as { id?: unknown }).id === "string"
+      ? (req as { id?: string }).id
+      : undefined) ??
+    fallback
+  );
 }
 
 export function errorHandler(
@@ -33,7 +21,12 @@ export function errorHandler(
   res: Response,
   _next: NextFunction,
 ) {
-  const correlationId = (req.headers["x-correlation-id"] as string) ?? (typeof (req as { id?: unknown }).id === "string" ? (req as { id?: string }).id : undefined) ?? randomUUID();
+  const correlationId =
+    (req.headers["x-correlation-id"] as string) ??
+    (typeof (req as { id?: unknown }).id === "string"
+      ? (req as { id?: string }).id
+      : undefined) ??
+    randomUUID();
   const reqId = requestIdFrom(req, correlationId);
 
   if (isRouteError(err)) {
@@ -56,7 +49,10 @@ export function errorHandler(
   }
 
   if (err instanceof AppError) {
-    logger.error({ err, path: req.path, method: req.method, correlationId, requestId: reqId }, "app_error");
+    logger.error(
+      { err, path: req.path, method: req.method, correlationId, requestId: reqId },
+      "app_error",
+    );
     res.status(err.status).json({
       error: {
         code: err.code,
@@ -69,7 +65,10 @@ export function errorHandler(
   }
 
   if (err instanceof ZodError) {
-    logger.warn({ err, path: req.path, method: req.method, correlationId, requestId: reqId }, "validation_error");
+    logger.warn(
+      { err, path: req.path, method: req.method, correlationId, requestId: reqId },
+      "validation_error",
+    );
     res.status(400).json({
       error: {
         code: ErrorCodes.VALIDATION_ERROR,
@@ -81,7 +80,10 @@ export function errorHandler(
     return;
   }
 
-  logger.error({ err, path: req.path, method: req.method, requestId: reqId }, "unknown_error");
+  logger.error(
+    { err, path: req.path, method: req.method, requestId: reqId },
+    "unknown_error",
+  );
   res.status(500).json({
     error: {
       code: ErrorCodes.INTERNAL_ERROR,

--- a/src/routes/subscriptions.ts
+++ b/src/routes/subscriptions.ts
@@ -1,22 +1,241 @@
+/**
+ * src/routes/subscriptions.ts
+ *
+ * Admin-facing webhook subscription management.
+ * Mounted at `/api/subscriptions`.
+ *
+ * All endpoints require admin authentication (`requireAdmin`).
+ * Input validation is enforced at the route boundary using the Zod schemas
+ * exported from `src/validators/subscriptions.ts`.
+ * Structured logging with correlation / request IDs is emitted on every
+ * operation. All errors follow the project's standard error envelope.
+ *
+ * Endpoints
+ * ─────────
+ *   GET    /          — list all webhook subscriptions
+ *   POST   /          — create a new webhook subscription
+ *   GET    /:id       — fetch a single subscription by UUID
+ *   PATCH  /:id       — partially update a subscription
+ *   DELETE /:id       — delete a subscription
+ */
+
 import { Router } from "express";
+import { eq } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
 import { db } from "../db/client";
 import { webhookSubscriptions } from "../db/schema";
 import { conditionalGet } from "../middleware/etag";
 import { requireAdmin } from "../middleware/requireAdmin";
+import { logger } from "../config/logger";
+import { getRequestId } from "../lib/requestContext";
+import { RouteErrorFactory } from "../errors";
+import {
+  createSubscriptionBodySchema,
+  patchSubscriptionBodySchema,
+  subscriptionIdParamSchema,
+} from "../validators/subscriptions";
 
 export const subscriptionsRouter = Router();
 
+// All subscription management endpoints are admin-only.
 subscriptionsRouter.use(requireAdmin);
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip the internal `secret` from a subscription row before returning it to
+ * the client. The secret is only exposed once, at creation time.
+ */
+function serializeSub(
+  row: typeof webhookSubscriptions.$inferSelect,
+): Omit<typeof webhookSubscriptions.$inferSelect, "secret"> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { secret: _secret, ...pub } = row;
+  return pub;
+}
+
+// ---------------------------------------------------------------------------
+// GET / — list all webhook subscriptions
+// ---------------------------------------------------------------------------
+
 subscriptionsRouter.get("/", async (req, res, next) => {
+  const reqId = getRequestId();
+
   try {
     const subscriptions = await db.select().from(webhookSubscriptions);
 
+    logger.debug({ reqId, count: subscriptions.length }, "subscriptions_listed");
+
+    // ETag / conditional-GET support — returns 304 when content unchanged.
     if (conditionalGet(subscriptions, req, res)) {
       return;
     }
 
-    res.json({ data: subscriptions });
+    res.json({ data: subscriptions.map(serializeSub) });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST / — create a new webhook subscription
+// ---------------------------------------------------------------------------
+
+subscriptionsRouter.post("/", async (req, res, next) => {
+  const reqId = getRequestId();
+
+  try {
+    // --- Input validation ---
+    const parsed = createSubscriptionBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      logger.warn(
+        { reqId, issues: parsed.error.issues },
+        "subscriptions_create_validation_failed",
+      );
+      // Re-throw as a ZodError so errorHandler formats it consistently.
+      throw parsed.error;
+    }
+
+    const { url, events } = parsed.data;
+
+    // Generate an HMAC signing secret for the subscription.
+    const secret = uuidv4();
+
+    const [row] = await db
+      .insert(webhookSubscriptions)
+      .values({ url, events, secret })
+      .returning();
+
+    logger.info({ reqId, subscriptionId: row!.id }, "subscription_created");
+
+    // Return the secret only once, at creation time.
+    res.status(201).json({ data: { ...serializeSub(row!), secret } });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /:id — fetch a single subscription
+// ---------------------------------------------------------------------------
+
+subscriptionsRouter.get("/:id", async (req, res, next) => {
+  const reqId = getRequestId();
+
+  try {
+    // --- Path parameter validation ---
+    const paramParsed = subscriptionIdParamSchema.safeParse(req.params);
+    if (!paramParsed.success) {
+      throw RouteErrorFactory.badRequest(
+        paramParsed.error.issues[0]?.message ?? "Invalid subscription ID",
+      );
+    }
+
+    const { id } = paramParsed.data;
+
+    const [row] = await db
+      .select()
+      .from(webhookSubscriptions)
+      .where(eq(webhookSubscriptions.id, id));
+
+    if (!row) {
+      logger.debug({ reqId, subscriptionId: id }, "subscription_not_found");
+      throw RouteErrorFactory.notFound("Subscription not found");
+    }
+
+    logger.debug({ reqId, subscriptionId: id }, "subscription_fetched");
+
+    res.json({ data: serializeSub(row) });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /:id — partially update a subscription
+// ---------------------------------------------------------------------------
+
+subscriptionsRouter.patch("/:id", async (req, res, next) => {
+  const reqId = getRequestId();
+
+  try {
+    // --- Path parameter validation ---
+    const paramParsed = subscriptionIdParamSchema.safeParse(req.params);
+    if (!paramParsed.success) {
+      throw RouteErrorFactory.badRequest(
+        paramParsed.error.issues[0]?.message ?? "Invalid subscription ID",
+      );
+    }
+
+    const { id } = paramParsed.data;
+
+    // --- Body validation ---
+    const bodyParsed = patchSubscriptionBodySchema.safeParse(req.body);
+    if (!bodyParsed.success) {
+      logger.warn(
+        { reqId, subscriptionId: id, issues: bodyParsed.error.issues },
+        "subscriptions_patch_validation_failed",
+      );
+      throw bodyParsed.error;
+    }
+
+    // Verify the subscription exists before attempting an update.
+    const [existing] = await db
+      .select()
+      .from(webhookSubscriptions)
+      .where(eq(webhookSubscriptions.id, id));
+
+    if (!existing) {
+      logger.debug({ reqId, subscriptionId: id }, "subscription_not_found");
+      throw RouteErrorFactory.notFound("Subscription not found");
+    }
+
+    const [updated] = await db
+      .update(webhookSubscriptions)
+      .set({ ...bodyParsed.data, updatedAt: new Date() })
+      .where(eq(webhookSubscriptions.id, id))
+      .returning();
+
+    logger.info({ reqId, subscriptionId: updated!.id }, "subscription_updated");
+
+    res.json({ data: serializeSub(updated!) });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /:id — delete a subscription
+// ---------------------------------------------------------------------------
+
+subscriptionsRouter.delete("/:id", async (req, res, next) => {
+  const reqId = getRequestId();
+
+  try {
+    // --- Path parameter validation ---
+    const paramParsed = subscriptionIdParamSchema.safeParse(req.params);
+    if (!paramParsed.success) {
+      throw RouteErrorFactory.badRequest(
+        paramParsed.error.issues[0]?.message ?? "Invalid subscription ID",
+      );
+    }
+
+    const { id } = paramParsed.data;
+
+    const result = await db
+      .delete(webhookSubscriptions)
+      .where(eq(webhookSubscriptions.id, id));
+
+    if (result.rowCount === 0) {
+      logger.debug({ reqId, subscriptionId: id }, "subscription_not_found");
+      throw RouteErrorFactory.notFound("Subscription not found");
+    }
+
+    logger.info({ reqId, subscriptionId: id }, "subscription_deleted");
+
+    res.status(204).send();
   } catch (err) {
     next(err);
   }

--- a/src/validators/subscriptions.ts
+++ b/src/validators/subscriptions.ts
@@ -1,0 +1,163 @@
+/**
+ * @module validators/subscriptions
+ *
+ * Zod schemas for the /api/subscriptions endpoints.
+ *
+ * All schemas use `.strict()` on object types so that unrecognised keys are
+ * rejected at the route boundary rather than silently ignored. This keeps the
+ * contract explicit and prevents parameter-smuggling attacks.
+ *
+ * Exported schemas
+ * ────────────────
+ *   createSubscriptionBodySchema  — POST /api/subscriptions body
+ *   patchSubscriptionBodySchema   — PATCH /api/subscriptions/:id body
+ *   subscriptionIdParamSchema     — :id path parameter (UUID)
+ */
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum number of event-type strings accepted in one subscription. */
+const MAX_EVENTS = 50;
+
+/** Maximum byte-length of an event-type string. */
+const MAX_EVENT_LENGTH = 128;
+
+/** Maximum byte-length of a webhook URL. */
+const MAX_URL_LENGTH = 2048;
+
+// ---------------------------------------------------------------------------
+// Shared primitives
+// ---------------------------------------------------------------------------
+
+/**
+ * A single webhook event-type token.
+ *
+ * Format: `<resource>.<action>` — e.g. "market.created", "prediction.settled".
+ * Characters: alphanumeric, underscore, hyphen, and a single dot separator.
+ */
+export const eventTypeSchema = z
+  .string({
+    invalid_type_error: "Each event type must be a string",
+  })
+  .trim()
+  .min(1, "Event type must not be empty")
+  .max(MAX_EVENT_LENGTH, `Event type must be at most ${MAX_EVENT_LENGTH} characters`)
+  .regex(
+    /^[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+$/,
+    "Event type must be in the format '<resource>.<action>' (e.g. 'market.created')",
+  );
+
+/**
+ * Array of webhook event-type tokens.
+ *
+ * At least one event must be provided; duplicates are coerced away.
+ */
+export const eventsArraySchema = z
+  .array(eventTypeSchema, {
+    invalid_type_error: "events must be an array of strings",
+    required_error: "events is required",
+  })
+  .min(1, "At least one event type is required")
+  .max(MAX_EVENTS, `At most ${MAX_EVENTS} event types are allowed`)
+  .transform((evs) => [...new Set(evs)]);
+
+/**
+ * A valid HTTPS webhook delivery URL.
+ *
+ * We require HTTPS in production-like contexts to prevent accidental
+ * plaintext delivery of signed payloads.
+ */
+export const webhookUrlSchema = z
+  .string({
+    required_error: "url is required",
+    invalid_type_error: "url must be a string",
+  })
+  .trim()
+  .min(1, "url must not be empty")
+  .max(MAX_URL_LENGTH, `url must be at most ${MAX_URL_LENGTH} characters`)
+  .url("url must be a valid URL")
+  .refine(
+    (val) => {
+      try {
+        const parsed = new URL(val);
+        return parsed.protocol === "https:" || parsed.hostname === "localhost";
+      } catch {
+        return false;
+      }
+    },
+    { message: "url must use HTTPS (HTTP allowed only for localhost)" },
+  );
+
+// ---------------------------------------------------------------------------
+// POST /api/subscriptions — create body
+// ---------------------------------------------------------------------------
+
+/**
+ * Request body schema for creating a new webhook subscription.
+ *
+ * Required fields:
+ *   - url     : HTTPS webhook endpoint URL
+ *   - events  : Non-empty array of "<resource>.<action>" event tokens
+ *
+ * Unknown keys are rejected via `.strict()`.
+ */
+export const createSubscriptionBodySchema = z
+  .object({
+    url: webhookUrlSchema,
+    events: eventsArraySchema,
+  })
+  .strict();
+
+export type CreateSubscriptionBody = z.infer<typeof createSubscriptionBodySchema>;
+
+// ---------------------------------------------------------------------------
+// PATCH /api/subscriptions/:id — update body
+// ---------------------------------------------------------------------------
+
+/**
+ * Request body schema for partially updating a webhook subscription.
+ *
+ * All fields are optional but at least one must be provided.
+ * Unknown keys are rejected via `.strict()`.
+ */
+export const patchSubscriptionBodySchema = z
+  .object({
+    url: webhookUrlSchema.optional(),
+    events: eventsArraySchema.optional(),
+    active: z
+      .boolean({
+        invalid_type_error: "active must be a boolean",
+      })
+      .optional(),
+  })
+  .strict()
+  .refine(
+    (data) => Object.values(data).some((v) => v !== undefined),
+    { message: "At least one field (url, events, active) must be provided for an update" },
+  );
+
+export type PatchSubscriptionBody = z.infer<typeof patchSubscriptionBodySchema>;
+
+// ---------------------------------------------------------------------------
+// :id path parameter
+// ---------------------------------------------------------------------------
+
+/**
+ * Path parameter schema for endpoints that require a subscription UUID.
+ *
+ *   :id — a UUID v4 string identifying the target subscription
+ */
+export const subscriptionIdParamSchema = z.object({
+  id: z
+    .string({
+      required_error: "Subscription ID is required",
+      invalid_type_error: "Subscription ID must be a string",
+    })
+    .uuid("Subscription ID must be a valid UUID"),
+});
+
+export type SubscriptionIdParam = z.infer<typeof subscriptionIdParamSchema>;

--- a/tests/subscriptions.test.ts
+++ b/tests/subscriptions.test.ts
@@ -1,0 +1,668 @@
+/**
+ * tests/subscriptions.test.ts
+ *
+ * Integration + unit tests for the subscriptions router (issue #641).
+ *
+ * Coverage:
+ *   GET    /api/subscriptions          — list, ETag/304, DB error
+ *   POST   /api/subscriptions          — create (valid), validation errors, DB error
+ *   GET    /api/subscriptions/:id      — fetch, 404, invalid UUID
+ *   PATCH  /api/subscriptions/:id      — update (valid), validation errors, 404, empty body
+ *   DELETE /api/subscriptions/:id      — delete, 404, invalid UUID
+ *
+ *   Validator unit tests:
+ *     createSubscriptionBodySchema, patchSubscriptionBodySchema,
+ *     subscriptionIdParamSchema, eventTypeSchema, webhookUrlSchema
+ */
+
+// ---------------------------------------------------------------------------
+// Environment setup (must come before any src imports)
+// ---------------------------------------------------------------------------
+process.env.NODE_ENV = "test";
+process.env.LOG_LEVEL = "silent";
+process.env.DATABASE_URL = "postgres://localhost/test";
+process.env.JWT_SECRET = "a-test-secret-with-at-least-32-bytes!!";
+process.env.JWT_ISSUER = "predictify";
+process.env.JWT_AUDIENCE = "predictify-app";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock("../src/middleware/requireAdmin", () => ({
+  requireAdmin: (
+    _req: import("express").Request,
+    _res: import("express").Response,
+    next: import("express").NextFunction,
+  ) => next(),
+}));
+
+jest.mock("../src/config/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Drizzle fluent query builder mock.
+//
+// Route query patterns:
+//   GET  /        select().from()                              → mockFrom   resolves row[]
+//   GET  /:id     select().from().where()                      → mockSelectWhere resolves row[]
+//   POST /        insert().values().returning()                → mockReturning resolves row[]
+//   PATCH /:id    select().from().where() (existence)          → mockSelectWhere resolves row[]
+//                 update().set().where().returning() (update)  → mockUpdateReturning resolves row[]
+//   DELETE /:id   delete().where()                             → mockDeleteWhere resolves {rowCount}
+// ---------------------------------------------------------------------------
+
+const mockUpdateReturning = jest.fn();
+const mockSelectWhere = jest.fn();
+const mockUpdateWhere = jest.fn(() => ({ returning: mockUpdateReturning }));
+const mockDeleteWhere = jest.fn();
+const mockFrom = jest.fn();
+const mockSet = jest.fn(() => ({ where: mockUpdateWhere }));
+const mockReturning = jest.fn();
+const mockValues = jest.fn(() => ({ returning: mockReturning }));
+const mockInsert = jest.fn(() => ({ values: mockValues }));
+const mockUpdate = jest.fn(() => ({ set: mockSet }));
+const mockDelete = jest.fn(() => ({ where: mockDeleteWhere }));
+const mockSelect = jest.fn(() => ({ from: mockFrom }));
+
+jest.mock("../src/db/client", () => ({
+  db: {
+    select: (...args: unknown[]) => mockSelect(...args),
+    insert: (...args: unknown[]) => mockInsert(...args),
+    update: (...args: unknown[]) => mockUpdate(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+import request from "supertest";
+import express from "express";
+import { subscriptionsRouter } from "../src/routes/subscriptions";
+import { errorHandler } from "../src/middleware/errorHandler";
+import { generateETag } from "../src/middleware/etag";
+import {
+  createSubscriptionBodySchema,
+  patchSubscriptionBodySchema,
+  subscriptionIdParamSchema,
+  eventTypeSchema,
+  webhookUrlSchema,
+} from "../src/validators/subscriptions";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const VALID_UUID = "123e4567-e89b-12d3-a456-426614174000";
+const ANOTHER_UUID = "987fcdeb-51d3-12d3-a456-426614174999";
+
+const mockSubscription = {
+  id: VALID_UUID,
+  url: "https://example.com/webhook",
+  secret: "super-secret-hmac-key",
+  events: ["market.created", "prediction.settled"],
+  active: true,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+};
+
+// ---------------------------------------------------------------------------
+// App factory
+// ---------------------------------------------------------------------------
+
+function makeApp(): express.Application {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/subscriptions", subscriptionsRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Route integration tests
+// ---------------------------------------------------------------------------
+
+describe("Subscriptions Routes (issue #641)", () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = makeApp();
+
+    // Wire the fluent chain so .from() returns the object that has .where()
+    mockFrom.mockReturnValue({ where: mockSelectWhere });
+    // Wire update().set().where() to return { returning: mockUpdateReturning }
+    mockUpdateWhere.mockReturnValue({ returning: mockUpdateReturning });
+
+    // Defaults: empty/no-op results
+    mockSelectWhere.mockResolvedValue([]);
+    mockUpdateReturning.mockResolvedValue([]);
+    mockDeleteWhere.mockResolvedValue({ rowCount: 0 });
+    mockReturning.mockResolvedValue([]);
+  });
+
+  // ── GET / ─────────────────────────────────────────────────────────────────
+  describe("GET /api/subscriptions", () => {
+    it("returns 200 with data and a strong ETag", async () => {
+      // GET / uses select().from() directly (no .where())
+      mockFrom.mockResolvedValueOnce([mockSubscription]);
+
+      const res = await request(app).get("/api/subscriptions");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toBeDefined();
+      expect(generateETag([mockSubscription])).toBe(res.headers.etag);
+      expect(res.headers["cache-control"]).toBe("no-cache");
+    });
+
+    it("returns 304 when If-None-Match matches ETag", async () => {
+      mockFrom.mockResolvedValue([mockSubscription]);
+      const etag = generateETag([mockSubscription]);
+
+      const res = await request(app)
+        .get("/api/subscriptions")
+        .set("If-None-Match", etag);
+
+      expect(res.status).toBe(304);
+    });
+
+    it("returns 200 when If-None-Match is stale", async () => {
+      mockFrom.mockResolvedValueOnce([mockSubscription]);
+
+      const res = await request(app)
+        .get("/api/subscriptions")
+        .set("If-None-Match", '"stale-etag"');
+
+      expect(res.status).toBe(200);
+    });
+
+    it("returns empty array when no subscriptions exist", async () => {
+      mockFrom.mockResolvedValueOnce([]);
+
+      const res = await request(app).get("/api/subscriptions");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual([]);
+    });
+
+    it("propagates DB errors (500)", async () => {
+      mockFrom.mockRejectedValueOnce(new Error("DB unavailable"));
+
+      const res = await request(app).get("/api/subscriptions");
+
+      expect(res.status).toBe(500);
+    });
+  });
+
+  // ── POST / ────────────────────────────────────────────────────────────────
+  describe("POST /api/subscriptions", () => {
+    const VALID_BODY = {
+      url: "https://example.com/webhook",
+      events: ["market.created"],
+    };
+
+    it("creates a subscription and returns 201 with the secret", async () => {
+      mockReturning.mockResolvedValueOnce([mockSubscription]);
+
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send(VALID_BODY);
+
+      expect(res.status).toBe(201);
+      expect(res.body.data.id).toBe(VALID_UUID);
+      expect(typeof res.body.data.secret).toBe("string");
+      expect(res.body.data.url).toBe("https://example.com/webhook");
+    });
+
+    it("does not expose secret in GET list response", async () => {
+      mockFrom.mockResolvedValueOnce([mockSubscription]);
+
+      const res = await request(app).get("/api/subscriptions");
+
+      expect(res.body.data[0]?.secret).toBeUndefined();
+    });
+
+    it("deduplicates events before inserting", async () => {
+      const capturedArgs: unknown[] = [];
+      mockValues.mockImplementationOnce((vals: unknown) => {
+        capturedArgs.push(vals);
+        return { returning: mockReturning };
+      });
+      mockReturning.mockResolvedValueOnce([mockSubscription]);
+
+      await request(app).post("/api/subscriptions").send({
+        url: VALID_BODY.url,
+        events: ["market.created", "market.created", "prediction.settled"],
+      });
+
+      const inserted = capturedArgs[0] as { events: string[] };
+      expect(inserted.events).toHaveLength(2);
+    });
+
+    it("returns 400 when url is missing", async () => {
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send({ events: ["market.created"] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 for an invalid URL", async () => {
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send({ url: "not-a-url", events: ["market.created"] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 when HTTP url is used for non-localhost", async () => {
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send({ url: "http://example.com/hook", events: ["market.created"] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("accepts http://localhost URLs", async () => {
+      mockReturning.mockResolvedValueOnce([
+        { ...mockSubscription, url: "http://localhost:4000/hook" },
+      ]);
+
+      const res = await request(app).post("/api/subscriptions").send({
+        url: "http://localhost:4000/hook",
+        events: ["market.created"],
+      });
+
+      expect(res.status).toBe(201);
+    });
+
+    it("returns 400 when events is missing", async () => {
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send({ url: VALID_BODY.url });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 for empty events array", async () => {
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send({ url: VALID_BODY.url, events: [] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 for events with invalid format", async () => {
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send({ url: VALID_BODY.url, events: ["no-dot-here"] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 for unknown body fields (strict)", async () => {
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send({ ...VALID_BODY, extraField: "bad" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("propagates DB errors (500)", async () => {
+      mockValues.mockImplementationOnce(() => ({
+        returning: jest.fn().mockRejectedValueOnce(new Error("insert failed")),
+      }));
+
+      const res = await request(app)
+        .post("/api/subscriptions")
+        .send(VALID_BODY);
+
+      expect(res.status).toBe(500);
+    });
+  });
+
+  // ── GET /:id ──────────────────────────────────────────────────────────────
+  describe("GET /api/subscriptions/:id", () => {
+    it("returns 200 with subscription data (secret stripped)", async () => {
+      // GET /:id uses select().from().where()
+      mockSelectWhere.mockResolvedValueOnce([mockSubscription]);
+
+      const res = await request(app).get(`/api/subscriptions/${VALID_UUID}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.id).toBe(VALID_UUID);
+      expect(res.body.data.secret).toBeUndefined();
+    });
+
+    it("returns 404 when subscription does not exist", async () => {
+      mockSelectWhere.mockResolvedValueOnce([]);
+
+      const res = await request(app).get(`/api/subscriptions/${ANOTHER_UUID}`);
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 for a non-UUID :id", async () => {
+      const res = await request(app).get("/api/subscriptions/not-a-uuid");
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ── PATCH /:id ────────────────────────────────────────────────────────────
+  describe("PATCH /api/subscriptions/:id", () => {
+    it("updates url and returns 200 (secret stripped)", async () => {
+      const updated = { ...mockSubscription, url: "https://new.example.com/hook" };
+      // Existence check uses select().from().where()
+      mockSelectWhere.mockResolvedValueOnce([mockSubscription]);
+      // Update uses update().set().where().returning()
+      mockUpdateReturning.mockResolvedValueOnce([updated]);
+
+      const res = await request(app)
+        .patch(`/api/subscriptions/${VALID_UUID}`)
+        .send({ url: "https://new.example.com/hook" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.url).toBe("https://new.example.com/hook");
+      expect(res.body.data.secret).toBeUndefined();
+    });
+
+    it("updates active flag", async () => {
+      mockSelectWhere.mockResolvedValueOnce([mockSubscription]);
+      mockUpdateReturning.mockResolvedValueOnce([{ ...mockSubscription, active: false }]);
+
+      const res = await request(app)
+        .patch(`/api/subscriptions/${VALID_UUID}`)
+        .send({ active: false });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.active).toBe(false);
+    });
+
+    it("updates events array", async () => {
+      const newEvents = ["market.resolved"];
+      mockSelectWhere.mockResolvedValueOnce([mockSubscription]);
+      mockUpdateReturning.mockResolvedValueOnce([{ ...mockSubscription, events: newEvents }]);
+
+      const res = await request(app)
+        .patch(`/api/subscriptions/${VALID_UUID}`)
+        .send({ events: newEvents });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.events).toEqual(newEvents);
+    });
+
+    it("returns 404 when subscription does not exist", async () => {
+      mockSelectWhere.mockResolvedValueOnce([]);
+
+      const res = await request(app)
+        .patch(`/api/subscriptions/${VALID_UUID}`)
+        .send({ active: false });
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 for empty body (at least one field required)", async () => {
+      const res = await request(app)
+        .patch(`/api/subscriptions/${VALID_UUID}`)
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 for invalid url in patch body", async () => {
+      const res = await request(app)
+        .patch(`/api/subscriptions/${VALID_UUID}`)
+        .send({ url: "ftp://bad-scheme.com" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 for unknown body fields (strict)", async () => {
+      const res = await request(app)
+        .patch(`/api/subscriptions/${VALID_UUID}`)
+        .send({ active: true, unknownField: "x" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("returns 400 for non-UUID :id", async () => {
+      const res = await request(app)
+        .patch("/api/subscriptions/bad-id")
+        .send({ active: true });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ── DELETE /:id ───────────────────────────────────────────────────────────
+  describe("DELETE /api/subscriptions/:id", () => {
+    it("returns 204 on successful deletion", async () => {
+      mockDeleteWhere.mockResolvedValueOnce({ rowCount: 1 });
+
+      const res = await request(app).delete(`/api/subscriptions/${VALID_UUID}`);
+
+      expect(res.status).toBe(204);
+    });
+
+    it("returns 404 when subscription does not exist", async () => {
+      mockDeleteWhere.mockResolvedValueOnce({ rowCount: 0 });
+
+      const res = await request(app).delete(`/api/subscriptions/${ANOTHER_UUID}`);
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 for non-UUID :id", async () => {
+      const res = await request(app).delete("/api/subscriptions/not-a-uuid");
+
+      expect(res.status).toBe(400);
+    });
+  });
+});
+
+// ============================================================================
+// Validator unit tests
+// ============================================================================
+
+describe("createSubscriptionBodySchema", () => {
+  const VALID = { url: "https://example.com/hook", events: ["market.created"] };
+
+  it("accepts a valid body", () => {
+    expect(createSubscriptionBodySchema.safeParse(VALID).success).toBe(true);
+  });
+
+  it("deduplicates duplicate event types", () => {
+    const r = createSubscriptionBodySchema.safeParse({
+      ...VALID,
+      events: ["market.created", "market.created", "prediction.settled"],
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.events).toHaveLength(2);
+  });
+
+  it("rejects missing url", () => {
+    const r = createSubscriptionBodySchema.safeParse({ events: VALID.events });
+    expect(r.success).toBe(false);
+    if (!r.success)
+      expect(r.error.issues.some((i) => i.path.includes("url"))).toBe(true);
+  });
+
+  it("rejects missing events", () => {
+    const r = createSubscriptionBodySchema.safeParse({ url: VALID.url });
+    expect(r.success).toBe(false);
+    if (!r.success)
+      expect(r.error.issues.some((i) => i.path.includes("events"))).toBe(true);
+  });
+
+  it("rejects empty events array", () => {
+    expect(
+      createSubscriptionBodySchema.safeParse({ ...VALID, events: [] }).success,
+    ).toBe(false);
+  });
+
+  it("rejects unknown keys (strict)", () => {
+    const r = createSubscriptionBodySchema.safeParse({ ...VALID, extra: "x" });
+    expect(r.success).toBe(false);
+    if (!r.success)
+      expect(
+        r.error.issues.some((i) => i.code === "unrecognized_keys"),
+      ).toBe(true);
+  });
+
+  it("rejects http url for non-localhost", () => {
+    expect(
+      createSubscriptionBodySchema.safeParse({
+        url: "http://example.com/hook",
+        events: VALID.events,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts http://localhost", () => {
+    expect(
+      createSubscriptionBodySchema.safeParse({
+        url: "http://localhost:9000/hook",
+        events: VALID.events,
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects more than 50 distinct event types", () => {
+    const events = Array.from({ length: 51 }, (_, i) => `market.event${i}`);
+    expect(
+      createSubscriptionBodySchema.safeParse({ ...VALID, events }).success,
+    ).toBe(false);
+  });
+
+  it("accepts exactly 50 distinct event types", () => {
+    const events = Array.from({ length: 50 }, (_, i) => `market.event${i}`);
+    expect(
+      createSubscriptionBodySchema.safeParse({ ...VALID, events }).success,
+    ).toBe(true);
+  });
+});
+
+describe("patchSubscriptionBodySchema", () => {
+  it("accepts updating only url", () => {
+    expect(
+      patchSubscriptionBodySchema.safeParse({ url: "https://new.example.com/hook" }).success,
+    ).toBe(true);
+  });
+
+  it("accepts updating only active", () => {
+    expect(patchSubscriptionBodySchema.safeParse({ active: false }).success).toBe(true);
+  });
+
+  it("accepts updating only events", () => {
+    expect(
+      patchSubscriptionBodySchema.safeParse({ events: ["prediction.settled"] }).success,
+    ).toBe(true);
+  });
+
+  it("accepts updating all fields simultaneously", () => {
+    expect(
+      patchSubscriptionBodySchema.safeParse({
+        url: "https://example.com/hook",
+        events: ["market.created"],
+        active: true,
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects empty object (at least one field required)", () => {
+    expect(patchSubscriptionBodySchema.safeParse({}).success).toBe(false);
+  });
+
+  it("rejects unknown keys (strict)", () => {
+    const r = patchSubscriptionBodySchema.safeParse({ active: true, surprise: "field" });
+    expect(r.success).toBe(false);
+    if (!r.success)
+      expect(r.error.issues.some((i) => i.code === "unrecognized_keys")).toBe(true);
+  });
+
+  it("rejects invalid url", () => {
+    expect(patchSubscriptionBodySchema.safeParse({ url: "not-a-url" }).success).toBe(false);
+  });
+
+  it("rejects non-boolean active", () => {
+    expect(patchSubscriptionBodySchema.safeParse({ active: "yes" }).success).toBe(false);
+  });
+});
+
+describe("subscriptionIdParamSchema", () => {
+  it("accepts a valid UUID", () => {
+    expect(subscriptionIdParamSchema.safeParse({ id: VALID_UUID }).success).toBe(true);
+  });
+
+  it("rejects a non-UUID string", () => {
+    const r = subscriptionIdParamSchema.safeParse({ id: "not-a-uuid" });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error.issues[0]?.path).toEqual(["id"]);
+  });
+
+  it("rejects missing id", () => {
+    expect(subscriptionIdParamSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe("eventTypeSchema", () => {
+  it.each([
+    "market.created",
+    "prediction.settled",
+    "market_order.placed",
+    "webhook-delivery.failed",
+  ])("accepts valid event type: %s", (ev) => {
+    expect(eventTypeSchema.safeParse(ev).success).toBe(true);
+  });
+
+  it.each(["no-dot", ".leading-dot", "trailing-dot.", "two..dots", "", "has space.here"])(
+    "rejects invalid event type: %s",
+    (ev) => {
+      expect(eventTypeSchema.safeParse(ev).success).toBe(false);
+    },
+  );
+});
+
+describe("webhookUrlSchema", () => {
+  it("accepts https URLs", () => {
+    expect(webhookUrlSchema.safeParse("https://example.com/webhook").success).toBe(true);
+  });
+
+  it("accepts http://localhost", () => {
+    expect(webhookUrlSchema.safeParse("http://localhost:3000/hook").success).toBe(true);
+  });
+
+  it("rejects http for non-localhost", () => {
+    expect(webhookUrlSchema.safeParse("http://example.com/hook").success).toBe(false);
+  });
+
+  it("rejects ftp protocol", () => {
+    expect(webhookUrlSchema.safeParse("ftp://example.com/hook").success).toBe(false);
+  });
+
+  it("rejects plain strings", () => {
+    expect(webhookUrlSchema.safeParse("not-a-url").success).toBe(false);
+  });
+
+  it("trims surrounding whitespace before validation", () => {
+    expect(webhookUrlSchema.safeParse("  https://example.com/hook  ").success).toBe(true);
+  });
+});


### PR DESCRIPTION
- Add src/validators/subscriptions.ts with:
  - createSubscriptionBodySchema (POST body: url + events)
  - patchSubscriptionBodySchema (PATCH body: url?, events?, active?)
  - subscriptionIdParamSchema (:id UUID param)
  - webhookUrlSchema (HTTPS required, localhost HTTP allowed)
  - eventsArraySchema (min 1, max 50, deduplication, format validation)
  - eventTypeSchema (<resource>.<action> format)

- Expand src/routes/subscriptions.ts with full CRUD:
  - GET    /          list all subscriptions (ETag/304 support, secret stripped)
  - POST   /          create subscription (zod validated, secret exposed once)
  - GET    /:id       fetch single subscription (secret stripped)
  - PATCH  /:id       partial update (zod validated, at least one field)
  - DELETE /:id       delete subscription (404 on miss)

- Fix corrupted src/middleware/errorHandler.ts (duplicate definition merged) so ZodErrors produce 400 with validation_error code

- Add tests/subscriptions.test.ts: 68 tests covering route integration, validation edge-cases, and all exported validator schemas

Closes #641