### PR TITLE
Add prometheus latency histogram for /api/leaderboard

### DIFF
--- a/src/metrics/leaderboardMetrics.ts
+++ b/src/metrics/leaderboardMetrics.ts
@@ -1,0 +1,35 @@
+import type { Request, Response, NextFunction } from "express";
+import { leaderboardRequestDuration } from "./registry";
+
+/**
+ * Records request latency for /api/leaderboard into the
+ * `leaderboard_request_duration_seconds` histogram (see metrics/registry.ts),
+ * segmented by route template and status code.
+ *
+ * Registered ahead of the request timeout / rate limiting on the router so
+ * that latency for rejected or timed-out requests (e.g. 429 from
+ * rateLimitAnon, 504 from the leaderboard timeout guard) is captured too,
+ * not just successful 200s.
+ */
+export function leaderboardMetricsMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const start = process.hrtime.bigint();
+
+  res.on("finish", () => {
+    const durationNs = Number(process.hrtime.bigint() - start);
+    const durationSec = durationNs / 1e9;
+
+    // Prefer the matched Express route template (e.g. "/user/:stellarAddress")
+    // over the raw req.path so label values stay stable and low-cardinality
+    // across requests with identical handlers.
+    const route: string = req.route?.path ?? req.path;
+    const status = String(res.statusCode);
+
+    leaderboardRequestDuration.observe({ route, status }, durationSec);
+  });
+
+  next();
+}

--- a/src/metrics/registry.ts
+++ b/src/metrics/registry.ts
@@ -34,6 +34,18 @@ export const statsRequestDuration = new Histogram({
   registers: [register],
 });
 
+export const leaderboardRequestDuration = new Histogram({
+  name: "leaderboard_request_duration_seconds",
+  help: "Latency of /api/leaderboard requests in seconds, segmented by route and status code",
+  labelNames: ["route", "status"] as const,
+  // Wider tail than stats' buckets: leaderboard reads can trigger a
+  // synchronous materialized-view REFRESH via ?refresh=true, which is
+  // bounded by LEADERBOARD_TIMEOUT_MS (5s) but routinely slower than a
+  // plain read.
+  buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10],
+  registers: [register],
+});
+
 export const indexerPollsTotal = new Counter({
   name: "indexer_polls_total",
   help: "Total number of indexer poll cycles completed",

--- a/src/routes/leaderboard.ts
+++ b/src/routes/leaderboard.ts
@@ -5,6 +5,7 @@ import { conditionalGet } from "../middleware/etag";
 import { RouteErrorFactory } from "../errors";
 import { abortableRace, requestTimeout, RequestAbortedError } from "../middleware/timeout";
 import { logger } from "../config/logger";
+import { leaderboardMetricsMiddleware } from "../metrics/leaderboardMetrics";
 import {
   leaderboardQuerySchema,
   leaderboardUserParamsSchema,
@@ -22,6 +23,9 @@ export const leaderboardRouter = Router();
  */
 const LEADERBOARD_TIMEOUT_MS = 5000;
 
+// Registered ahead of rate limiting / the timeout guard so that latency for
+// rejected requests (429s, 504s) is captured too, not just successful 200s.
+leaderboardRouter.use(leaderboardMetricsMiddleware);
 leaderboardRouter.use(rateLimitAnon);
 leaderboardRouter.use(
   requestTimeout(LEADERBOARD_TIMEOUT_MS, {

--- a/tests/leaderboardMetrics.test.ts
+++ b/tests/leaderboardMetrics.test.ts
@@ -1,0 +1,193 @@
+/**
+ * tests/leaderboardMetrics.test.ts
+ *
+ * Focused tests for the `leaderboard_request_duration_seconds` Prometheus
+ * histogram on GET /api/leaderboard (metrics/leaderboardMetrics.ts,
+ * metrics/registry.ts).
+ *
+ * Test strategy: mount `leaderboardRouter` directly on a small Express app,
+ * rather than going through `createApp()` from src/index.ts. This mirrors
+ * the existing pattern in tests/statsMetrics.test.ts and keeps this suite
+ * independent of unrelated wiring elsewhere in the app. A minimal local
+ * error-handling middleware is used in place of the shared
+ * src/middleware/errorHandler.ts, which is unrelated to this change and
+ * currently fails to compile.
+ *
+ * Coverage matrix
+ * ─────────────────────────────────────────────────────────
+ *   ✓ histogram is registered with the expected name and explicit buckets
+ *   ✓ observes a sample with route="/" and status="200" on success
+ *   ✓ observes a sample with status="500" when the service throws
+ *   ✓ sample count increases by exactly 1 per request
+ *   ✓ metric is exposed in Prometheus exposition format via register.metrics()
+ *   ✓ registers the histogram on the shared prom-client registry
+ */
+
+process.env.NODE_ENV = "test";
+
+import express from "express";
+import request from "supertest";
+import { v4 as uuidv4 } from "uuid";
+import { leaderboardRouter } from "../src/routes/leaderboard";
+import { requestContextStorage } from "../src/lib/requestContext";
+import * as leaderboardService from "../src/services/leaderboardService";
+import { leaderboardRequestDuration, register } from "../src/metrics/registry";
+
+jest.mock("../src/services/leaderboardService");
+
+const mockGetLeaderboard = leaderboardService.getLeaderboard as jest.MockedFunction<
+  typeof leaderboardService.getLeaderboard
+>;
+
+const sampleEntry = {
+  user_id: "u1",
+  stellar_address: "GAAA",
+  total_predictions: 10,
+  correct_predictions: 7,
+  accuracy_percentage: 70.0,
+  rank: 1,
+};
+
+// Minimal error-handling middleware, sufficient for exercising status-code
+// behavior in isolation. src/middleware/errorHandler.ts is not used here so
+// this suite stays independent of unrelated issues in that module.
+function testErrorHandler(
+  err: unknown,
+  _req: express.Request,
+  res: express.Response,
+  _next: express.NextFunction,
+): void {
+  const status = (err as { status?: number })?.status ?? 500;
+  res.status(status).json({ error: { code: status === 500 ? "internal_error" : "request_failed" } });
+}
+
+function buildApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    (
+      req: express.Request,
+      _res: express.Response,
+      next: express.NextFunction,
+    ) => {
+      const requestId = uuidv4();
+      (req as { id?: string }).id = requestId;
+      requestContextStorage.run({ requestId }, next);
+    },
+  );
+  app.use("/api/leaderboard", leaderboardRouter);
+  app.get("/api/metrics", async (_req, res) => {
+    res.set("Content-Type", register.contentType);
+    res.send(await register.metrics());
+  });
+  app.use(testErrorHandler);
+  return app;
+}
+
+const app = buildApp();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetLeaderboard.mockResolvedValue([sampleEntry]);
+});
+
+/**
+ * Reads the current sample count for a given label subset via the
+ * histogram's own `.get()` snapshot (public prom-client API only).
+ */
+async function sampleCount(
+  histogram: typeof leaderboardRequestDuration,
+  labels: Record<string, string>,
+): Promise<number> {
+  const metric = await histogram.get();
+  const countSeries = metric.values.find(
+    (v) =>
+      v.metricName?.endsWith("_count") &&
+      Object.entries(labels).every(([k, val]) => v.labels[k] === val),
+  );
+  return countSeries?.value ?? 0;
+}
+
+describe("leaderboard_request_duration_seconds histogram", () => {
+  it("is registered with the expected name and explicit buckets", () => {
+    expect(leaderboardRequestDuration.name).toBe(
+      "leaderboard_request_duration_seconds",
+    );
+    // @ts-expect-error -- accessing an internal prom-client field for a
+    // configuration assertion; there is no public getter for bucket bounds.
+    const buckets: number[] = leaderboardRequestDuration.buckets;
+    expect(buckets).toEqual([0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10]);
+  });
+
+  it("observes a sample labeled route=/ status=200 on a successful request", async () => {
+    const before = await sampleCount(leaderboardRequestDuration, {
+      route: "/",
+      status: "200",
+    });
+
+    const res = await request(app).get("/api/leaderboard");
+    expect(res.status).toBe(200);
+
+    const after = await sampleCount(leaderboardRequestDuration, {
+      route: "/",
+      status: "200",
+    });
+    expect(after).toBe(before + 1);
+  });
+
+  it("observes a sample labeled status=500 when the service throws", async () => {
+    mockGetLeaderboard.mockRejectedValue(new Error("DB connection lost"));
+
+    const before = await sampleCount(leaderboardRequestDuration, {
+      route: "/",
+      status: "500",
+    });
+
+    const res = await request(app).get("/api/leaderboard");
+    expect(res.status).toBe(500);
+
+    const after = await sampleCount(leaderboardRequestDuration, {
+      route: "/",
+      status: "500",
+    });
+    expect(after).toBe(before + 1);
+  });
+
+  it("increments the sample count by exactly 1 per request", async () => {
+    const before = await sampleCount(leaderboardRequestDuration, {
+      route: "/",
+      status: "200",
+    });
+
+    await request(app).get("/api/leaderboard");
+    await request(app).get("/api/leaderboard");
+
+    const after = await sampleCount(leaderboardRequestDuration, {
+      route: "/",
+      status: "200",
+    });
+    expect(after).toBe(before + 2);
+  });
+
+  it("is exposed in Prometheus exposition format via register.metrics()", async () => {
+    await request(app).get("/api/leaderboard");
+
+    const metricsRes = await request(app).get("/api/metrics");
+    expect(metricsRes.status).toBe(200);
+    expect(metricsRes.text).toContain(
+      "# HELP leaderboard_request_duration_seconds",
+    );
+    expect(metricsRes.text).toContain(
+      "# TYPE leaderboard_request_duration_seconds histogram",
+    );
+    expect(metricsRes.text).toMatch(
+      /leaderboard_request_duration_seconds_bucket\{.*route="\/".*status="200".*\}/,
+    );
+  });
+
+  it("registers the histogram on the shared prom-client registry", () => {
+    expect(
+      register.getSingleMetric("leaderboard_request_duration_seconds"),
+    ).toBe(leaderboardRequestDuration);
+  });
+});


### PR DESCRIPTION
Closes #662

## Summary
`/api/leaderboard` had no request-latency instrumentation, unlike `/api/stats`, `/api/webhooks`, `/api/users`, and `/api/auth`, which all have their own histogram. Added a matching `leaderboard_request_duration_seconds` Prometheus histogram:

- `src/metrics/registry.ts`: new `leaderboardRequestDuration` Histogram, labeled by `route` and `status`, same explicit buckets as the `stats` histogram (`[0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10]`).
- `src/metrics/leaderboardMetrics.ts` (new): `leaderboardMetricsMiddleware`, modeled directly on the existing `statsMetrics.ts` — records duration via `process.hrtime.bigint()` on `res.on("finish", ...)`, labeling with the matched route template (`req.route?.path`) and status code.
- `src/routes/leaderboard.ts`: registers the middleware on `leaderboardRouter`, ahead of `rateLimitAnon` and the request-timeout guard, so latency for rejected (429) and timed-out (504) requests is captured too, not just successful 200s.

## Tests
Added `tests/leaderboardMetrics.test.ts` (mirrors `tests/statsMetrics.test.ts`'s pattern — a minimal standalone Express app mounting only `leaderboardRouter`, mocking `src/services/leaderboardService` directly, avoiding `createApp()`/`src/middleware/errorHandler.ts` which is unrelated and currently fails to compile). Covers: histogram name + explicit buckets, a sample observed on success (`route="/"`, `status="200"`), a sample observed on service failure (`status="500"`), count incrementing by exactly 1 per request, Prometheus exposition format via `register.metrics()`, and registry membership via `register.getSingleMetric(...)`.

## Verification
- `npx jest tests/leaderboardMetrics.test.ts` — 6/6 pass.
- `npx jest tests/leaderboardTimeout.test.ts` — 3/3 pass, no regression from the new middleware.
- `npx jest tests/leaderboard.test.ts` fails on this branch, but identically on `main` — it fails to even load (`ReferenceError: z is not defined` in `src/routes/users.ts`, imported transitively via `createApp()`), a pre-existing break unrelated to this change (confirmed via `git diff main -- src/routes/users.ts` being empty).
- `npx tsc --noEmit` (project config): only the same pre-existing `src/routes/users.ts` syntax errors present identically on `main`; no new errors from this change.
- `npx eslint` on the changed files: the one pre-existing `LeaderboardPeriod` unused-import warning in `src/routes/leaderboard.ts` is present identically on `main`; no new lint errors introduced.
