### PR TITLE
feat: per-endpoint SLO monitor

### DIFF
--- a/src/config/slo.ts
+++ b/src/config/slo.ts
@@ -1,0 +1,26 @@
+// src/config/slo.ts
+import { z } from "zod";
+
+/**
+ * Per‑endpoint SLO configuration.
+ * Keys are route patterns (as produced by the metricsHistogram middleware after sanitization).
+ * Use "*" as a wildcard default for any route not explicitly defined.
+ */
+export const sloConfigSchema = z.object({
+  latencySec: z.number().positive().optional(),
+  errorRate: z.number().min(0).max(1).optional(),
+  windowSec: z.number().positive().optional(),
+});
+
+type ConfigMap = Record<string, z.infer<typeof sloConfigSchema>>;
+
+export const sloConfigMap: ConfigMap = {
+  // Default configuration applying to all routes unless overridden.
+  "*": {
+    latencySec: 1, // seconds
+    errorRate: 0.01, // 1% errors allowed
+    windowSec: 300, // 5-minute rolling window
+  },
+  // Example of a custom endpoint configuration (override as needed).
+  // "/api/feature-flags": { latencySec: 0.5, errorRate: 0.005, windowSec: 60 },
+};

--- a/src/metrics/registry.ts
+++ b/src/metrics/registry.ts
@@ -126,3 +126,25 @@ export const usersEndpointDuration = new Histogram({
   buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10],
   registers: [register],
 });
+
+export const endpointRequestsTotal = new Counter({
+  name: "endpoint_requests_total",
+  help: "Total number of requests per endpoint, segmented by method, route, and status",
+  labelNames: ["method", "route", "status"] as const,
+  registers: [register],
+});
+
+export const endpointRequestDuration = new Histogram({
+  name: "endpoint_request_duration_seconds",
+  help: "Request duration in seconds per endpoint, segmented by method, route, and status",
+  labelNames: ["method", "route", "status"] as const,
+  buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10],
+  registers: [register],
+});
+
+export const sloViolationsTotal = new Counter({
+  name: "slo_violations_total",
+  help: "Total SLO violations, segmented by method, route, and type (latency or error)",
+  labelNames: ["method", "route", "type"] as const,
+  registers: [register],
+});

--- a/src/middleware/metricsHistogram.ts
+++ b/src/middleware/metricsHistogram.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
 import { endpointRequestsTotal, endpointRequestDuration } from "../metrics/registry";
+import { sloMonitor } from "../services/sloMonitor";
 
 function sanitizeRoute(route: string): string {
   return route
@@ -24,6 +25,7 @@ export function metricsHistogramMiddleware(req: Request, res: Response, next: Ne
 
     endpointRequestsTotal.inc({ method, route, status });
     endpointRequestDuration.observe({ method, route, status }, durationSec);
+    sloMonitor.record(req, res, durationSec, route);
   });
 
   next();

--- a/src/services/sloMonitor.ts
+++ b/src/services/sloMonitor.ts
@@ -1,0 +1,87 @@
+import { Counter } from "prom-client";
+import { register, sloViolationsTotal } from "../metrics/registry";
+import { Request, Response } from "express";
+import { sloConfigMap } from "../config/slo";
+
+// Counter for total requests per endpoint (optional, for internal tracking)
+const requestCounter = new Counter({
+  name: "slo_requests_total",
+  help: "Total requests observed by SLO monitor",
+  labelNames: ["method", "route"] as const,
+  registers: [register],
+});
+
+export interface SLOConfig {
+  /** maximum allowed latency in seconds */
+  latencySec?: number;
+  /** maximum allowed error rate (fraction, e.g., 0.01 for 1%) */
+  errorRate?: number;
+  /** window size in seconds for evaluating error rate */
+  windowSec?: number;
+}
+
+interface RequestSample {
+  timestamp: number;
+  isError: boolean;
+}
+
+const requestBuckets: Record<string, RequestSample[]> = {};
+
+export class SLOMonitor {
+  /** Record a request and evaluate SLOs */
+  record(req: Request, res: Response, durationSec: number, route?: string): void {
+    const finalRoute = route ?? (req.baseUrl || "") + (req.route?.path || req.path);
+    const method = req.method;
+    const key = `${method}:${finalRoute}`;
+
+    // Increment request counter
+    requestCounter.inc({ method, route: finalRoute });
+
+    // Load config (fallback to default "*" entry)
+    const cfg: SLOConfig = sloConfigMap[finalRoute] ?? sloConfigMap["*"] ?? {};
+
+    // Latency check
+    if (cfg.latencySec !== undefined && durationSec > cfg.latencySec) {
+      sloViolationsTotal.inc({ method, route: finalRoute, type: "latency" });
+      console.warn(`[SLOMonitor] Latency violation on ${method} ${finalRoute}: ${durationSec}s > ${cfg.latencySec}s`);
+    }
+
+    // Error-rate check (status >= 400 is considered an error)
+    if (cfg.errorRate !== undefined) {
+      const status = res.statusCode;
+      const isError = status >= 400;
+      const now = Date.now();
+
+      const samples = (requestBuckets[key] ??= []);
+      samples.push({ timestamp: now, isError });
+
+      // Keep only samples within the configured window
+      const windowSec = cfg.windowSec ?? 300;
+      const cutoff = now - windowSec * 1000;
+
+      // Filter out old samples
+      const activeSamples = samples.filter((s) => s.timestamp >= cutoff);
+      requestBuckets[key] = activeSamples;
+
+      const totalRequests = activeSamples.length;
+      const errorRequests = activeSamples.filter((s) => s.isError).length;
+      const errorRate = totalRequests > 0 ? errorRequests / totalRequests : 0;
+
+      if (errorRate > cfg.errorRate) {
+        sloViolationsTotal.inc({ method, route: finalRoute, type: "error" });
+        console.warn(
+          `[SLOMonitor] Error-rate violation on ${method} ${finalRoute}: ${(errorRate * 100).toFixed(2)}% (${errorRequests}/${totalRequests}) > ${(cfg.errorRate * 100).toFixed(2)}% in ${windowSec}s`
+        );
+      }
+    }
+  }
+
+  /** Clear all tracked request buckets (mainly for unit tests) */
+  clear(): void {
+    for (const key of Object.keys(requestBuckets)) {
+      delete requestBuckets[key];
+    }
+  }
+}
+
+export const sloMonitor = new SLOMonitor();

--- a/tests/sloMonitor.test.ts
+++ b/tests/sloMonitor.test.ts
@@ -1,0 +1,147 @@
+process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
+process.env.JWT_SECRET = "abcdefghijklmnopqrstuvwxyz123456789012";
+process.env.SOROBAN_RPC_URL = "https://testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "test-contract-id";
+
+import { sloMonitor } from "../src/services/sloMonitor";
+import { sloConfigMap } from "../src/config/slo";
+import { sloViolationsTotal } from "../src/metrics/registry";
+import { Request, Response } from "express";
+
+function mockRequest(method: string, path: string): Partial<Request> {
+  return {
+    method,
+    path,
+    baseUrl: "",
+  };
+}
+
+function mockResponse(statusCode: number): Partial<Response> {
+  return {
+    statusCode,
+  };
+}
+
+async function getViolationCount(labels: { method: string; route: string; type: string }): Promise<number> {
+  const metrics = await sloViolationsTotal.get();
+  const metric = metrics.values.find(
+    (v) =>
+      v.labels.method === labels.method &&
+      v.labels.route === labels.route &&
+      v.labels.type === labels.type
+  );
+  return metric?.value ?? 0;
+}
+
+describe("SLOMonitor unit tests", () => {
+  beforeEach(() => {
+    sloMonitor.clear();
+    sloViolationsTotal.reset();
+  });
+
+  afterAll(() => {
+    // Clean up temporary config overrides
+    delete sloConfigMap["/test/latency"];
+    delete sloConfigMap["/test/error-rate"];
+  });
+
+  describe("Latency SLO checks", () => {
+    it("does not increment latency violation counter when latency is within limits", async () => {
+      sloConfigMap["/test/latency"] = { latencySec: 0.5 };
+      const req = mockRequest("GET", "/test/latency") as Request;
+      const res = mockResponse(200) as Response;
+
+      sloMonitor.record(req, res, 0.4, "/test/latency");
+
+      const count = await getViolationCount({ method: "GET", route: "/test/latency", type: "latency" });
+      expect(count).toBe(0);
+    });
+
+    it("increments latency violation counter when latency exceeds limits", async () => {
+      sloConfigMap["/test/latency"] = { latencySec: 0.5 };
+      const req = mockRequest("GET", "/test/latency") as Request;
+      const res = mockResponse(200) as Response;
+
+      sloMonitor.record(req, res, 0.6, "/test/latency");
+
+      const count = await getViolationCount({ method: "GET", route: "/test/latency", type: "latency" });
+      expect(count).toBe(1);
+    });
+  });
+
+  describe("Error rate SLO checks", () => {
+    it("does not increment error rate violation counter when error rate is within limits", async () => {
+      sloConfigMap["/test/error-rate"] = { errorRate: 0.5, windowSec: 10 };
+      const req = mockRequest("POST", "/test/error-rate") as Request;
+      const resOk = mockResponse(200) as Response;
+      const resErr = mockResponse(500) as Response;
+
+      // 1 OK, 1 Error -> 50% error rate.
+      // Under limit if it's <= 0.5
+      sloMonitor.record(req, resOk, 0.1, "/test/error-rate");
+      sloMonitor.record(req, resErr, 0.1, "/test/error-rate");
+
+      const count = await getViolationCount({ method: "POST", route: "/test/error-rate", type: "error" });
+      expect(count).toBe(0);
+    });
+
+    it("increments error rate violation counter when error rate exceeds limits", async () => {
+      sloConfigMap["/test/error-rate"] = { errorRate: 0.4, windowSec: 10 };
+      const req = mockRequest("POST", "/test/error-rate") as Request;
+      const resOk = mockResponse(200) as Response;
+      const resErr = mockResponse(500) as Response;
+
+      // 2 OK, 2 Errors -> 50% error rate, which is > 40%
+      // 1. OK (0/1 = 0%) - count = 0
+      // 2. OK (0/2 = 0%) - count = 0
+      // 3. Err (1/3 = 33.3%) - count = 0
+      // 4. Err (2/4 = 50.0%) - count = 1
+      sloMonitor.record(req, resOk, 0.1, "/test/error-rate");
+      sloMonitor.record(req, resOk, 0.1, "/test/error-rate");
+      sloMonitor.record(req, resErr, 0.1, "/test/error-rate");
+      sloMonitor.record(req, resErr, 0.1, "/test/error-rate");
+
+      const count = await getViolationCount({ method: "POST", route: "/test/error-rate", type: "error" });
+      expect(count).toBe(1);
+    });
+
+    it("evaluates sliding window: evicts samples outside windowSec", async () => {
+      sloConfigMap["/test/error-rate"] = { errorRate: 0.1, windowSec: 2 }; // 2 second window
+      const req = mockRequest("GET", "/test/error-rate") as Request;
+      const resErr = mockResponse(500) as Response;
+
+      const now = Date.now();
+      const mockDateNow = jest.spyOn(Date, "now");
+
+      // First sample at t=0 (error)
+      mockDateNow.mockReturnValue(now);
+      sloMonitor.record(req, resErr, 0.1, "/test/error-rate");
+
+      // Second sample at t=3000ms (error) -> t=0 sample is evicted since t=3000 is > 2000ms window
+      // Since it's evicted, we have 1 request in active window, which is 1 error -> 100% error rate
+      mockDateNow.mockReturnValue(now + 3000);
+      sloMonitor.record(req, resErr, 0.1, "/test/error-rate");
+
+      mockDateNow.mockRestore();
+
+      // Since both records were errors, it should have triggered a violation on both.
+      const count = await getViolationCount({ method: "GET", route: "/test/error-rate", type: "error" });
+      expect(count).toBe(2);
+    });
+  });
+
+  describe("Wildcard config fallback", () => {
+    it("falls back to * default configuration when route is not explicitly configured", async () => {
+      // * is configured in src/config/slo.ts with latencySec = 1
+      const req = mockRequest("GET", "/some/unconfigured/route") as Request;
+      const res = mockResponse(200) as Response;
+
+      // Over default latencySec of 1s
+      sloMonitor.record(req, res, 1.5, "/some/unconfigured/route");
+
+      const count = await getViolationCount({ method: "GET", route: "/some/unconfigured/route", type: "latency" });
+      expect(count).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
Description
This PR implements per-endpoint SLO monitoring for latency and error rate metrics with alert thresholds, adhering to project styles and guidelines.

Changes
Metrics Registration: restored missing endpointRequestsTotal (Counter) and endpointRequestDuration (Histogram) metrics to resolve downstream merge conflict errors, and added sloViolationsTotal (Counter).
SLO Monitor Service: Created src/services/sloMonitor.ts to manage in-memory sliding window request logs per endpoint. Evaluates requests against configured limits (using src/config/slo.ts) and increments sloViolationsTotal for breaches.
Middleware Integration: Updated src/middleware/metricsHistogram.ts to sanitize and pass completed request metadata to the SLO Monitor.
Unit Tests: Added focused tests in tests/sloMonitor.test.ts to cover latency thresholds, sliding window sample eviction (simulated using mocked timers), and configuration fallback routing.