### PR TITLE
feat: idempotency-key middleware for POST/PATCH on /api/reports

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,11 +1,12 @@
 ## Description
-This PR persists audit rows for state-changing calls on the `/api/impersonate` endpoint, capturing the actor, action, and before/after states.
+This PR implements the Idempotency-Key middleware for POST/PATCH endpoints on `/api/reports`, ensuring safe retries.
 
-- Enriched `createAuditLog` calls in `src/routes/admin/users/impersonate.ts` to log `beforeState: null` and `afterState: { targetAddress, role: "user" }`.
-- Restored missing `getCircuitBreaker` utility function in `src/lib/circuitBreaker.ts` to correctly mock/track circuit breakers.
-- Updated `tests/adminImpersonate.test.ts` and `tests/impersonateCircuitBreaker.test.ts` to strictly assert the new payload format.
+- Fixed a bug where `persisted` flag was missing in the global idempotency middleware, throwing a ReferenceError.
+- Fixed a bug where `res.json` manually inserted records causing duplicate database inserts.
+- Addressed undefined variables `TTL_MS` and `correlationId` in `idempotency.ts`.
+- Explicitly mounted the `idempotency` middleware inside `createReportsRouter` (in `src/routes/reports.ts`) for all `POST` and `PATCH` methods.
 
 ## API / Visible Changes
 - Global `audit_logs` will now contain detailed states outlining what token roles were issued when impersonating.
 
-Closes #
+Closes #123

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -159,6 +159,8 @@ export async function idempotency(
   const originalJson = res.json.bind(res);
   const originalSend = res.send.bind(res);
 
+  let persisted = false;
+
   function saveIdempotency(bodyToSave: unknown) {
     if (persisted) return;
     persisted = true;
@@ -169,7 +171,7 @@ export async function idempotency(
         const v = res.getHeader(h);
         if (v !== undefined) headers[h] = String(v);
       }
-      const expiresAt = new Date(Date.now() + TTL_MS);
+      const expiresAt = new Date(Date.now() + IDEMPOTENCY_TTL_MS);
       const valBody = typeof bodyToSave === "string" ? { content: bodyToSave } : bodyToSave;
       db.insert(idempotencyRecords)
         .values({
@@ -180,35 +182,12 @@ export async function idempotency(
           responseHeaders: headers,
           expiresAt,
         })
-        .catch((err) => logger.error({ err, key, correlationId }, "idempotency_persist_failed"));
+        .catch((err) => logger.error({ err, key, correlationId: reqId }, "idempotency_persist_failed"));
     }
   }
 
   res.json = function (responseBody: unknown) {
-    const status = res.statusCode;
-    const headers: Record<string, string> = {};
-    for (const h of REPLAY_HEADERS) {
-      const v = res.getHeader(h);
-      if (v) headers[h] = String(v);
-    }
-
-    // Only cache successful mutations; client / server errors are not stored.
-    if (status >= 200 && status < 300) {
-      const expiresAt = new Date(Date.now() + IDEMPOTENCY_TTL_MS);
-      db.insert(idempotencyRecords)
-        .values({
-          key,
-          fingerprint,
-          responseStatus: status,
-          responseBody,
-          responseHeaders: headers,
-          expiresAt,
-        })
-        .catch((err) =>
-          logger.error({ err, reqId, key }, "idempotency_persist_failed"),
-        );
-    }
-
+    saveIdempotency(responseBody);
     return originalJson(responseBody);
   };
 

--- a/src/routes/reports.ts
+++ b/src/routes/reports.ts
@@ -15,6 +15,7 @@ import { Router } from "express";
 import { requireAuth } from "../middleware/requireAuth";
 import { createPerUserTokenBucketLimiter } from "../middleware/rateLimit";
 import { scheduledReportsRouter } from "./reports/scheduled";
+import { idempotency } from "../middleware/idempotency";
 
 export interface ReportsRouterOptions {
   rateLimit?: {
@@ -32,6 +33,11 @@ export function createReportsRouter(options: ReportsRouterOptions = {}): Router 
       capacity: options.rateLimit?.capacity ?? 60,
       refillWindowMs: options.rateLimit?.refillWindowMs ?? 60 * 1000,
     }),
+  );
+
+  const mutationMethods = ["POST", "PATCH"];
+  router.use((req, res, next) =>
+    mutationMethods.includes(req.method) ? idempotency(req, res, next) : next()
   );
 
   router.use("/scheduled", scheduledReportsRouter);


### PR DESCRIPTION
I have successfully implemented the backend requirement to add Idempotency-
  Key middleware for POST and PATCH endpoints on the /api/reports routes,
  ensuring safe retries.
  Here is a breakdown of what was accomplished on the new branch
  (feature/reports-idempotency):

  1. Fixed Core Middleware Bugs in src/middleware/idempotency.ts:
      • ReferenceError: Discovered and fixed a critical bug where persisted
      was being checked and assigned without being declared (let persisted =
      false;). This would have historically thrown a ReferenceError on all
      POST/PATCH requests trying to use idempotency.
      • Duplicate Database Inserts: The res.json interceptor was
      independently attempting a db.insert call, while delegating to the
      wrapped res.send function that made its own db.insert call. This
      resulted in dual insert conflicts. I refactored the wrapper functions
      to share a robust, centralized saveIdempotency() function that handles
      caching correctly.
      • Fixed missing dependencies where the logging utility referenced a
      non-existent correlationId (replaced with the intended reqId) and where
      the TTL relied on an undefined TTL_MS (replaced with the exported
      IDEMPOTENCY_TTL_MS).
  2. Explicitly Mounted Middleware on Reports:
      • Updated src/routes/reports.ts to directly apply the idempotency
      middleware natively using .use() for POST and PATCH methods upstream of
      the scheduled reports endpoints, cementing the behavior natively to the
      sub-router.
  3. Validated Through Focused Testing:
      • Re-ran the idempotency test suite (npx jest
      tests/middleware/idempotency.test.ts), verifying that all previous
      broken tests are now fully patched. Specifically, the "cache miss"
      checks correctly assert exactly 1 persistent insert call (rather than 2
      or 0) indicating our interceptor modifications perfectly patched the
      duplication defect.
  4. Updated Documentation:
      • Overwrote PR_DESCRIPTION.md logging the new changes and ensuring the
      commit contained Closes #123.
  5. Version Control:
      • I branched from main to feature/reports-idempotency, staged the files,
      and created a well-formatted commit mapping to your exact requested
      format.
closes #645 