### PR TITLE
fix: reconcile circuit breaker API and mount impersonate router

### DIFF
--- a/docs/impersonate-circuit-breaker.md
+++ b/docs/impersonate-circuit-breaker.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-`POST /api/admin/users/:address/impersonate` wraps all downstream work — JWT
-signing and audit log writes — in a **circuit breaker**. When the downstream
-is repeatedly failing the breaker trips to the OPEN state and the endpoint
+`POST /api/admin/users/:address/impersonate` wraps all downstream work — audit
+log writes and JWT signing — in a **circuit breaker**. When the downstream is
+repeatedly failing the breaker trips to the OPEN state and the endpoint
 immediately returns **HTTP 503** instead of waiting for a slow or failing call
 to time out.
 
@@ -19,38 +19,38 @@ recovers, giving a fast, predictable failure signal.
 ## State machine
 
 ```
-           ┌─────────────────────────────────────────┐
-           │                                         │
-           ▼   failureThreshold consecutive fails    │
-        CLOSED ───────────────────────────────► OPEN
-           ▲                                    │
-           │                           halfOpenAfterMs elapses
-           │                                    │
-           │                                    ▼
-           │   successThreshold successes   HALF_OPEN
-           └────────────────────────────────────┘
-                                           │
-                              probe fails  │
-                                    ┌──────┘
-                                    ▼
-                                  OPEN
+                    failureThreshold failures within windowMs
+        ┌────────┐ ───────────────────────────────────────────► ┌──────┐
+        │ CLOSED │                                              │ OPEN │
+        └────────┘ ◄─────────────────────────────────────────── └──────┘
+             ▲            successThreshold probe successes          │
+             │                                                      │
+             │                                       halfOpenAfterMs elapses
+             │                                                      │
+             │                  ┌───────────┐                       │
+             └───────────────── │ HALF_OPEN │ ◄─────────────────────┘
+                                └───────────┘
+                                      │ ▲
+                             probe    │ │
+                             fails    └─┘ back to OPEN
 ```
 
 | State | Behaviour |
 |---|---|
-| **CLOSED** | Normal operation. Failures are counted. |
+| **CLOSED** | Normal operation. Failures are counted in a rolling `windowMs` window; any success clears the count. |
 | **OPEN** | Fast-fail: every call throws `CircuitOpenError` immediately. No downstream calls are made. |
-| **HALF_OPEN** | One probe call is allowed through. Success → CLOSED. Failure → OPEN. |
+| **HALF_OPEN** | One probe at a time is allowed through; concurrent callers are fast-failed. `successThreshold` successes → CLOSED. Any failure → OPEN. |
 
 ## Default configuration
 
 | Option | Default | Description |
 |---|---|---|
-| `failureThreshold` | `5` | Consecutive failures that trip CLOSED → OPEN |
-| `successThreshold` | `1` | Consecutive probe successes needed to reset OPEN → CLOSED |
+| `failureThreshold` | `5` | Failures within `windowMs` that trip CLOSED → OPEN |
+| `successThreshold` | `1` | Probe successes needed to reset HALF_OPEN → CLOSED |
 | `halfOpenAfterMs` | `30 000` | Milliseconds in OPEN before a probe is allowed (HALF_OPEN) |
+| `windowMs` | `60 000` | Rolling failure-count window |
 
-These defaults are applied when the router is instantiated without overrides.
+These defaults apply when the router is instantiated without overrides.
 
 ## API behaviour
 
@@ -75,6 +75,7 @@ POST /api/admin/users/:address/impersonate
 Authorization: Bearer <admin-jwt>
 
 503 Service Unavailable
+Retry-After: 30
 {
   "error": {
     "code": "service_unavailable",
@@ -85,8 +86,11 @@ Authorization: Bearer <admin-jwt>
 }
 ```
 
-- `retryAfterMs` tells the caller how long before the breaker will allow a
-  probe (i.e. the configured `halfOpenAfterMs` value).
+- `retryAfterMs` is the time **remaining** before the breaker will allow a
+  probe — it counts down as the OPEN window elapses, rather than always
+  reporting the full `halfOpenAfterMs`.
+- `Retry-After` carries the same value in seconds (rounded up) for standard
+  HTTP clients and proxies.
 - When the circuit is OPEN, **no downstream calls are made** — the JWT service
   and audit service are never invoked.
 
@@ -97,6 +101,9 @@ Authorization: Bearer <admin-jwt>
 | `400` | `validation_error` | `:address` param is blank / whitespace-only |
 | `403` | `forbidden` | Missing, invalid, or non-admin JWT |
 | `429` | `rate_limit_exceeded` | Rate limit: 60 req/min per admin token |
+
+Auth and validation guards run **before** circuit evaluation, so a request
+without a valid admin JWT always returns 403 regardless of circuit state.
 
 ## Implementation
 
@@ -119,32 +126,47 @@ const token = await breaker.execute(async () => {
 });
 ```
 
-The `CircuitOpenError` is caught in the route handler and mapped to HTTP 503.
-All other errors are forwarded to the global error handler.
+`getCircuitBreaker` returns the shared breaker for a given name, applying any
+options passed — so the endpoint's tuning is honoured regardless of which
+caller resolves the breaker first. `CircuitOpenError` is caught in the route
+handler and mapped to HTTP 503; all other errors are forwarded to the global
+error handler.
+
+### Route wiring
+
+The router is mounted in `src/index.ts` on the shared `/api/admin/users`
+prefix, ahead of the other routers on that prefix. Its rate limit and
+`requireAdmin` guard are attached to the `POST /:address/impersonate` route
+itself rather than via `router.use`, so requests for sibling paths pass
+through untouched on their way to a later mount.
 
 ## Testing
 
 ### Unit tests — `tests/circuitBreaker.test.ts`
 
-Tests every state transition, the public API (`execute`, `snapshot`, `state`),
-`CircuitOpenError`, and both test helpers.
+Covers every state transition, the public API (`execute`, `snapshot`, `state`),
+`CircuitOpenError`, registry isolation, and both test helpers.
 
-### Integration tests — `tests/impersonateCircuitBreaker.test.ts`
+### Route tests — `tests/impersonateCircuitBreaker.test.ts`
 
-Tests the route end-to-end against every circuit state:
+Exercises the route against every circuit state:
 
 | Scenario | Expected |
 |---|---|
 | CLOSED + succeeding downstream | 200 + token |
 | CLOSED + failing downstream (below threshold) | 500 propagated; counter incremented |
 | CLOSED + failing downstream (at threshold) | next call → 503 |
-| OPEN | 503, downstream not called, `retryAfterMs` present |
+| OPEN | 503, downstream not called, `retryAfterMs` + `Retry-After` present |
+| OPEN, partially elapsed | `retryAfterMs` reflects remaining time only |
 | HALF_OPEN + success | 200, breaker → CLOSED |
 | HALF_OPEN + failure | 500, breaker → OPEN |
 | OPEN after `halfOpenAfterMs` elapses | probe allowed, responds 200 |
 
-Auth and validation guards run **before** circuit evaluation, so a request
-without a valid admin JWT always returns 403 regardless of circuit state.
+### Wiring tests — `tests/impersonateRouteMounted.test.ts`
+
+Asserts the route is actually reachable through `createApp()` (a 404 there
+would mean the router is not mounted) and that it does not shadow sibling
+`/api/admin/users` routes.
 
 ## Runbook
 
@@ -157,10 +179,15 @@ Look for the `circuit_breaker_opened` log line in the application logs:
   "level": "warn",
   "circuitName": "impersonate",
   "failures": 5,
+  "threshold": 5,
   "openedAt": 1722175200000,
+  "state": "OPEN",
   "msg": "circuit_breaker_opened"
 }
 ```
+
+Each rejected request also logs `impersonate_circuit_open` at warn level with
+the `correlationId`, so tripped-breaker 503s can be traced per request.
 
 ### How to tell when it recovers
 
@@ -173,11 +200,18 @@ Look for the `circuit_breaker_opened` log line in the application logs:
 }
 ```
 
+Related log events: `circuit_breaker_half_open` (probe window opened),
+`circuit_breaker_probe_success` (probe succeeded but `successThreshold` not yet
+met), `circuit_breaker_probe_failed_reopened` (probe failed, back to OPEN), and
+`circuit_breaker_half_open_probe_busy` (a concurrent caller was fast-failed
+while a probe was in flight).
+
 ### Forcing a fresh breaker (process restart)
 
-The circuit state is **in-memory only** and resets when the process restarts.
-A rolling restart is the quickest way to reset a stuck-open breaker if the
-downstream has been fixed but the `halfOpenAfterMs` window hasn't elapsed yet.
+The circuit state is **in-memory and per-process** — it resets when the process
+restarts, and each instance maintains its own breaker. A rolling restart is the
+quickest way to reset a stuck-open breaker if the downstream has been fixed but
+the `halfOpenAfterMs` window hasn't elapsed yet.
 
 ### Adjusting thresholds
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import { featureFlagsRouter } from "./routes/feature-flags";
 import { adminFeatureFlagsRouter } from "./routes/admin/featureFlags";
 import { adminUsersRouter } from "./routes/adminUsers";
 import { adminNotesRouter } from "./routes/admin/users/notes";
+import { adminImpersonateRouter } from "./routes/admin/users/impersonate";
 import { leaderboardRouter } from "./routes/leaderboard";
 import { globalLeaderboardRouter } from "./routes/leaderboard/global";
 import { createDocsRouter } from "./routes/docs";
@@ -214,6 +215,10 @@ export function createApp(): express.Express {
   app.use("/api/audit/counts", auditCountsRouter);
   app.use("/api/audit/user", userAuditRouter);
   app.use("/api/admin/health", adminHealthRouter);
+  // Mounted ahead of the other /api/admin/users routers: it only matches
+  // POST /:address/impersonate and attaches its rate limit and admin guard to
+  // that route alone, so unrelated requests fall straight through untouched.
+  app.use("/api/admin/users", adminImpersonateRouter);
   app.use("/api/admin/users", adminUsersRouter);
   app.use("/api/admin/users", adminNotesRouter);
   app.use("/api/feature-flags", featureFlagsRouter);

--- a/src/lib/circuitBreaker.ts
+++ b/src/lib/circuitBreaker.ts
@@ -9,42 +9,50 @@
  * CLOSED (normal operation)
  *   All calls pass through. Failures are counted in a rolling window. Once
  *   `failureThreshold` failures accumulate within `windowMs`, the breaker
- *   transitions to OPEN.
+ *   transitions to OPEN. Any success clears the accumulated failures.
  *
  * OPEN (fast-fail)
  *   All calls are rejected immediately with a `CircuitOpenError` (callers
- *   should translate this to HTTP 503). After `resetTimeoutMs` has elapsed
+ *   should translate this to HTTP 503). After `halfOpenAfterMs` has elapsed
  *   the breaker transitions to HALF_OPEN to probe whether the downstream has
  *   recovered.
  *
  * HALF_OPEN (probe)
- *   A single call is allowed through as a probe. If it succeeds the breaker
- *   returns to CLOSED and the failure counts are reset. If it fails the
- *   breaker returns to OPEN and the reset timeout restarts.
+ *   A single call at a time is allowed through as a probe; concurrent callers
+ *   are fast-failed so a sick downstream is not stampeded. Once
+ *   `successThreshold` probes have succeeded the breaker returns to CLOSED.
+ *   Any probe failure sends it straight back to OPEN and restarts the timer.
  *
  * Usage
  * -----
  *
  * ```ts
- * import { CircuitBreaker } from "../lib/circuitBreaker";
+ * import { getCircuitBreaker, CircuitOpenError } from "../lib/circuitBreaker";
  *
- * // One breaker instance per downstream endpoint (module-level singleton).
- * const dbBreaker = new CircuitBreaker("comments-db");
- * const httpBreaker = new CircuitBreaker("comments-outbound");
+ * // One breaker per logical downstream dependency, resolved from the registry
+ * // so every route/module sharing a name shares the same state.
+ * const breaker = getCircuitBreaker("impersonate", { failureThreshold: 5 });
  *
- * // Wrap any async call with the breaker:
- * const result = await dbBreaker.fire(() => listMarketComments(id, cursor, limit));
+ * try {
+ *   const result = await breaker.execute(() => doDownstreamWork());
+ * } catch (err) {
+ *   if (err instanceof CircuitOpenError) {
+ *     // fast-fail path → respond 503
+ *   }
+ * }
  * ```
  *
  * Tuning
  * ------
- * Pass a `CircuitBreakerOptions` object to the constructor:
+ * Pass a `CircuitBreakerOptions` object to `getCircuitBreaker` (or the
+ * constructor):
  *
- * | Option             | Default | Description                                         |
- * |--------------------|---------|-----------------------------------------------------|
- * | failureThreshold   | 5       | Failures in the window before opening               |
- * | windowMs           | 60 000  | Rolling window length in milliseconds               |
- * | resetTimeoutMs     | 30 000  | Time to stay OPEN before probing                    |
+ * | Option             | Default | Description                                    |
+ * |--------------------|---------|------------------------------------------------|
+ * | failureThreshold   | 5       | In-window failures before opening               |
+ * | successThreshold   | 1       | HALF_OPEN probe successes needed to close       |
+ * | halfOpenAfterMs    | 30 000  | Time to stay OPEN before probing                |
+ * | windowMs           | 60 000  | Rolling failure-window length                   |
  *
  * Thread safety
  * -------------
@@ -61,13 +69,24 @@ import { logger } from "../config/logger";
 /** The three states of the circuit breaker. */
 export type CircuitBreakerState = "CLOSED" | "OPEN" | "HALF_OPEN";
 
-/** Options accepted by the {@link CircuitBreaker} constructor. */
+/** Options accepted by {@link CircuitBreaker} and {@link getCircuitBreaker}. */
 export interface CircuitBreakerOptions {
   /**
-   * Number of failures in the rolling window that cause the breaker to open.
+   * Number of failures within `windowMs` that cause the breaker to open.
    * @default 5
    */
   failureThreshold?: number;
+  /**
+   * Number of consecutive HALF_OPEN probe successes required before the
+   * breaker closes again.
+   * @default 1
+   */
+  successThreshold?: number;
+  /**
+   * How long the breaker stays OPEN before allowing a HALF_OPEN probe.
+   * @default 30_000
+   */
+  halfOpenAfterMs?: number;
   /**
    * Length of the rolling failure-count window in milliseconds.
    * Failures older than this are discarded.
@@ -75,101 +94,205 @@ export interface CircuitBreakerOptions {
    */
   windowMs?: number;
   /**
-   * How long the breaker stays OPEN before transitioning to HALF_OPEN
-   * to attempt a probe call.
-   * @default 30_000
+   * @deprecated Legacy alias for {@link CircuitBreakerOptions.halfOpenAfterMs}.
+   * Retained for existing callers; `halfOpenAfterMs` wins when both are given.
    */
   resetTimeoutMs?: number;
 }
 
+/** Immutable view of a breaker's configuration and live counters. */
+export interface CircuitBreakerSnapshot {
+  /** Registry name of the breaker. */
+  name: string;
+  /** Current state, after applying any due OPEN → HALF_OPEN transition. */
+  state: CircuitBreakerState;
+  /** Failures currently inside the rolling window. */
+  failures: number;
+  /** Consecutive HALF_OPEN probe successes so far. */
+  successes: number;
+  /** When the breaker last tripped to OPEN, or `null` if it is closed. */
+  openedAt: number | null;
+  failureThreshold: number;
+  successThreshold: number;
+  halfOpenAfterMs: number;
+}
+
 /**
- * Thrown by {@link CircuitBreaker.fire} when the breaker is OPEN or when the
- * HALF_OPEN probe slot is already occupied. Callers should map this to HTTP 503.
+ * Thrown by {@link CircuitBreaker.execute} when the breaker is OPEN, or when
+ * the single HALF_OPEN probe slot is already occupied. Callers should map this
+ * to HTTP 503 and surface `openedAt` / `halfOpenAfterMs` so clients can back
+ * off intelligently.
  */
 export class CircuitOpenError extends Error {
   public readonly name = "CircuitOpenError";
-  public readonly breakerName: string;
+  /** Registry name of the breaker that rejected the call. */
+  public readonly circuitName: string;
+  /** When the breaker tripped to OPEN. */
+  public readonly openedAt: number;
+  /** State the breaker was in when it rejected the call. */
   public readonly state: CircuitBreakerState;
 
-  constructor(breakerName: string, state: CircuitBreakerState) {
-    super(`Circuit breaker '${breakerName}' is ${state} — downstream call rejected`);
-    this.breakerName = breakerName;
-    this.state = state;
+  constructor(
+    circuitName: string,
+    openedAt: number,
+    state?: CircuitBreakerState,
+  );
+  /**
+   * @deprecated Legacy two-argument form that passes the state in second
+   * position. `openedAt` defaults to now. Prefer
+   * `new CircuitOpenError(name, openedAt, state)`.
+   */
+  constructor(circuitName: string, state: CircuitBreakerState);
+  constructor(
+    circuitName: string,
+    openedAtOrState: number | CircuitBreakerState,
+    state: CircuitBreakerState = "OPEN",
+  ) {
+    // Discriminate the two supported shapes on the runtime type of the second
+    // argument: a number is an `openedAt` timestamp, a string is a state.
+    const legacyStateForm = typeof openedAtOrState === "string";
+    const resolvedState = legacyStateForm ? openedAtOrState : state;
+
+    super(
+      `Circuit breaker '${circuitName}' is ${resolvedState} — downstream call rejected`,
+    );
+    this.circuitName = circuitName;
+    this.openedAt = legacyStateForm ? Date.now() : openedAtOrState;
+    this.state = resolvedState;
     Object.setPrototypeOf(this, CircuitOpenError.prototype);
   }
+
+  /** @deprecated Legacy alias for {@link CircuitOpenError.circuitName}. */
+  get breakerName(): string {
+    return this.circuitName;
+  }
 }
+
+// ── Defaults ─────────────────────────────────────────────────────────────────
+
+const DEFAULT_FAILURE_THRESHOLD = 5;
+const DEFAULT_SUCCESS_THRESHOLD = 1;
+const DEFAULT_HALF_OPEN_AFTER_MS = 30_000;
+const DEFAULT_WINDOW_MS = 60_000;
 
 // ── CircuitBreaker class ─────────────────────────────────────────────────────
 
 /**
  * Per-endpoint circuit breaker with CLOSED / OPEN / HALF_OPEN state machine.
  *
- * Create one instance per logical downstream dependency and reuse it for the
- * lifetime of the process. Module-level singletons are the idiomatic pattern.
+ * Prefer {@link getCircuitBreaker} over `new CircuitBreaker(...)` so that all
+ * callers referring to the same logical downstream share one instance — a
+ * breaker only protects a dependency if every caller trips the same counters.
  */
 export class CircuitBreaker {
-  private readonly name: string;
-  private readonly failureThreshold: number;
-  private readonly windowMs: number;
-  private readonly resetTimeoutMs: number;
+  private readonly _name: string;
+
+  private _failureThreshold = DEFAULT_FAILURE_THRESHOLD;
+  private _successThreshold = DEFAULT_SUCCESS_THRESHOLD;
+  private _halfOpenAfterMs = DEFAULT_HALF_OPEN_AFTER_MS;
+  private _windowMs = DEFAULT_WINDOW_MS;
 
   private _state: CircuitBreakerState = "CLOSED";
   /** Timestamps (ms since epoch) of recent failures within the rolling window. */
   private failureTimes: number[] = [];
-  /** Wall-clock time at which the OPEN → HALF_OPEN transition may occur. */
-  private openedAt: number | null = null;
+  /** Consecutive HALF_OPEN probe successes accumulated so far. */
+  private _successes = 0;
+  /** Wall-clock time at which the breaker last tripped to OPEN. */
+  private _openedAt: number | null = null;
   /** Guards the single probe slot when HALF_OPEN. */
   private halfOpenProbeInFlight = false;
 
   constructor(name: string, opts: CircuitBreakerOptions = {}) {
-    this.name = name;
-    this.failureThreshold = opts.failureThreshold ?? 5;
-    this.windowMs = opts.windowMs ?? 60_000;
-    this.resetTimeoutMs = opts.resetTimeoutMs ?? 30_000;
+    this._name = name;
+    this.configure(opts);
   }
 
   // ── Public API ─────────────────────────────────────────────────────────────
 
-  /** The current state of the circuit breaker. */
+  /**
+   * The current state of the circuit breaker. Reading this applies any due
+   * OPEN → HALF_OPEN transition, so it is safe to poll.
+   */
   get state(): CircuitBreakerState {
     this._maybeTransitionToHalfOpen();
     return this._state;
   }
 
   /**
-   * Fire the supplied async callable through the breaker.
+   * Apply configuration overrides in place.
    *
-   * - CLOSED: calls through, records success/failure.
-   * - OPEN:   throws {@link CircuitOpenError} immediately (fast-fail).
-   * - HALF_OPEN: allows one probe call; success → CLOSED, failure → OPEN.
-   *   If the probe slot is already occupied, throws {@link CircuitOpenError}.
+   * Only keys that are actually present are applied, so passing a partial
+   * object never resets unrelated tuning back to defaults. Called by
+   * {@link getCircuitBreaker} so a route can configure the shared breaker it
+   * resolves from the registry.
+   */
+  configure(opts: CircuitBreakerOptions = {}): void {
+    if (opts.failureThreshold !== undefined) {
+      this._failureThreshold = opts.failureThreshold;
+    }
+    if (opts.successThreshold !== undefined) {
+      this._successThreshold = opts.successThreshold;
+    }
+    // `halfOpenAfterMs` is the current name; `resetTimeoutMs` is the legacy
+    // alias kept for existing callers.
+    if (opts.halfOpenAfterMs !== undefined) {
+      this._halfOpenAfterMs = opts.halfOpenAfterMs;
+    } else if (opts.resetTimeoutMs !== undefined) {
+      this._halfOpenAfterMs = opts.resetTimeoutMs;
+    }
+    if (opts.windowMs !== undefined) {
+      this._windowMs = opts.windowMs;
+    }
+  }
+
+  /**
+   * Run the supplied async callable through the breaker.
+   *
+   * - CLOSED: calls through, recording success/failure.
+   * - OPEN: throws {@link CircuitOpenError} immediately (fast-fail) without
+   *   invoking `callable` at all.
+   * - HALF_OPEN: allows one probe at a time; `successThreshold` successes →
+   *   CLOSED, any failure → OPEN. Concurrent callers get a
+   *   {@link CircuitOpenError} while a probe is in flight.
    *
    * @param callable  Zero-argument async function wrapping the downstream call.
    * @returns The resolved value of `callable`.
    * @throws  {@link CircuitOpenError} when the breaker is OPEN or the HALF_OPEN
-   *          probe slot is busy.
+   *          probe slot is busy. A `CircuitOpenError` raised here is *not*
+   *          counted as a downstream failure — no call was made.
    * @throws  Whatever `callable` throws when it fails while the breaker is
    *          CLOSED or serving as the HALF_OPEN probe.
    */
-  async fire<T>(callable: () => Promise<T>): Promise<T> {
+  async execute<T>(callable: () => Promise<T>): Promise<T> {
     this._maybeTransitionToHalfOpen();
 
     if (this._state === "OPEN") {
       logger.warn(
-        { breaker: this.name, state: this._state },
+        { circuitName: this._name, state: this._state, openedAt: this._openedAt },
         "circuit_breaker_open_fast_fail",
       );
-      throw new CircuitOpenError(this.name, this._state);
+      throw new CircuitOpenError(
+        this._name,
+        this._openedAt ?? Date.now(),
+        "OPEN",
+      );
     }
 
-    if (this._state === "HALF_OPEN") {
+    // Capture up front: `_state` may change while `callable` is in flight, and
+    // only the call that claimed the probe slot may release it.
+    const isProbe = this._state === "HALF_OPEN";
+
+    if (isProbe) {
       if (this.halfOpenProbeInFlight) {
-        // Probe already in flight; reject all other callers.
         logger.warn(
-          { breaker: this.name, state: this._state },
+          { circuitName: this._name, state: this._state },
           "circuit_breaker_half_open_probe_busy",
         );
-        throw new CircuitOpenError(this.name, this._state);
+        throw new CircuitOpenError(
+          this._name,
+          this._openedAt ?? Date.now(),
+          "HALF_OPEN",
+        );
       }
       this.halfOpenProbeInFlight = true;
     }
@@ -182,43 +305,77 @@ export class CircuitBreaker {
       this._onFailure();
       throw err;
     } finally {
-      if (this._state === "HALF_OPEN") {
+      if (isProbe) {
         this.halfOpenProbeInFlight = false;
       }
     }
   }
 
+  /** @deprecated Legacy alias for {@link CircuitBreaker.execute}. */
+  fire<T>(callable: () => Promise<T>): Promise<T> {
+    return this.execute(callable);
+  }
+
+  /** A point-in-time view of configuration and counters, safe to log or serve. */
+  snapshot(): CircuitBreakerSnapshot {
+    // Read through the getter so a due OPEN → HALF_OPEN transition is applied.
+    const state = this.state;
+    return {
+      name: this._name,
+      state,
+      failures: this._prunedFailureCount(),
+      successes: this._successes,
+      openedAt: this._openedAt,
+      failureThreshold: this._failureThreshold,
+      successThreshold: this._successThreshold,
+      halfOpenAfterMs: this._halfOpenAfterMs,
+    };
+  }
+
   /**
-   * Reset the breaker to CLOSED and clear all failure tracking.
-   * Intended for test suites; production code should not call this directly.
+   * Reset the breaker to CLOSED and clear all counters. Intended for test
+   * suites and operational tooling; the normal recovery path is the HALF_OPEN
+   * probe.
    */
   reset(): void {
-    this._state = "CLOSED";
-    this.failureTimes = [];
-    this.openedAt = null;
+    this._close();
+  }
+
+  /**
+   * Force a state, bypassing the state machine. **Test-only** — production
+   * code must drive the breaker through {@link CircuitBreaker.execute}.
+   */
+  forceStateForTests(state: CircuitBreakerState): void {
+    this._state = state;
+    this._openedAt = state === "CLOSED" ? null : Date.now();
+    this._successes = 0;
     this.halfOpenProbeInFlight = false;
+    if (state === "CLOSED") {
+      this.failureTimes = [];
+    }
   }
 
   // ── Internal helpers ───────────────────────────────────────────────────────
 
-  /** Prunes stale timestamps and returns the current failure count. */
+  /** Prunes stale timestamps and returns the current in-window failure count. */
   private _prunedFailureCount(): number {
-    const cutoff = Date.now() - this.windowMs;
+    const cutoff = Date.now() - this._windowMs;
     this.failureTimes = this.failureTimes.filter((t) => t > cutoff);
     return this.failureTimes.length;
   }
 
-  /** Transitions from OPEN to HALF_OPEN if the reset timeout has elapsed. */
+  /** Transitions from OPEN to HALF_OPEN once `halfOpenAfterMs` has elapsed. */
   private _maybeTransitionToHalfOpen(): void {
     if (
       this._state === "OPEN" &&
-      this.openedAt !== null &&
-      Date.now() - this.openedAt >= this.resetTimeoutMs
+      this._openedAt !== null &&
+      Date.now() - this._openedAt >= this._halfOpenAfterMs
     ) {
       this._state = "HALF_OPEN";
+      this._successes = 0;
       this.halfOpenProbeInFlight = false;
       logger.info(
-        { breaker: this.name, state: "HALF_OPEN" },
+        { circuitName: this._name, state: "HALF_OPEN" },
         "circuit_breaker_half_open",
       );
     }
@@ -226,15 +383,25 @@ export class CircuitBreaker {
 
   private _onSuccess(): void {
     if (this._state === "HALF_OPEN") {
-      logger.info(
-        { breaker: this.name },
-        "circuit_breaker_probe_success_closing",
-      );
+      this._successes += 1;
+      if (this._successes >= this._successThreshold) {
+        this._close();
+      } else {
+        logger.info(
+          {
+            circuitName: this._name,
+            successes: this._successes,
+            successThreshold: this._successThreshold,
+          },
+          "circuit_breaker_probe_success",
+        );
+      }
+      return;
     }
-    // Any success resets the breaker fully.
-    this._state = "CLOSED";
+
+    // CLOSED — a success clears any accumulated failures.
     this.failureTimes = [];
-    this.openedAt = null;
+    this._successes = 0;
   }
 
   private _onFailure(): void {
@@ -242,27 +409,26 @@ export class CircuitBreaker {
 
     if (this._state === "HALF_OPEN") {
       // Probe failed — return to OPEN and restart the reset timer.
-      this._state = "OPEN";
-      this.openedAt = now;
+      this._trip(now);
       logger.warn(
-        { breaker: this.name, state: "OPEN" },
+        { circuitName: this._name, state: "OPEN" },
         "circuit_breaker_probe_failed_reopened",
       );
       return;
     }
 
-    // CLOSED — record failure and check threshold.
+    // CLOSED — record the failure and check the threshold.
     this.failureTimes.push(now);
     const count = this._prunedFailureCount();
 
-    if (count >= this.failureThreshold) {
-      this._state = "OPEN";
-      this.openedAt = now;
+    if (count >= this._failureThreshold) {
+      this._trip(now);
       logger.warn(
         {
-          breaker: this.name,
+          circuitName: this._name,
           failures: count,
-          threshold: this.failureThreshold,
+          threshold: this._failureThreshold,
+          openedAt: now,
           state: "OPEN",
         },
         "circuit_breaker_opened",
@@ -270,12 +436,27 @@ export class CircuitBreaker {
     }
   }
 
-  snapshot(): { state: CircuitBreakerState; failures: number; halfOpenAfterMs: number } {
-    return {
-      state: this.state,
-      failures: this.failureTimes.length,
-      halfOpenAfterMs: this.resetTimeoutMs,
-    };
+  /** Trip to OPEN and start the `halfOpenAfterMs` countdown. */
+  private _trip(now: number): void {
+    this._state = "OPEN";
+    this._openedAt = now;
+    this._successes = 0;
+  }
+
+  /** Return to CLOSED and clear every counter. */
+  private _close(): void {
+    const wasOpen = this._state !== "CLOSED";
+    this._state = "CLOSED";
+    this.failureTimes = [];
+    this._successes = 0;
+    this._openedAt = null;
+    this.halfOpenProbeInFlight = false;
+    if (wasOpen) {
+      logger.info(
+        { circuitName: this._name, state: "CLOSED" },
+        "circuit_breaker_closed",
+      );
+    }
   }
 }
 
@@ -283,29 +464,40 @@ export class CircuitBreaker {
 
 const breakers = new Map<string, CircuitBreaker>();
 
-export function getCircuitBreaker(name: string, opts?: CircuitBreakerOptions): CircuitBreaker {
+/**
+ * Resolve the shared breaker for `name`, creating it on first use.
+ *
+ * When `opts` is supplied it is applied to the breaker even if it already
+ * exists, so a route can express its tuning without having to be the first
+ * caller. Only keys present in `opts` are applied.
+ */
+export function getCircuitBreaker(
+  name: string,
+  opts?: CircuitBreakerOptions,
+): CircuitBreaker {
   let breaker = breakers.get(name);
   if (!breaker) {
     breaker = new CircuitBreaker(name, opts);
     breakers.set(name, breaker);
+  } else if (opts) {
+    breaker.configure(opts);
   }
   return breaker;
 }
 
+/** Drop every registered breaker. **Test-only.** */
 export function resetCircuitBreakersForTests(): void {
   breakers.clear();
 }
 
+/**
+ * Force a registered breaker into `state`, optionally applying configuration
+ * overrides at the same time. **Test-only.**
+ */
 export function forceCircuitStateForTests(
   name: string,
   state: CircuitBreakerState,
-  opts?: { halfOpenAfterMs?: number }
+  opts?: CircuitBreakerOptions,
 ): void {
-  const breaker = getCircuitBreaker(name);
-  // @ts-ignore - access private fields for test overrides
-  breaker._state = state;
-  // @ts-ignore
-  breaker.openedAt = state === "OPEN" || state === "HALF_OPEN" ? Date.now() : null;
-  // @ts-ignore
-  if (opts?.halfOpenAfterMs !== undefined) { breaker.resetTimeoutMs = opts.halfOpenAfterMs; }
+  getCircuitBreaker(name, opts).forceStateForTests(state);
 }

--- a/src/openapi/registry.ts
+++ b/src/openapi/registry.ts
@@ -2893,6 +2893,70 @@ registry.registerPath({
   },
 });
 
+// ── /api/admin/users/{address}/impersonate ──────────────────────────────────
+
+/**
+ * 503 envelope for the impersonate endpoint. `retryAfterMs` reports the time
+ * remaining before the circuit breaker will allow a recovery probe; the same
+ * value is echoed, in seconds, in the `Retry-After` response header.
+ */
+const CircuitOpenErrorBody = z
+  .object({
+    error: z.object({
+      code: z.literal("service_unavailable"),
+      message: z.string(),
+      retryAfterMs: z.number().int().nonnegative(),
+      requestId: z.string(),
+    }),
+  })
+  .openapi("CircuitOpenErrorBody");
+
+registry.registerPath({
+  method: "post",
+  path: "/api/admin/users/{address}/impersonate",
+  operationId: "impersonateUser",
+  tags: ["Admin"],
+  summary: "Generate an impersonation JWT for a user (admin only)",
+  description:
+    "Admin-only endpoint that creates an audit-logged JWT allowing the caller " +
+    "to act as the target user. The generated token carries a `user` role " +
+    "assertion.\n\n" +
+    "Downstream work (audit-log writes and token signing) is wrapped in a " +
+    "per-endpoint circuit breaker. After repeated downstream failures the " +
+    "breaker opens and the endpoint fast-fails with 503 without attempting " +
+    "any downstream call, until a recovery probe succeeds.",
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ address: z.string() }) },
+  responses: {
+    200: {
+      description: "Impersonation token",
+      content: {
+        "application/json": {
+          schema: z.object({ data: z.object({ token: z.string() }) }),
+        },
+      },
+    },
+    400: {
+      description: "Validation error — address is blank or whitespace-only",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    403: {
+      description: "Forbidden — missing, invalid, or non-admin JWT",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    429: {
+      description: "Rate limit exceeded",
+      content: { "application/json": { schema: ErrorBody } },
+    },
+    503: {
+      description:
+        "Circuit breaker is open — downstream dependencies are unhealthy and " +
+        "no downstream call was attempted. Retry after `retryAfterMs`.",
+      content: { "application/json": { schema: CircuitOpenErrorBody } },
+    },
+  },
+});
+
 // ── /api/admin/audit ────────────────────────────────────────────────────────
 
 const AuditEntry = z

--- a/src/routes/admin/users/impersonate.ts
+++ b/src/routes/admin/users/impersonate.ts
@@ -28,6 +28,7 @@
  *  - 403 Forbidden     missing/invalid/non-admin JWT
  *  - 429 Too Many Requests  rate limit exceeded
  *  - 503 Service Unavailable  circuit is OPEN; body: { error: { code: "service_unavailable", retryAfterMs } }
+ *    and a `Retry-After` header (seconds) so standard HTTP clients back off.
  */
 
 import { Router } from "express";
@@ -66,103 +67,124 @@ export function createAdminImpersonateRouter(
   const router = Router();
   const limit = opts.rateLimitPerMinute ?? 60;
 
-  // Lazily instantiated so tests can inject custom thresholds via opts.
+  // Resolved from the shared registry so every caller of this endpoint trips
+  // the same counters. `opts.circuitBreaker` is applied even if the breaker
+  // already exists, so thresholds are honoured regardless of creation order.
   const breaker = getCircuitBreaker(IMPERSONATE_CIRCUIT_NAME, opts.circuitBreaker);
 
-  router.use(
-    rateLimit({
-      windowMs: 60_000,
-      limit,
-      keyGenerator: (req) =>
-        (req.headers.authorization as string | undefined) ?? req.ip ?? "unknown",
-      standardHeaders: "draft-6",
-      legacyHeaders: false,
-      message: { error: { code: "rate_limit_exceeded" } },
-    }),
-  );
-
-  router.use(requireAdmin);
-
-  router.post("/:address/impersonate", async (req, res, next) => {
-    const reqId = getRequestId() ?? (req as { id?: string }).id ?? "unknown";
-
-    try {
-      const parsed = paramsSchema.safeParse(req.params);
-
-      if (!parsed.success) {
-        res.status(400).json({
-          error: {
-            code: "validation_error",
-            details: parsed.error.issues,
-            requestId: reqId,
-          },
-        });
-        return;
-      }
-
-      const targetAddress = parsed.data.address;
-      const adminAddress = req.adminAddress!;
-
-      // Wrap all downstream I/O in the circuit breaker.
-      // If the breaker is OPEN this throws CircuitOpenError immediately
-      // (before any network or DB call is attempted).
-      const token = await breaker.fire(async () => {
-        // 1. Audit log in global audit_logs
-        await createAuditLog({
-          action: "admin.impersonate",
-          walletAddress: adminAddress,
-          ip: req.ip ?? "unknown",
-          correlationId: reqId,
-          beforeState: null,
-          afterState: { targetAddress, role: "user" },
-        });
-
-        // 2. Audit log in admin_audit_log keyed by target address
-        await db.insert(adminAuditLog).values({
-          adminAddress,
-          action: "impersonate",
-          targetAddress,
-        });
-
-        // 3. Structured logging with correlation IDs
-        logger.info(
-          {
-            adminAddress,
-            targetAddress,
-            correlationId: reqId,
-          },
-          "Admin impersonated user",
-        );
-
-        // 4. Generate the impersonation token
-        return signAccessToken({ sub: targetAddress, role: "user" });
-      });
-
-      res.status(200).json({ data: { token } });
-    } catch (err) {
-      if (err instanceof CircuitOpenError) {
-        const retryAfterMs = breaker.snapshot().halfOpenAfterMs;
-        logger.warn(
-          {
-            circuitName: IMPERSONATE_CIRCUIT_NAME,
-            openedAt: err.openedAt,
-            reqId,
-          },
-          "impersonate_circuit_open",
-        );
-        res.status(503).json({
-          error: {
-            code: "service_unavailable",
-            message: "Impersonate service is temporarily unavailable. Please retry later.",
-            retryAfterMs,
-            requestId: reqId,
-          },
-        });
-        return;
-      }
-      next(err);
-    }
+  const impersonateRateLimit = rateLimit({
+    windowMs: 60_000,
+    limit,
+    keyGenerator: (req) =>
+      (req.headers.authorization as string | undefined) ?? req.ip ?? "unknown",
+    standardHeaders: "draft-6",
+    legacyHeaders: false,
+    message: { error: { code: "rate_limit_exceeded" } },
   });
+
+  // Middleware is attached to the route rather than via `router.use` so that
+  // mounting this router on the shared /api/admin/users prefix cannot apply
+  // this endpoint's rate limit or auth to sibling routers' requests that
+  // merely pass through on their way to a later mount.
+  router.post(
+    "/:address/impersonate",
+    impersonateRateLimit,
+    requireAdmin,
+    async (req, res, next) => {
+      const reqId = getRequestId() ?? (req as { id?: string }).id ?? "unknown";
+
+      try {
+        const parsed = paramsSchema.safeParse(req.params);
+
+        if (!parsed.success) {
+          res.status(400).json({
+            error: {
+              code: "validation_error",
+              details: parsed.error.issues,
+              requestId: reqId,
+            },
+          });
+          return;
+        }
+
+        const targetAddress = parsed.data.address;
+        const adminAddress = req.adminAddress!;
+
+        // Wrap all downstream I/O in the circuit breaker.
+        // If the breaker is OPEN this throws CircuitOpenError immediately
+        // (before any network or DB call is attempted).
+        const token = await breaker.execute(async () => {
+          // 1. Audit log in global audit_logs
+          await createAuditLog({
+            action: "admin.impersonate",
+            walletAddress: adminAddress,
+            ip: req.ip ?? "unknown",
+            correlationId: reqId,
+            beforeState: null,
+            afterState: { targetAddress, role: "user" },
+          });
+
+          // 2. Audit log in admin_audit_log keyed by target address
+          await db.insert(adminAuditLog).values({
+            adminAddress,
+            action: "impersonate",
+            targetAddress,
+          });
+
+          // 3. Structured logging with correlation IDs
+          logger.info(
+            {
+              adminAddress,
+              targetAddress,
+              correlationId: reqId,
+            },
+            "Admin impersonated user",
+          );
+
+          // 4. Generate the impersonation token
+          return signAccessToken({ sub: targetAddress, role: "user" });
+        });
+
+        res.status(200).json({ data: { token } });
+      } catch (err) {
+        if (err instanceof CircuitOpenError) {
+          // Report the time actually remaining before a probe is allowed
+          // rather than the full window, so a caller that retries late is not
+          // told to wait all over again.
+          const { halfOpenAfterMs } = breaker.snapshot();
+          const elapsed = Date.now() - err.openedAt;
+          const retryAfterMs = Math.max(0, halfOpenAfterMs - elapsed);
+
+          logger.warn(
+            {
+              circuitName: IMPERSONATE_CIRCUIT_NAME,
+              state: err.state,
+              openedAt: err.openedAt,
+              retryAfterMs,
+              correlationId: reqId,
+              reqId,
+            },
+            "impersonate_circuit_open",
+          );
+
+          // Standard HTTP back-off signal, in seconds, alongside the
+          // millisecond precision value in the error envelope.
+          res.setHeader("Retry-After", String(Math.ceil(retryAfterMs / 1000)));
+          res.status(503).json({
+            error: {
+              code: "service_unavailable",
+              message:
+                "Impersonate service is temporarily unavailable. Please retry later.",
+              retryAfterMs,
+              requestId: reqId,
+            },
+          });
+          return;
+        }
+        next(err);
+      }
+    },
+  );
 
   return router;
 }

--- a/tests/circuitBreaker.test.ts
+++ b/tests/circuitBreaker.test.ts
@@ -381,6 +381,25 @@ describe("forceCircuitStateForTests", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Legacy option alias
+// ---------------------------------------------------------------------------
+
+describe("resetTimeoutMs legacy alias", () => {
+  it("is accepted as an alias for halfOpenAfterMs", () => {
+    const cb = getCircuitBreaker("legacy-alias", { resetTimeoutMs: 7_500 });
+    expect(cb.snapshot().halfOpenAfterMs).toBe(7_500);
+  });
+
+  it("loses to halfOpenAfterMs when both are supplied", () => {
+    const cb = getCircuitBreaker("legacy-both", {
+      halfOpenAfterMs: 1_000,
+      resetTimeoutMs: 9_000,
+    });
+    expect(cb.snapshot().halfOpenAfterMs).toBe(1_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // snapshot() — name field
 // ---------------------------------------------------------------------------
 

--- a/tests/impersonateCircuitBreaker.test.ts
+++ b/tests/impersonateCircuitBreaker.test.ts
@@ -181,6 +181,33 @@ describe("OPEN state — fast-fail 503", () => {
     expect(res.body.error.retryAfterMs).toBeGreaterThan(0);
   });
 
+  it("503 response sets a Retry-After header in seconds", async () => {
+    const app = makeApp({ halfOpenAfterMs: 30_000 });
+    forceCircuitStateForTests(IMPERSONATE_CIRCUIT_NAME, "OPEN", { halfOpenAfterMs: 30_000 });
+
+    const res = await authReq(app);
+    expect(res.status).toBe(503);
+    expect(res.headers["retry-after"]).toBe("30");
+  });
+
+  it("retryAfterMs counts down the remaining wait, not the full window", async () => {
+    jest.useFakeTimers();
+    try {
+      const app = makeApp({ halfOpenAfterMs: 30_000 });
+      forceCircuitStateForTests(IMPERSONATE_CIRCUIT_NAME, "OPEN", { halfOpenAfterMs: 30_000 });
+
+      // Burn 10s of the 30s window; 20s should remain.
+      jest.advanceTimersByTime(10_000);
+
+      const res = await authReq(app);
+      expect(res.status).toBe(503);
+      expect(res.body.error.retryAfterMs).toBeLessThanOrEqual(20_000);
+      expect(res.body.error.retryAfterMs).toBeGreaterThan(15_000);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it("does NOT call signAccessToken when circuit is OPEN", async () => {
     const app = makeApp();
     forceCircuitStateForTests(IMPERSONATE_CIRCUIT_NAME, "OPEN");
@@ -229,7 +256,7 @@ describe("OPEN state — fast-fail 503", () => {
 
 describe("HALF_OPEN state — probe behaviour", () => {
   it("lets a probe through when in HALF_OPEN and resets to CLOSED on success", async () => {
-    const app = makeApp({ halfOpenAfterMs: 0 }); // instant transition for tests
+    const app = makeApp({ halfOpenAfterMs: 30_000 });
     forceCircuitStateForTests(IMPERSONATE_CIRCUIT_NAME, "HALF_OPEN");
 
     // The probe call should succeed → breaker returns to CLOSED
@@ -241,7 +268,11 @@ describe("HALF_OPEN state — probe behaviour", () => {
   });
 
   it("trips back to OPEN when the HALF_OPEN probe fails", async () => {
-    const app = makeApp({ halfOpenAfterMs: 0 });
+    // A non-zero half-open window is required for the assertion below to mean
+    // anything: with halfOpenAfterMs = 0 the breaker is immediately eligible
+    // to probe again, so reading the state back would report HALF_OPEN even
+    // though the probe correctly tripped it to OPEN.
+    const app = makeApp({ halfOpenAfterMs: 30_000 });
     forceCircuitStateForTests(IMPERSONATE_CIRCUIT_NAME, "HALF_OPEN");
 
     mockSignAccessToken.mockImplementationOnce(() => {

--- a/tests/impersonateRouteMounted.test.ts
+++ b/tests/impersonateRouteMounted.test.ts
@@ -1,0 +1,62 @@
+/**
+ * impersonateRouteMounted.test.ts
+ *
+ * Guards the wiring of POST /api/admin/users/:address/impersonate into the
+ * composed application.
+ *
+ * The impersonate router existed and was fully unit-tested, but was never
+ * mounted in src/index.ts — so the endpoint returned 404 in the real app and
+ * the circuit breaker protecting it was unreachable. Suite-local Express apps
+ * (as used by the other impersonate tests) cannot catch that class of bug, so
+ * these tests exercise `createApp()` itself.
+ *
+ * Mocks below stand in for external infrastructure so `createApp()` can be
+ * built without a live Postgres/Redis. `src/routes/users` is additionally
+ * stubbed because it currently throws at import time on main (a botched merge
+ * left orphaned code referencing an unimported `z`), which would otherwise
+ * prevent this suite from loading for reasons unrelated to the route wiring.
+ */
+
+jest.mock("../src/db/client", () => ({ db: {} }));
+jest.mock("../src/queue", () => ({
+  redisConnection: { on: jest.fn() },
+  webhookQueue: { add: jest.fn() },
+  backupVerificationQueue: { add: jest.fn() },
+  reconciliationQueue: { add: jest.fn() },
+  marketResolutionQueue: { add: jest.fn() },
+}));
+jest.mock("../src/routes/users", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Router } = require("express");
+  return { usersRouter: Router() };
+});
+
+import request from "supertest";
+import { createApp } from "../src/index";
+
+const USER_ADDRESS = "GUSER88888888888888888888888888888888888888888888888888888";
+const IMPERSONATE_PATH = `/api/admin/users/${USER_ADDRESS}/impersonate`;
+
+describe("POST /api/admin/users/:address/impersonate — mounted in createApp", () => {
+  it("is routed by the composed app (403 from the admin guard, not 404)", async () => {
+    const res = await request(createApp()).post(IMPERSONATE_PATH).send({});
+
+    // A 404 here would mean the router is not mounted at all. Reaching the
+    // admin guard proves the route is wired up.
+    expect(res.status).not.toBe(404);
+    expect(res.status).toBe(403);
+  });
+
+  it("does not answer sibling /api/admin/users routes", async () => {
+    // The impersonate router is mounted on the shared /api/admin/users prefix
+    // ahead of the user-read and notes routers. Its rate limit and admin guard
+    // are attached to its own route only, so a request for a sibling path must
+    // pass through untouched to be handled by a later mount — in particular it
+    // must not be answered by the impersonate handler.
+    const res = await request(createApp())
+      .post(`/api/admin/users/${USER_ADDRESS}/notes`)
+      .send({});
+
+    expect(res.status).not.toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a per-endpoint circuit breaker around the downstream calls made by the
impersonate endpoint, returning **503 fast** while the circuit is open.

Note on paths: the issue references `src/routes/impersonate.ts` and
`/api/impersonate`. Neither exists in this repo — the only (admin-only)
impersonation endpoint is `POST /api/admin/users/:address/impersonate` in
`src/routes/admin/users/impersonate.ts`. This PR wires the breaker into the
real endpoint rather than adding a second, unauthenticated impersonation
surface.

Closes #778

## Why this is bigger than expected

The route, the breaker library, its unit suite and its docs already existed
on `main` — but none of them agreed with each other:

- `tests/circuitBreaker.test.ts` specified an API (`execute()`,
  `successThreshold`, `halfOpenAfterMs`,
  `snapshot().openedAt`/`name`/`successes`) that `src/lib/circuitBreaker.ts`
  never implemented — the library only had `fire()` and `resetTimeoutMs`.
  **25 of 36 tests failed.**
- The route logged `err.openedAt`, a property `CircuitOpenError` did not have.
- The route passed `halfOpenAfterMs`, an option the library silently
  ignored, so the configured recovery window had no effect.
- **`adminImpersonateRouter` was exported but never mounted** in
  `src/index.ts`, so the endpoint returned 404 and its circuit breaker was
  unreachable.
- `docs/impersonate-circuit-breaker.md` documented an API that was never
  built.

## Changes

### `src/lib/circuitBreaker.ts`

- Implement the API the unit suite specified: `execute()`,
  `successThreshold`, `halfOpenAfterMs`, and a full
  `CircuitBreakerSnapshot` (`name`/`state`/`failures`/`successes`/`openedAt`).
- `CircuitOpenError` now carries `circuitName` and `openedAt`.
- **Bug fix — probe-slot leak:** the probe flag was only cleared when the
  state was still `HALF_OPEN` after the call, so it leaked on both the
  success and failure paths, which transition away from `HALF_OPEN`. In the
  old code this self-healed — `_maybeTransitionToHalfOpen()` reset the flag
  on every `OPEN` → `HALF_OPEN` transition — so it was latent. It becomes
  fatal with `successThreshold > 1`, where the breaker stays `HALF_OPEN`
  across probes and that transition never happens: the leaked flag would
  reject every subsequent probe permanently. Now released by whichever call
  claimed it.
- `getCircuitBreaker(name, opts)` applies new options to an
  already-registered breaker, so a route's tuning is honoured regardless of
  creation order.
- **Backward compatible:** `fire()`, `resetTimeoutMs`, `windowMs`,
  `breakerName` and the legacy two-arg `CircuitOpenError(name, state)` form
  all still work — `src/routes/comments.ts` depends on every one of them,
  which is why they were kept. It required no changes.

### `src/routes/admin/users/impersonate.ts`

- Use `execute()`; keep the whole downstream unit (both audit writes + token
  signing) inside the breaker.
- `retryAfterMs` now reports the time **remaining** before a probe rather
  than always the full window, plus a standard `Retry-After` header in
  seconds.
- Attach the rate limit and `requireAdmin` to the route itself instead of
  via `router.use`, so mounting on the shared `/api/admin/users` prefix
  cannot apply this endpoint's limiter and guard to sibling routers'
  pass-through requests.

### `src/index.ts`

- Mount the router, ahead of the other `/api/admin/users` mounts.

### Docs / OpenAPI

- `docs/impersonate-circuit-breaker.md` rewritten to match the
  implementation (state machine, real option names, response shape).
- Registered the endpoint **and its 503** in `src/openapi/registry.ts`; it
  was absent from the served spec entirely.

## API behaviour

| Status | Cause |
|---|---|
| `200` | Impersonation token issued |
| `400` | `validation_error` — blank/whitespace `:address` |
| `403` | `forbidden` — missing, invalid, or non-admin JWT |
| `429` | `rate_limit_exceeded` |
| `503` | `service_unavailable` — circuit open, no downstream call attempted |

```json
{
  "error": {
    "code": "service_unavailable",
    "message": "Impersonate service is temporarily unavailable. Please retry later.",
    "retryAfterMs": 29974,
    "requestId": "<uuid>"
  }
}
```

Auth and validation run **before** the circuit check, so an unauthenticated
request is always 403 regardless of circuit state.

## Testing

| Check | Result |
|---|---|
| Circuit-breaker/impersonate suites | 7 suites, 126 tests passing |
| `tests/circuitBreaker.test.ts` | 25 failing → 38/38 passing |
| Coverage on changed files | 100% lines/statements/functions |
| ESLint on changed files | clean |
| Regression check (87 `createApp()` suites) | compared before/after — identical |

New tests cover the `Retry-After` header, the `retryAfterMs` countdown, the
legacy `resetTimeoutMs` alias, and router mounting itself
(`tests/impersonateRouteMounted.test.ts` — a 404 there means the router is
not mounted, the exact bug this PR fixes).

One pre-existing test passed `halfOpenAfterMs: 0` expecting the breaker
reads back as `OPEN`. That option was previously ignored; now that it works,
a 0 ms window makes the breaker immediately eligible for `HALF_OPEN`, so the
original assertion was unobservable. It now uses a real window, which makes
it strictly stronger.

## Known limitation, not introduced here

`main` is currently broken: `createApp()` throws
`ReferenceError: z is not defined` at import time, so the app does not boot.
The circuit breaker itself is correct and tested, but the endpoint cannot
serve live traffic until that is fixed. Details in a comment below. My
wiring test mocks the broken module so it verifies the mount without
depending on the bug.
