### PR TITLE
Add response schema stability test for /api/subscriptions

### DIFF
--- a/tests/schema/__snapshots__/subscriptions.test.ts.snap
+++ b/tests/schema/__snapshots__/subscriptions.test.ts.snap
@@ -1,0 +1,89 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`/api/subscriptions response schema stability GET / — matches the stable empty-list shape 1`] = `
+{
+  "data": [],
+}
+`;
+
+exports[`/api/subscriptions response schema stability GET / — matches the stable list shape (secret stripped) 1`] = `
+{
+  "data": [
+    {
+      "active": true,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "events": [
+        "market.created",
+        "prediction.settled",
+      ],
+      "id": "123e4567-e89b-12d3-a456-426614174000",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "url": "https://example.com/webhook",
+    },
+  ],
+}
+`;
+
+exports[`/api/subscriptions response schema stability GET /:id — matches the stable not-found error shape 1`] = `
+{
+  "error": {
+    "code": "not_found",
+    "correlationId": Any<String>,
+    "message": "Subscription not found",
+  },
+}
+`;
+
+exports[`/api/subscriptions response schema stability GET /:id — matches the stable single-resource shape 1`] = `
+{
+  "data": {
+    "active": true,
+    "createdAt": "2026-01-01T00:00:00.000Z",
+    "events": [
+      "market.created",
+      "prediction.settled",
+    ],
+    "id": "123e4567-e89b-12d3-a456-426614174000",
+    "updatedAt": "2026-01-01T00:00:00.000Z",
+    "url": "https://example.com/webhook",
+  },
+}
+`;
+
+exports[`/api/subscriptions response schema stability POST / — matches the stable creation shape (secret included once) 1`] = `
+{
+  "data": {
+    "active": true,
+    "createdAt": "2026-01-01T00:00:00.000Z",
+    "events": [
+      "market.created",
+      "prediction.settled",
+    ],
+    "id": "123e4567-e89b-12d3-a456-426614174000",
+    "secret": Any<String>,
+    "updatedAt": "2026-01-01T00:00:00.000Z",
+    "url": "https://example.com/webhook",
+  },
+}
+`;
+
+exports[`/api/subscriptions response schema stability POST / — matches the stable validation-error shape 1`] = `
+{
+  "error": {
+    "code": "validation_error",
+    "correlationId": Any<String>,
+    "details": [
+      {
+        "code": "invalid_type",
+        "expected": "string",
+        "message": "url is required",
+        "path": [
+          "url",
+        ],
+        "received": "undefined",
+      },
+    ],
+    "message": "Validation failed",
+  },
+}
+`;

--- a/tests/schema/subscriptions.test.ts
+++ b/tests/schema/subscriptions.test.ts
@@ -1,0 +1,142 @@
+/**
+ * tests/schema/subscriptions.test.ts
+ *
+ * Snapshot-based response-shape stability tests for /api/subscriptions.
+ * These complement the behavioral assertions in tests/subscriptions.test.ts
+ * by pinning the exact JSON shape returned to clients, so an accidental
+ * field rename/addition/removal shows up as a snapshot diff in review
+ * rather than silently shipping.
+ */
+
+jest.mock("../../src/middleware/requireAdmin", () => ({
+  requireAdmin: (
+    _req: import("express").Request,
+    _res: import("express").Response,
+    next: import("express").NextFunction,
+  ) => next(),
+}));
+
+jest.mock("../../src/config/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock("../../src/services/auditService", () => ({
+  createAuditLog: jest.fn().mockResolvedValue("corr-id"),
+  sanitizeState: jest.fn((state: unknown) => state),
+}));
+
+const mockSelectWhere = jest.fn();
+const mockFrom = jest.fn(() => ({ where: mockSelectWhere }));
+const mockReturning = jest.fn();
+const mockValues = jest.fn(() => ({ returning: mockReturning }));
+const mockInsert = jest.fn(() => ({ values: mockValues }));
+const mockSelect = jest.fn(() => ({ from: mockFrom }));
+
+jest.mock("../../src/db/client", () => ({
+  db: {
+    select: (...args: unknown[]) => mockSelect(...args),
+    insert: (...args: unknown[]) => mockInsert(...args),
+  },
+}));
+
+import request from "supertest";
+import express from "express";
+import { subscriptionsRouter } from "../../src/routes/subscriptions";
+import { errorHandler } from "../../src/middleware/errorHandler";
+
+const VALID_UUID = "123e4567-e89b-12d3-a456-426614174000";
+
+const mockSubscription = {
+  id: VALID_UUID,
+  url: "https://example.com/webhook",
+  secret: "super-secret-hmac-key",
+  events: ["market.created", "prediction.settled"],
+  active: true,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+};
+
+function makeApp(): express.Application {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/subscriptions", subscriptionsRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+describe("/api/subscriptions response schema stability", () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = makeApp();
+    mockFrom.mockReturnValue({ where: mockSelectWhere });
+  });
+
+  it("GET / — matches the stable list shape (secret stripped)", async () => {
+    mockFrom.mockResolvedValueOnce([mockSubscription]);
+
+    const res = await request(app).get("/api/subscriptions");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchSnapshot();
+  });
+
+  it("GET / — matches the stable empty-list shape", async () => {
+    mockFrom.mockResolvedValueOnce([]);
+
+    const res = await request(app).get("/api/subscriptions");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchSnapshot();
+  });
+
+  it("POST / — matches the stable creation shape (secret included once)", async () => {
+    mockReturning.mockResolvedValueOnce([mockSubscription]);
+
+    const res = await request(app)
+      .post("/api/subscriptions")
+      .send({ url: "https://example.com/webhook", events: ["market.created"] });
+
+    expect(res.status).toBe(201);
+    // `secret` in the real handler is a freshly generated uuidv4() per request,
+    // not the stored row's secret, so it varies run-to-run; pin its shape
+    // (a string) rather than its value.
+    expect(res.body).toMatchSnapshot({
+      data: { secret: expect.any(String) },
+    });
+  });
+
+  it("POST / — matches the stable validation-error shape", async () => {
+    const res = await request(app)
+      .post("/api/subscriptions")
+      .send({ events: ["market.created"] });
+
+    expect(res.status).toBe(400);
+    // correlationId is a fresh randomUUID() per request outside of
+    // requestContextStorage, so it varies run-to-run; pin its shape only.
+    expect(res.body).toMatchSnapshot({
+      error: { correlationId: expect.any(String) },
+    });
+  });
+
+  it("GET /:id — matches the stable single-resource shape", async () => {
+    mockSelectWhere.mockResolvedValueOnce([mockSubscription]);
+
+    const res = await request(app).get(`/api/subscriptions/${VALID_UUID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchSnapshot();
+  });
+
+  it("GET /:id — matches the stable not-found error shape", async () => {
+    mockSelectWhere.mockResolvedValueOnce([]);
+
+    const res = await request(app).get(`/api/subscriptions/${VALID_UUID}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchSnapshot({
+      error: { correlationId: expect.any(String) },
+    });
+  });
+});


### PR DESCRIPTION
Closes #668

## Summary
Added `tests/schema/subscriptions.test.ts`, a snapshot-based response-shape stability suite for `/api/subscriptions`, following this repo's existing `tests/schema/` convention (e.g. `rate-limit.test.ts`, `alerts.test.ts`). Pins the exact JSON returned for:

- `GET /` — list shape (secret stripped) and empty-list shape
- `POST /` — creation shape (secret included once)
- `POST /` — validation-error shape
- `GET /:id` — single-resource shape and not-found error shape

Two response fields are non-deterministic per request outside this test's control — the freshly generated `secret` (a `uuidv4()` minted per `POST /`) and `correlationId` on error responses (a `randomUUID()` fallback outside `requestContextStorage`) — both are pinned with `expect.any(String)` property matchers rather than snapshotted by value, so the suite stays deterministic across runs while still catching shape drift.

This complements the existing behavioral coverage in `tests/subscriptions.test.ts` (explicit field-by-field assertions for CRUD + validators) rather than duplicating it — the new file's only job is catching accidental shape drift (a renamed/added/removed field) via snapshot diff.

## Verification
- `npx jest tests/schema/subscriptions.test.ts` — 6/6 pass, run twice back-to-back to confirm the snapshots are stable (second run reports "6 passed" against the committed snapshot file, not "6 written").
- `npx jest tests/subscriptions.test.ts` (pre-existing file, unmodified) — 67/68 pass; one pre-existing failure (`DELETE /:id` expects 204, receives 404) reproduces identically on `main` (`git diff main --stat` shows zero modifications to any tracked file in this PR), unrelated to this change.
- `npx tsc --noEmit` (project config): only the pre-existing `src/routes/users.ts` syntax errors present identically on `main`.
- `npx eslint tests/schema/subscriptions.test.ts` — clean, no errors.
