### PR TITLE
Add zod input validation for /api/devices (#621)

### DIFF
--- a/src/routes/devices.ts
+++ b/src/routes/devices.ts
@@ -5,6 +5,7 @@ import { refreshTokens } from "../db/schema";
 import { requireAuth } from "../middleware/requireAuth";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { logger } from "../config/logger";
+import { listDevicesQuerySchema } from "../validators/devices";
 
 export interface DeviceSummary {
   id: string;
@@ -20,6 +21,11 @@ devicesRouter.get(
   "/",
   async (req: AuthenticatedRequest, res, next) => {
     try {
+      const parsed = listDevicesQuerySchema.safeParse(req.query);
+      if (!parsed.success) {
+        throw parsed.error;
+      }
+
       const userId = req.user!.id;
 
       const rows = await db

--- a/src/routes/devicesRevoke.ts
+++ b/src/routes/devicesRevoke.ts
@@ -1,14 +1,12 @@
 import { Router } from "express";
 import { and, eq, isNull } from "drizzle-orm";
-import { z } from "zod";
 import { db } from "../db";
 import { refreshTokens } from "../db/schema";
 import { requireAuth } from "../middleware/requireAuth";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { logger } from "../config/logger";
 import { RouteErrorFactory } from "../errors";
-
-const paramsSchema = z.object({ id: z.string().uuid({ message: "invalid device id" }) });
+import { deviceIdParamSchema } from "../validators/devices";
 
 export const devicesRevokeRouter = Router({ mergeParams: true });
 
@@ -18,9 +16,9 @@ devicesRevokeRouter.post(
   "/",
   async (req: AuthenticatedRequest, res, next) => {
     try {
-      const parsed = paramsSchema.safeParse(req.params);
+      const parsed = deviceIdParamSchema.safeParse(req.params);
       if (!parsed.success) {
-        throw RouteErrorFactory.validation(parsed.error.issues[0]?.message ?? "invalid device id");
+        throw parsed.error;
       }
 
       const userId = req.user!.id;

--- a/src/validators/devices.ts
+++ b/src/validators/devices.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const listDevicesQuerySchema = z.object({}).strict();
+
+export type ListDevicesQuery = z.infer<typeof listDevicesQuerySchema>;
+
+export const deviceIdParamSchema = z.object({
+  id: z.string().uuid({ message: "invalid device id" }),
+});
+
+export type DeviceIdParam = z.infer<typeof deviceIdParamSchema>;

--- a/tests/devices.test.ts
+++ b/tests/devices.test.ts
@@ -29,11 +29,13 @@ jest.mock("../src/config/logger", () => ({
 }));
 
 import { devicesRouter } from "../src/routes/devices";
+import { errorHandler } from "../src/middleware/errorHandler";
 
 function makeApp(): express.Express {
   const app = express();
   app.use(express.json());
   app.use("/api/me/devices", devicesRouter);
+  app.use(errorHandler);
   return app;
 }
 
@@ -67,5 +69,11 @@ describe("GET /api/me/devices", () => {
     const res = await request(makeApp()).get("/api/me/devices");
     expect(res.status).toBe(200);
     expect(res.body.data.devices).toEqual([]);
+  });
+
+  it("rejects unknown query parameters", async () => {
+    const res = await request(makeApp()).get("/api/me/devices?unknown=1");
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
   });
 });

--- a/tests/devicesRevoke.test.ts
+++ b/tests/devicesRevoke.test.ts
@@ -29,6 +29,7 @@ jest.mock("../src/config/logger", () => ({
 }));
 
 import { devicesRevokeRouter } from "../src/routes/devicesRevoke";
+import { errorHandler } from "../src/middleware/errorHandler";
 
 const FAMILY = "11111111-1111-1111-1111-111111111111";
 
@@ -36,6 +37,7 @@ function makeApp(): express.Express {
   const app = express();
   app.use(express.json());
   app.use("/api/me/devices/:id/revoke", devicesRevokeRouter);
+  app.use(errorHandler);
   return app;
 }
 


### PR DESCRIPTION
## Description

Adds Zod input validation for the `/api/devices` endpoints with structured 400 errors.

### Changes

**`src/validators/devices.ts`** (new)
- `listDevicesQuerySchema` — validates GET query params (empty, rejects unknown via `.strict()`)
- `deviceIdParamSchema` — validates POST `:id` path param as UUID
- Exports inferred TypeScript types via `z.infer<>`

**`src/routes/devices.ts`**
- Imports and validates `req.query` with `listDevicesQuerySchema.safeParse()`; throws ZodError on failure

**`src/routes/devicesRevoke.ts`**
- Replaced inline `paramsSchema` with imported `deviceIdParamSchema` from validators
- Changed validation error to throw `parsed.error` (ZodError) directly instead of `RouteErrorFactory.validation()`, producing consistent 400 with `validation_error` code

**`tests/devices.test.ts`**
- Added test: rejects unknown query parameters (400 + `validation_error`)
- Wired `errorHandler` middleware into test app

**`tests/devicesRevoke.test.ts`**
- Wired `errorHandler` middleware into test app

### Test coverage
All 6 devices tests pass (3 list, 3 revoke), including new validation coverage for unknown query params and malformed UUIDs.

Closes https://github.com/Predictify-org/predictify-backend/issues/621