### PR TITLE
feat: metrics on /api/auth

### DIFF
--- a/src/metrics/authMetrics.ts
+++ b/src/metrics/authMetrics.ts
@@ -1,0 +1,79 @@
+/**
+ * authMetrics.ts
+ *
+ * Express middleware that records per-request Prometheus metrics for the
+ * /api/auth router.
+ *
+ * On every response finish event it:
+ *   - Increments `auth_endpoint_requests_total{method, route, status}`
+ *   - Observes into `auth_endpoint_duration_seconds{method, route, status}`
+ *
+ * The `route` label is derived from the matched Express route template
+ * (e.g. `/challenge`, `/verify`, `/refresh`, `/logout`, `/wallet/logout`)
+ * so label cardinality stays bounded even when future sub-paths are added.
+ * Dynamic segments (UUIDs, numeric IDs) are normalised to `/:id` to
+ * prevent unbounded cardinality.
+ *
+ * Registration: imported and applied via `authRouter.use(authMetricsMiddleware)`
+ * near the top of src/routes/auth.ts, after the drain guard and before the
+ * individual route handlers, so that all requests — including rejected ones
+ * (rate-limited, timed out, validation errors) — are captured.
+ */
+
+import type { Request, Response, NextFunction } from "express";
+import { authEndpointRequestsTotal, authEndpointDuration } from "./registry";
+
+/**
+ * Normalise a raw Express route template or path to a stable label value.
+ *
+ * Replaces:
+ *   - UUID-shaped segments  →  /:id
+ *   - Pure-numeric segments →  /:id
+ *
+ * Keeping named templates (e.g. `/challenge`, `/wallet/logout`) intact
+ * ensures Prometheus cardinality remains bounded while still being useful.
+ */
+function sanitizeRoute(route: string): string {
+  return route
+    .replace(/\/[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}/gi, "/:id")
+    .replace(/\/\d+/g, "/:id");
+}
+
+/**
+ * Prometheus metrics middleware for /api/auth.
+ *
+ * Attaches a `finish` listener to the response so timing and status are
+ * recorded after the full response has been sent (including streaming bodies).
+ * Using `process.hrtime.bigint()` for sub-millisecond precision.
+ *
+ * @example
+ * // src/routes/auth.ts
+ * import { authMetricsMiddleware } from "../metrics/authMetrics";
+ * authRouter.use(authMetricsMiddleware);
+ */
+export function authMetricsMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const start = process.hrtime.bigint();
+
+  res.on("finish", () => {
+    const durationNs = Number(process.hrtime.bigint() - start);
+    const durationSec = durationNs / 1e9;
+
+    // Prefer the matched Express route template (e.g. "/challenge") over the
+    // raw req.path so label values are stable across requests with identical
+    // handlers. Fall back to req.path when route matching has not occurred
+    // (e.g. for requests that were short-circuited by early-exit middleware).
+    const routeTemplate: string = req.route?.path ?? req.path;
+    const route = sanitizeRoute(routeTemplate);
+    const method = req.method;
+    const status = String(res.statusCode);
+
+    authEndpointRequestsTotal.inc({ method, route, status });
+    authEndpointDuration.observe({ method, route, status }, durationSec);
+  });
+
+  next();
+}

--- a/src/metrics/registry.ts
+++ b/src/metrics/registry.ts
@@ -156,3 +156,38 @@ export const sloViolationsTotal = new Counter({
   labelNames: ["method", "route", "type"] as const,
   registers: [register],
 });
+
+/**
+ * Per-endpoint request counter for /api/auth routes.
+ *
+ * Labels:
+ *   method — HTTP verb (POST, GET, …)
+ *   route  — Express route template (e.g. /challenge, /verify, /refresh,
+ *             /logout, /wallet/logout); dynamic path segments such as UUIDs
+ *             and numeric IDs are normalised to /:id by the middleware.
+ *   status — HTTP response status code as a string (e.g. "200", "422", "429")
+ */
+export const authEndpointRequestsTotal = new Counter({
+  name: "auth_endpoint_requests_total",
+  help: "Total number of requests to /api/auth endpoints, segmented by method, route, and status",
+  labelNames: ["method", "route", "status"] as const,
+  registers: [register],
+});
+
+/**
+ * Per-endpoint request latency histogram for /api/auth routes.
+ *
+ * Labels match authEndpointRequestsTotal so counter and histogram can be
+ * joined in PromQL / Grafana dashboards without additional relabelling.
+ *
+ * Buckets (seconds) are tuned for auth flows: most successful challenge +
+ * verify pairs complete in < 100 ms; the 10 s upper bound catches edge-case
+ * timeouts before the 15 s route-level deadline fires.
+ */
+export const authEndpointDuration = new Histogram({
+  name: "auth_endpoint_duration_seconds",
+  help: "Request duration in seconds for /api/auth endpoints, segmented by method, route, and status",
+  labelNames: ["method", "route", "status"] as const,
+  buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+  registers: [register],
+});

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -21,6 +21,7 @@ import {
   authLogoutBodySchema,
   authWalletLogoutBodySchema,
 } from "../validators/auth";
+import { authMetricsMiddleware } from "../metrics/authMetrics";
 
 let activeAuthRequests = 0;
 let isAuthDraining = false;
@@ -97,6 +98,12 @@ authRouter.use((req, res, next) => {
 
 authRouter.use(accessLog);
 authRouter.use(requestTimeout(15000));
+
+// ── Per-endpoint Prometheus metrics ──────────────────────────────────────────
+// Registered after the drain guard so that all requests — including those
+// rejected early (rate limited, timed out, validation errors) — are counted.
+// Placed before the health sub-router so health probes are also tracked.
+authRouter.use(authMetricsMiddleware);
 
 // ── Health probe (no auth required) ───────────────────────────────────────
 authRouter.use("/health", authHealthRouter);

--- a/tests/authMetrics.test.ts
+++ b/tests/authMetrics.test.ts
@@ -1,0 +1,713 @@
+/**
+ * tests/authMetrics.test.ts
+ *
+ * Focused tests for the per-endpoint Prometheus metrics on /api/auth.
+ *
+ * Verifies that `authEndpointRequestsTotal` (Counter) and
+ * `authEndpointDuration` (Histogram) are incremented/observed for each
+ * route handler in src/routes/auth.ts:
+ *
+ *   POST /challenge
+ *   POST /verify
+ *   POST /refresh
+ *   POST /logout
+ *   POST /wallet/logout
+ *
+ * Strategy: mount `authRouter` directly on a small Express app (same pattern
+ * as usersMetrics.test.ts) with all service and middleware dependencies mocked
+ * so the tests exercise only the route + metrics wiring. No real DB, Redis, or
+ * Stellar RPC required.
+ *
+ * Coverage matrix
+ * ───────────────────────────────────────────────────────────────────────────
+ *   ✓  counter increments by 1 on success (200 / 201 / 204) for every route
+ *   ✓  counter increments for client errors (422 validation failure)
+ *   ✓  histogram receives an observation for every request
+ *   ✓  histogram labels include method, route, and status
+ *   ✓  counter labels include method, route, and status
+ *   ✓  metric names are present in Prometheus exposition output
+ *   ✓  counter increments across repeated requests
+ */
+
+// ---------------------------------------------------------------------------
+// 1. Env vars — must be set before any project imports
+// ---------------------------------------------------------------------------
+process.env.NODE_ENV = "test";
+process.env.PORT = "3001";
+process.env.LOG_LEVEL = "fatal";
+process.env.DATABASE_URL = "postgres://localhost/test";
+process.env.JWT_SECRET = "auth-metrics-test-secret-at-least-32-bytes!!";
+process.env.JWT_ISSUER = "predictify";
+process.env.JWT_AUDIENCE = "predictify-app";
+process.env.JWT_TTL_SECONDS = "3600";
+process.env.STELLAR_NETWORK = "testnet";
+process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.PREDICTIFY_CONTRACT_ID = "CABCDEF";
+
+// ---------------------------------------------------------------------------
+// 2. Mock pg so the module graph cannot open a real socket
+// ---------------------------------------------------------------------------
+jest.mock("pg", () => {
+  const Pool = jest.fn().mockImplementation(() => ({
+    connect: jest.fn(),
+    query: jest.fn(),
+    end: jest.fn(),
+    on: jest.fn(),
+  }));
+  return { Pool };
+});
+
+// ---------------------------------------------------------------------------
+// 3. Mock drizzle-orm so requireAuth DB lookups are controllable
+// ---------------------------------------------------------------------------
+const drizzleLimit = jest.fn();
+const drizzleWhere = jest.fn(() => ({ limit: drizzleLimit }));
+const drizzleFrom = jest.fn(() => ({ where: drizzleWhere }));
+const drizzleSelect = jest.fn(() => ({ from: drizzleFrom }));
+
+jest.mock("drizzle-orm/node-postgres", () => ({
+  drizzle: jest.fn(() => ({ select: drizzleSelect })),
+}));
+
+jest.mock("../src/db/client", () => ({
+  db: { select: jest.fn() },
+  pool: { on: jest.fn(), end: jest.fn(), query: jest.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// 4. Mock auth services
+// ---------------------------------------------------------------------------
+jest.mock("../src/services/authChallengeService", () => ({
+  __esModule: true,
+  createChallenge: jest.fn(),
+}));
+
+jest.mock("../src/services/authVerifyService", () => ({
+  __esModule: true,
+  verifyChallengeAndIssueJwt: jest.fn(),
+}));
+
+jest.mock("../src/services/refreshTokenService", () => ({
+  __esModule: true,
+  rotateRefreshToken: jest.fn(),
+  revokeFamily: jest.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// 5. No-op middleware shims (accessLog, timeout, loginRateLimit, rateLimiter)
+// ---------------------------------------------------------------------------
+jest.mock("../src/middleware/accessLog", () => ({
+  accessLog: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock("../src/middleware/timeout", () => ({
+  requestTimeout: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock("../src/middleware/loginRateLimit", () => ({
+  loginRateLimit: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock("../src/middleware/rateLimit", () => ({
+  createPerUserRateLimiter:
+    () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+// Silence logger output during tests
+jest.mock("../src/config/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// 6. Project imports (env + mocks are in place)
+// ---------------------------------------------------------------------------
+import express from "express";
+import request from "supertest";
+import { authRouter } from "../src/routes/auth";
+import { errorHandler } from "../src/middleware/errorHandler";
+import { createChallenge } from "../src/services/authChallengeService";
+import { verifyChallengeAndIssueJwt } from "../src/services/authVerifyService";
+import {
+  rotateRefreshToken,
+  revokeFamily,
+} from "../src/services/refreshTokenService";
+import {
+  authEndpointRequestsTotal,
+  authEndpointDuration,
+  register,
+} from "../src/metrics/registry";
+
+// Typed mock helpers
+const mockCreateChallenge = createChallenge as jest.MockedFunction<typeof createChallenge>;
+const mockVerify = verifyChallengeAndIssueJwt as jest.MockedFunction<typeof verifyChallengeAndIssueJwt>;
+const mockRotate = rotateRefreshToken as jest.MockedFunction<typeof rotateRefreshToken>;
+const mockRevoke = revokeFamily as jest.MockedFunction<typeof revokeFamily>;
+
+// ---------------------------------------------------------------------------
+// App factory
+// ---------------------------------------------------------------------------
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/auth", authRouter);
+  // Expose /api/metrics for exposition-format assertions
+  app.get("/api/metrics", async (_req, res) => {
+    res.set("Content-Type", register.contentType);
+    res.send(await register.metrics());
+  });
+  app.use(errorHandler);
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the current value for a given label set from the counter's hashMap.
+ * The prom-client internal key format is sorted "key:value," pairs.
+ */
+function counterValue(
+  counter: typeof authEndpointRequestsTotal,
+  labels: Record<string, string>,
+): number {
+  const key =
+    Object.keys(labels)
+      .sort()
+      .map((k) => `${k}:${labels[k]}`)
+      .join(",") + ",";
+  const entry = (counter as unknown as { hashMap: Record<string, { value: number }> }).hashMap[key];
+  return entry?.value ?? 0;
+}
+
+// Shared test fixtures
+const VALID_STELLAR = "GABSCDZCXMOO6CYNTHBGHAOE3RX72FRMNWK6O4FOXW6OBQATNWKBUUW6";
+const VALID_NONCE   = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+const VALID_SIG     = "dGVzdA=="; // base64("test") — accepted by the mock
+const VALID_TOKEN   = "opaque-refresh-token";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Per-endpoint Prometheus metrics on /api/auth", () => {
+  let app: express.Express;
+
+  beforeAll(() => {
+    app = makeApp();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── Metric registration ─────────────────────────────────────────────────
+
+  describe("metric registration", () => {
+    it("exposes auth_endpoint_requests_total in Prometheus output", async () => {
+      const res = await request(app).get("/api/metrics");
+      expect(res.text).toContain("auth_endpoint_requests_total");
+    });
+
+    it("exposes auth_endpoint_duration_seconds in Prometheus output", async () => {
+      const res = await request(app).get("/api/metrics");
+      expect(res.text).toContain("auth_endpoint_duration_seconds");
+    });
+
+    it("declares explicit histogram buckets", async () => {
+      // Make a request so the histogram emits bucket lines in the exposition output.
+      mockCreateChallenge.mockResolvedValueOnce({
+        nonce: VALID_NONCE,
+        expiresAt: new Date(Date.now() + 300_000),
+      });
+      await request(app)
+        .post("/api/auth/challenge")
+        .send({ stellarAddress: VALID_STELLAR });
+
+      const res = await request(app).get("/api/metrics");
+      // At minimum the 0.01 and 10 boundary buckets must be present
+      expect(res.text).toMatch(/auth_endpoint_duration_seconds_bucket\{.*le="0\.01"/);
+      expect(res.text).toMatch(/auth_endpoint_duration_seconds_bucket\{.*le="10"/);
+    });
+  });
+
+  // ── POST /challenge ─────────────────────────────────────────────────────
+
+  describe("POST /api/auth/challenge", () => {
+    it("increments counter with method=POST, route=/challenge, status=201", async () => {
+      mockCreateChallenge.mockResolvedValueOnce({
+        nonce: VALID_NONCE,
+        expiresAt: new Date(Date.now() + 300_000),
+      });
+
+      const before = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/challenge",
+        status: "201",
+      });
+
+      await request(app)
+        .post("/api/auth/challenge")
+        .send({ stellarAddress: VALID_STELLAR });
+
+      const after = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/challenge",
+        status: "201",
+      });
+      expect(after).toBe(before + 1);
+    });
+
+    it("increments counter with status=422 on validation failure", async () => {
+      const before = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/challenge",
+        status: "422",
+      });
+
+      await request(app)
+        .post("/api/auth/challenge")
+        .send({ stellarAddress: "not-a-valid-stellar-address" });
+
+      const after = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/challenge",
+        status: "422",
+      });
+      expect(after).toBe(before + 1);
+    });
+
+    it("observes duration in histogram for /challenge", async () => {
+      mockCreateChallenge.mockResolvedValueOnce({
+        nonce: VALID_NONCE,
+        expiresAt: new Date(Date.now() + 300_000),
+      });
+
+      await request(app)
+        .post("/api/auth/challenge")
+        .send({ stellarAddress: VALID_STELLAR });
+
+      const metrics = await authEndpointDuration.get();
+      const sample = metrics.values.find(
+        (v) => v.labels.route === "/challenge" && v.labels.method === "POST",
+      );
+      expect(sample).toBeDefined();
+    });
+
+    it("increments counter across repeated requests", async () => {
+      mockCreateChallenge.mockResolvedValue({
+        nonce: VALID_NONCE,
+        expiresAt: new Date(Date.now() + 300_000),
+      });
+
+      const before = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/challenge",
+        status: "201",
+      });
+
+      await request(app).post("/api/auth/challenge").send({ stellarAddress: VALID_STELLAR });
+      await request(app).post("/api/auth/challenge").send({ stellarAddress: VALID_STELLAR });
+
+      const after = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/challenge",
+        status: "201",
+      });
+      expect(after).toBe(before + 2);
+    });
+  });
+
+  // ── POST /verify ────────────────────────────────────────────────────────
+
+  describe("POST /api/auth/verify", () => {
+    it("increments counter with status=200 on successful verify", async () => {
+      mockVerify.mockResolvedValueOnce({
+        ok: true,
+        value: {
+          accessToken: "tok",
+          expiresIn: 3600,
+          refreshToken: "refresh-tok",
+        },
+      });
+
+      const before = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/verify",
+        status: "200",
+      });
+
+      await request(app)
+        .post("/api/auth/verify")
+        .send({
+          stellarAddress: VALID_STELLAR,
+          nonce: VALID_NONCE,
+          signature: VALID_SIG,
+        });
+
+      const after = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/verify",
+        status: "200",
+      });
+      expect(after).toBe(before + 1);
+    });
+
+    it("increments counter with status=422 on validation failure", async () => {
+      const before = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/verify",
+        status: "422",
+      });
+
+      // Missing required fields
+      await request(app).post("/api/auth/verify").send({});
+
+      const after = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/verify",
+        status: "422",
+      });
+      expect(after).toBe(before + 1);
+    });
+
+    it("observes duration in histogram for /verify", async () => {
+      mockVerify.mockResolvedValueOnce({
+        ok: true,
+        value: {
+          accessToken: "tok",
+          expiresIn: 3600,
+          refreshToken: "refresh-tok",
+        },
+      });
+
+      await request(app)
+        .post("/api/auth/verify")
+        .send({
+          stellarAddress: VALID_STELLAR,
+          nonce: VALID_NONCE,
+          signature: VALID_SIG,
+        });
+
+      const metrics = await authEndpointDuration.get();
+      const sample = metrics.values.find(
+        (v) => v.labels.route === "/verify" && v.labels.method === "POST",
+      );
+      expect(sample).toBeDefined();
+    });
+
+    it("increments counter with error status when service returns !ok", async () => {
+      // Return a RouteError (plain object with `kind`) so the errorHandler
+      // maps it to 401. The auth route does `throw result.error` which the
+      // errorHandler catches via isRouteError().
+      mockVerify.mockResolvedValueOnce({
+        ok: false,
+        error: { kind: "Unauthorized", message: "Signature did not match" } as never,
+      });
+
+      const before = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/verify",
+        status: "401",
+      });
+
+      await request(app)
+        .post("/api/auth/verify")
+        .send({
+          stellarAddress: VALID_STELLAR,
+          nonce: VALID_NONCE,
+          signature: VALID_SIG,
+        });
+
+      const after = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/verify",
+        status: "401",
+      });
+      expect(after).toBe(before + 1);
+    });
+  });
+
+  // ── POST /refresh ───────────────────────────────────────────────────────
+
+  describe("POST /api/auth/refresh", () => {
+    it("increments counter with status=200 on successful token rotation", async () => {
+      mockRotate.mockResolvedValueOnce({
+        ok: true,
+        value: {
+          accessToken: "new-access",
+          expiresIn: 3600,
+          refreshToken: "new-refresh",
+        },
+      });
+
+      const before = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/refresh",
+        status: "200",
+      });
+
+      await request(app)
+        .post("/api/auth/refresh")
+        .send({ refreshToken: VALID_TOKEN });
+
+      const after = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/refresh",
+        status: "200",
+      });
+      expect(after).toBe(before + 1);
+    });
+
+    it("increments counter with status=422 when refreshToken is missing", async () => {
+      const before = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/refresh",
+        status: "422",
+      });
+
+      await request(app).post("/api/auth/refresh").send({});
+
+      const after = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/refresh",
+        status: "422",
+      });
+      expect(after).toBe(before + 1);
+    });
+
+    it("observes duration in histogram for /refresh", async () => {
+      mockRotate.mockResolvedValueOnce({
+        ok: true,
+        value: {
+          accessToken: "new-access",
+          expiresIn: 3600,
+          refreshToken: "new-refresh",
+        },
+      });
+
+      await request(app)
+        .post("/api/auth/refresh")
+        .send({ refreshToken: VALID_TOKEN });
+
+      const metrics = await authEndpointDuration.get();
+      const sample = metrics.values.find(
+        (v) => v.labels.route === "/refresh" && v.labels.method === "POST",
+      );
+      expect(sample).toBeDefined();
+    });
+  });
+
+  // ── POST /logout ────────────────────────────────────────────────────────
+
+  describe("POST /api/auth/logout", () => {
+    it("increments counter with status=204 on successful logout", async () => {
+      mockRevoke.mockResolvedValueOnce(undefined);
+
+      const before = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/logout",
+        status: "204",
+      });
+
+      await request(app)
+        .post("/api/auth/logout")
+        .send({ refreshToken: VALID_TOKEN });
+
+      const after = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/logout",
+        status: "204",
+      });
+      expect(after).toBe(before + 1);
+    });
+
+    it("increments counter with status=422 when refreshToken is missing", async () => {
+      const before = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/logout",
+        status: "422",
+      });
+
+      await request(app).post("/api/auth/logout").send({});
+
+      const after = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/logout",
+        status: "422",
+      });
+      expect(after).toBe(before + 1);
+    });
+
+    it("observes duration in histogram for /logout", async () => {
+      mockRevoke.mockResolvedValueOnce(undefined);
+
+      await request(app)
+        .post("/api/auth/logout")
+        .send({ refreshToken: VALID_TOKEN });
+
+      const metrics = await authEndpointDuration.get();
+      const sample = metrics.values.find(
+        (v) => v.labels.route === "/logout" && v.labels.method === "POST",
+      );
+      expect(sample).toBeDefined();
+    });
+  });
+
+  // ── POST /wallet/logout ─────────────────────────────────────────────────
+
+  describe("POST /api/auth/wallet/logout", () => {
+    it("increments counter with status=204 on successful wallet logout", async () => {
+      mockRevoke.mockResolvedValueOnce(undefined);
+
+      const before = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/wallet/logout",
+        status: "204",
+      });
+
+      await request(app)
+        .post("/api/auth/wallet/logout")
+        .send({ refreshToken: VALID_TOKEN });
+
+      const after = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/wallet/logout",
+        status: "204",
+      });
+      expect(after).toBe(before + 1);
+    });
+
+    it("increments counter with status=422 when refreshToken is missing", async () => {
+      const before = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/wallet/logout",
+        status: "422",
+      });
+
+      await request(app).post("/api/auth/wallet/logout").send({});
+
+      const after = counterValue(authEndpointRequestsTotal, {
+        method: "POST",
+        route: "/wallet/logout",
+        status: "422",
+      });
+      expect(after).toBe(before + 1);
+    });
+
+    it("observes duration in histogram for /wallet/logout", async () => {
+      mockRevoke.mockResolvedValueOnce(undefined);
+
+      await request(app)
+        .post("/api/auth/wallet/logout")
+        .send({ refreshToken: VALID_TOKEN });
+
+      const metrics = await authEndpointDuration.get();
+      const sample = metrics.values.find(
+        (v) =>
+          v.labels.route === "/wallet/logout" && v.labels.method === "POST",
+      );
+      expect(sample).toBeDefined();
+    });
+  });
+
+  // ── Label structure ──────────────────────────────────────────────────────
+
+  describe("histogram label structure", () => {
+    it("includes method, route, and status labels on /challenge observations", async () => {
+      mockCreateChallenge.mockResolvedValueOnce({
+        nonce: VALID_NONCE,
+        expiresAt: new Date(Date.now() + 300_000),
+      });
+
+      await request(app)
+        .post("/api/auth/challenge")
+        .send({ stellarAddress: VALID_STELLAR });
+
+      const metrics = await authEndpointDuration.get();
+      const sample = metrics.values.find(
+        (v) => v.labels.route === "/challenge",
+      );
+      expect(sample).toBeDefined();
+      expect(sample!.labels).toMatchObject({
+        method: "POST",
+        route: "/challenge",
+        status: "201",
+      });
+    });
+  });
+
+  describe("counter label structure", () => {
+    it("includes method, route, and status labels on /challenge observations", async () => {
+      mockCreateChallenge.mockResolvedValueOnce({
+        nonce: VALID_NONCE,
+        expiresAt: new Date(Date.now() + 300_000),
+      });
+
+      await request(app)
+        .post("/api/auth/challenge")
+        .send({ stellarAddress: VALID_STELLAR });
+
+      const metrics = await authEndpointRequestsTotal.get();
+      const sample = metrics.values.find(
+        (v) => v.labels.route === "/challenge",
+      );
+      expect(sample).toBeDefined();
+      expect(sample!.labels).toHaveProperty("method", "POST");
+      expect(sample!.labels).toHaveProperty("status", "201");
+      expect(sample!.value).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // ── Exposition format ────────────────────────────────────────────────────
+
+  describe("Prometheus exposition format", () => {
+    it("records /challenge requests in text exposition output", async () => {
+      mockCreateChallenge.mockResolvedValueOnce({
+        nonce: VALID_NONCE,
+        expiresAt: new Date(Date.now() + 300_000),
+      });
+
+      await request(app)
+        .post("/api/auth/challenge")
+        .send({ stellarAddress: VALID_STELLAR });
+
+      const res = await request(app).get("/api/metrics");
+      expect(res.text).toContain(
+        'auth_endpoint_requests_total{method="POST",route="/challenge",status="201"}',
+      );
+    });
+
+    it("records /logout requests in text exposition output", async () => {
+      mockRevoke.mockResolvedValueOnce(undefined);
+
+      await request(app)
+        .post("/api/auth/logout")
+        .send({ refreshToken: VALID_TOKEN });
+
+      const res = await request(app).get("/api/metrics");
+      expect(res.text).toContain(
+        'auth_endpoint_requests_total{method="POST",route="/logout",status="204"}',
+      );
+    });
+
+    it("records /wallet/logout requests in text exposition output", async () => {
+      mockRevoke.mockResolvedValueOnce(undefined);
+
+      await request(app)
+        .post("/api/auth/wallet/logout")
+        .send({ refreshToken: VALID_TOKEN });
+
+      const res = await request(app).get("/api/metrics");
+      expect(res.text).toContain(
+        'auth_endpoint_requests_total{method="POST",route="/wallet/logout",status="204"}',
+      );
+    });
+  });
+});


### PR DESCRIPTION
Add per-endpoint Prometheus counter and histogram to /api/auth routes.

Changes:
- src/metrics/registry.ts: export authEndpointRequestsTotal (Counter) and authEndpointDuration (Histogram) with {method, route, status} labels and auth-flow-tuned buckets [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]s.

- src/metrics/authMetrics.ts: new middleware that attaches a res.finish listener to record duration and increment the counter for every request to the auth router.  Route templates are sanitised (UUID/numeric segments → /:id) to bound cardinality.

- src/routes/auth.ts: register authMetricsMiddleware via authRouter.use(authMetricsMiddleware) after the drain guard, accessLog, and requestTimeout — ensuring all requests (including rejected ones) are counted.

- tests/authMetrics.test.ts: 25 focused unit tests covering all five auth routes (POST /challenge, /verify, /refresh, /logout, /wallet/logout). Validates counter increments, histogram observations, label structure, and Prometheus exposition format.  All services and middleware are mocked so tests are hermetic and require no real DB/Redis/Stellar RPC.

closes #424