### PR TITLE
Add /api/notifications/health dependency probe

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import { searchRouter } from "./routes/search";
 import { sessionsRouter } from "./routes/me/sessions";
 import { referralsRouter } from "./routes/referrals";
 import { notificationsRouter } from "./routes/notifications";
+import { notificationsHealthRouter } from "./routes/notifications/health";
 import { socialRouter } from "./routes/social";
 import { webhooksRouter } from "./routes/webhooks";
 import { webhooksHealthRouter } from "./routes/webhooks/health";
@@ -190,6 +191,7 @@ export function createApp(): express.Express {
   app.use("/api/rate-limit", rateLimitRouter);
   app.use("/api/search", searchRouter);
   app.use("/api/quota/requests", quotaRequestsRouter);
+  app.use("/api/notifications/health", notificationsHealthRouter);
   app.use("/api/notifications", notificationsRouter);
   app.use("/api/webhooks/health", webhooksHealthRouter);
   app.use("/api/users/health", usersHealthRouter);

--- a/src/routes/notifications/health.ts
+++ b/src/routes/notifications/health.ts
@@ -1,0 +1,92 @@
+import { randomUUID } from "crypto";
+import { NextFunction, Request, Response, Router } from "express";
+import { pool } from "../../db/client";
+import { logger } from "../../config/logger";
+import { getRequestId } from "../../lib/requestContext";
+
+export interface NotificationsHealthDependencyStatus {
+  status: "ok" | "down";
+  latencyMs: number;
+  error?: string;
+}
+
+export interface NotificationsHealthRouterDeps {
+  probeDatabase?: () => Promise<NotificationsHealthDependencyStatus>;
+}
+
+function resolveCorrelationId(req: Request, res: Response): string {
+  const resCorrelationId = res.locals.correlationId as string | undefined;
+  const headerValue = [req.headers["x-correlation-id"], req.headers["x-request-id"]]
+    .find((value): value is string => typeof value === "string" && value.trim().length > 0);
+
+  return (resCorrelationId ?? headerValue?.trim() ?? getRequestId() ?? randomUUID()).trim();
+}
+
+async function defaultProbeDatabase(): Promise<NotificationsHealthDependencyStatus> {
+  const startedAt = Date.now();
+
+  try {
+    await pool.query("SELECT 1");
+    return {
+      status: "ok",
+      latencyMs: Date.now() - startedAt,
+    };
+  } catch (error) {
+    return {
+      status: "down",
+      latencyMs: Date.now() - startedAt,
+      error: error instanceof Error ? error.message : "Database health probe failed",
+    };
+  }
+}
+
+/**
+ * Creates the /api/notifications/health router with injected dependencies.
+ *
+ * @param deps - Override probe functions for testing. Defaults to production
+ *               implementations that hit real Postgres.
+ */
+export function createNotificationsHealthRouter(
+  deps: NotificationsHealthRouterDeps = {},
+): Router {
+  const probeDatabase = deps.probeDatabase ?? defaultProbeDatabase;
+  const router = Router();
+
+  router.get("/", async (req: Request, res: Response, next: NextFunction) => {
+    const correlationId = resolveCorrelationId(req, res);
+    const startedAt = Date.now();
+
+    try {
+      const database = await probeDatabase();
+      const status = database.status === "ok" ? "ok" : "down";
+      const httpStatus = status === "ok" ? 200 : 503;
+
+      logger.info(
+        {
+          correlationId,
+          status,
+          database,
+          elapsedMs: Date.now() - startedAt,
+        },
+        "notifications_health_checked",
+      );
+
+      return res.status(httpStatus).json({
+        status,
+        correlationId,
+        checkedAt: new Date().toISOString(),
+        dependencies: {
+          database,
+        },
+      });
+    } catch (error) {
+      logger.error({ correlationId, error }, "notifications_health_probe_failed");
+      return next(error);
+    }
+  });
+
+  return router;
+}
+
+/** Production router instance wired into src/index.ts. */
+export const notificationsHealthRouter = createNotificationsHealthRouter();

--- a/tests/routes/notifications/health.test.ts
+++ b/tests/routes/notifications/health.test.ts
@@ -1,0 +1,77 @@
+import express from "express";
+import request from "supertest";
+import {
+  createNotificationsHealthRouter,
+  NotificationsHealthDependencyStatus,
+} from "../../../src/routes/notifications/health";
+
+function buildApp(
+  probeDatabase: () => Promise<NotificationsHealthDependencyStatus>,
+): express.Express {
+  const app = express();
+  app.use(
+    "/api/notifications/health",
+    createNotificationsHealthRouter({ probeDatabase }),
+  );
+  app.use(
+    (err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+      res.status(500).json({ error: err instanceof Error ? err.message : "unknown" });
+    },
+  );
+  return app;
+}
+
+describe("GET /api/notifications/health", () => {
+  it("returns 200 with status ok when the database probe succeeds", async () => {
+    const app = buildApp(async () => ({ status: "ok", latencyMs: 5 }));
+
+    const res = await request(app).get("/api/notifications/health");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("ok");
+    expect(res.body.dependencies.database).toEqual({ status: "ok", latencyMs: 5 });
+    expect(typeof res.body.correlationId).toBe("string");
+    expect(res.body.correlationId.length).toBeGreaterThan(0);
+    expect(typeof res.body.checkedAt).toBe("string");
+  });
+
+  it("returns 503 with status down when the database probe fails", async () => {
+    const app = buildApp(async () => ({
+      status: "down",
+      latencyMs: 12,
+      error: "connection refused",
+    }));
+
+    const res = await request(app).get("/api/notifications/health");
+
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe("down");
+    expect(res.body.dependencies.database).toEqual({
+      status: "down",
+      latencyMs: 12,
+      error: "connection refused",
+    });
+  });
+
+  it("echoes an incoming x-correlation-id header", async () => {
+    const app = buildApp(async () => ({ status: "ok", latencyMs: 1 }));
+
+    const res = await request(app)
+      .get("/api/notifications/health")
+      .set("x-correlation-id", "test-correlation-123");
+
+    expect(res.status).toBe(200);
+    expect(res.body.correlationId).toBe("test-correlation-123");
+  });
+
+  it("passes probe errors to the error handler instead of crashing", async () => {
+    const app = buildApp(async () => {
+      throw new Error("probe exploded");
+    });
+
+    const res = await request(app).get("/api/notifications/health");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("probe exploded");
+  });
+});


### PR DESCRIPTION
Closes #663

## Summary
Added a focused health-check endpoint for the notifications subsystem, listing its external dependencies with status — mirroring the existing per-resource health probes already in this repo (`/api/users/health`, `/api/webhooks/health`, `/api/markets/health`):

- `src/routes/notifications/health.ts` (new): `GET /` probes Postgres (the only external dependency `notificationService`/`notificationPrefs` rely on — confirmed via their imports) via `SELECT 1`, and responds `200` (`status: "ok"`) or `503` (`status: "down"`) with a `{ status, correlationId, checkedAt, dependencies: { database } }` envelope. Follows the exact same injectable-probe factory shape as `src/routes/users/health.ts` (`createNotificationsHealthRouter(deps)`), so tests can substitute a fully-controlled stub without touching real infrastructure.
- `src/index.ts`: wires the new router at `/api/notifications/health`, registered **before** the main `notificationsRouter` at `/api/notifications`. This ordering matters — `notificationsRouter` applies `requireAuth` via router-level `.use()`, which would otherwise gate this (deliberately unauthenticated) health check behind auth. This mirrors the existing `/api/users/health` vs `/api/users` ordering in the same file.

## Tests
Added `tests/routes/notifications/health.test.ts` (4 cases): 200 on a healthy probe, 503 on a failing probe, correlation ID echoed from an `x-correlation-id` request header, and probe errors forwarded to `next(err)` rather than crashing the process.

## Verification
- `npx jest tests/routes/notifications/health.test.ts` — 4/4 pass.
- `npx tsc --noEmit` (project config): only pre-existing `src/routes/users.ts` syntax errors present identically on `main`; no new errors from this change.
- `npx eslint` on the changed files: the 5 pre-existing `no-unused-vars` warnings in `src/index.ts` (e.g. `adminRouter`, `webhooksRouter`) are present identically on `main`, on lines untouched by this diff; no new lint errors introduced.
