### PR TITLE
Add Idempotency-Key support on /api/health mutations

### DIFF
--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -5,6 +5,7 @@ import { db } from "../db/client";
 import { auditLogs } from "../db/schema";
 import { eq, desc } from "drizzle-orm";
 import { requestTimeout, abortableRace } from "../middleware/timeout";
+import { idempotency } from "../middleware/idempotency";
 
 export const healthRouter = Router();
 
@@ -30,7 +31,11 @@ healthRouter.get("/", async (_req, res, next) => {
   }
 });
 
-healthRouter.post("/mutations", async (req, res, next) => {
+// The global Idempotency-Key middleware (src/index.ts) is registered after
+// this router's /api/health mount, so it never runs for this route; applying
+// it here directly makes retried mutations (e.g. after a client-side timeout)
+// safe without double-writing audit log entries.
+healthRouter.post("/mutations", idempotency, async (req, res, next) => {
   try {
     const ip = req.ip || req.socket.remoteAddress || "unknown";
     const correlationId = getRequestId();

--- a/tests/healthIdempotency.test.ts
+++ b/tests/healthIdempotency.test.ts
@@ -1,0 +1,172 @@
+/**
+ * tests/healthIdempotency.test.ts
+ *
+ * Verifies POST /api/health/mutations is protected by the Idempotency-Key
+ * middleware (issue #665). The global idempotency middleware in src/index.ts
+ * is registered *after* /api/health, so it never runs for this route;
+ * src/routes/health.ts now applies it directly on the /mutations route.
+ *
+ * The db mock is a small stateful in-memory map (mirrors the approach in
+ * tests/authIdempotency.test.ts) so persist-then-replay round trips can be
+ * exercised without a real database.
+ */
+
+import { auditLogs, idempotencyRecords } from "../src/db/schema";
+
+const idempotencyStore = new Map<string, Record<string, unknown>>();
+
+// src/middleware/timeout.ts's requestTimeout() aborts res.locals.abortSignal
+// on the request's "close" event, which — independent of this change — can
+// fire under supertest before the response is fully sent, racing
+// abortableRace() in the health route handler. That's a pre-existing,
+// unrelated issue (reproduces with requestTimeout + abortableRace alone, no
+// idempotency involved); stub both out here so this suite stays focused on
+// idempotency behavior specifically.
+jest.mock("../src/middleware/timeout", () => ({
+  requestTimeout: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+  abortableRace: (promise: Promise<unknown>) => promise,
+}));
+
+// src/middleware/idempotency.ts reads/writes via "../db" (src/db/index.ts) —
+// a separate module/instance from "../db/client", which the health route
+// itself uses for its own auditLogs query below.
+jest.mock("../src/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => Array.from(idempotencyStore.values()),
+        }),
+      }),
+    }),
+    insert: () => ({
+      values: async (record: Record<string, unknown>) => {
+        idempotencyStore.set(record.key as string, record);
+      },
+    }),
+  },
+}));
+
+jest.mock("../src/db/client", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => ({
+            limit: async () => [
+              { afterState: { mode: "active", maintenance: false } },
+            ],
+          }),
+        }),
+      }),
+    }),
+  },
+  pool: { query: jest.fn() },
+}));
+
+jest.mock("../src/services/auditService", () => ({
+  createAuditLog: jest.fn().mockResolvedValue("mock-correlation-id"),
+}));
+
+import express from "express";
+import request from "supertest";
+import { healthRouter } from "../src/routes/health";
+import { errorHandler } from "../src/middleware/errorHandler";
+import { createAuditLog } from "../src/services/auditService";
+
+const mockCreateAuditLog = createAuditLog as jest.MockedFunction<typeof createAuditLog>;
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/health", healthRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+let app: express.Express;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  idempotencyStore.clear();
+  app = makeApp();
+});
+
+describe("Idempotency for POST /api/health/mutations", () => {
+  it("replays the stored response for a repeated Idempotency-Key + body", async () => {
+    const key = "health-mutation-key-1";
+    const body = { mode: "maintenance", maintenance: true };
+
+    const first = await request(app)
+      .post("/api/health/mutations")
+      .set("Idempotency-Key", key)
+      .send(body);
+
+    expect(first.status).toBe(200);
+    expect(first.headers["idempotent-replayed"]).toBeUndefined();
+    expect(first.body.status).toBe("updated");
+    expect(mockCreateAuditLog).toHaveBeenCalledTimes(1);
+
+    const second = await request(app)
+      .post("/api/health/mutations")
+      .set("Idempotency-Key", key)
+      .send(body);
+
+    expect(second.status).toBe(200);
+    expect(second.headers["idempotent-replayed"]).toBe("true");
+    expect(second.body).toEqual(first.body);
+    // The route handler (and its audit log write) must not run a second time.
+    expect(mockCreateAuditLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 409 when the same Idempotency-Key is reused with a different body", async () => {
+    const key = "health-mutation-key-2";
+
+    await request(app)
+      .post("/api/health/mutations")
+      .set("Idempotency-Key", key)
+      .send({ mode: "maintenance", maintenance: true })
+      .expect(200);
+
+    const conflict = await request(app)
+      .post("/api/health/mutations")
+      .set("Idempotency-Key", key)
+      .send({ mode: "active", maintenance: false })
+      .expect(409);
+
+    expect(conflict.body.error.code).toBe("conflict");
+    expect(mockCreateAuditLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 400 for a malformed Idempotency-Key", async () => {
+    const res = await request(app)
+      .post("/api/health/mutations")
+      .set("Idempotency-Key", "a".repeat(256))
+      .send({ mode: "maintenance", maintenance: true });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("invalid_idempotency_key");
+    expect(mockCreateAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("processes every request independently when no Idempotency-Key is sent", async () => {
+    await request(app)
+      .post("/api/health/mutations")
+      .send({ mode: "maintenance", maintenance: true })
+      .expect(200);
+
+    await request(app)
+      .post("/api/health/mutations")
+      .send({ mode: "maintenance", maintenance: true })
+      .expect(200);
+
+    expect(mockCreateAuditLog).toHaveBeenCalledTimes(2);
+  });
+});
+
+// Sanity check that the schema imports used to build the mock actually exist.
+describe("schema sanity", () => {
+  it("idempotencyRecords and auditLogs are distinct table objects", () => {
+    expect(idempotencyRecords).not.toBe(auditLogs);
+  });
+});


### PR DESCRIPTION
Closes #665

## Summary
`POST /api/health/mutations` writes an audit-log row on every call, recording a before/after state transition (`mode`/`maintenance`). A client retry after a network blip (e.g. a response that timed out client-side after the write actually succeeded server-side) silently creates a duplicate mutation record, with no way to detect or dedupe it.

This repo already has a general-purpose Idempotency-Key middleware (`src/middleware/idempotency.ts`), applied globally to `/api` POST/PATCH routes in `src/index.ts` — but that global registration happens **after** `app.use("/api/health", healthRouter)`, so it never actually runs for this route (Express matches middleware in registration order; the request is fully handled by `healthRouter` before ever reaching the later `idempotency` mount).

Fix: apply `idempotency` directly as route-level middleware on `POST /mutations` in `src/routes/health.ts`, so retried requests with the same `Idempotency-Key` + body replay the original response instead of re-executing the mutation (and re-writing the audit log). Requests without the header are unaffected — the middleware is a no-op when no key is present.

## Tests
Added `tests/healthIdempotency.test.ts` (5 cases): replay on a repeated key+body (audit log written exactly once across two identical requests), 409 conflict when the same key is reused with a different body, 400 for a malformed key, independent processing when no key header is sent, and a schema sanity check. Uses a small stateful in-memory map for the `db` mock (mirroring the existing `tests/authIdempotency.test.ts` pattern) so persist-then-replay round trips can be exercised without a real database.

**Note on `src/middleware/timeout.ts`:** while writing these tests I found that `requestTimeout`'s `req.on("close", () => abort())` handler fires under `supertest` before the response finishes, causing `abortableRace` to reject in-flight promises — this reproduces in total isolation (a two-line Express app with just `requestTimeout` + `abortableRace`, no idempotency or health-route code involved) and is unrelated to this change (confirmed `git diff main -- src/middleware/timeout.ts` is empty). It's out of scope for this issue since `requestTimeout` is shared by most routes in this codebase and warrants its own investigation; I stubbed both `requestTimeout` and `abortableRace` as pass-throughs in this test file so the idempotency suite isn't flaky because of it.

## Verification
- `npx jest tests/healthIdempotency.test.ts` — 5/5 pass.
- `npx tsc --noEmit` (project config): only the pre-existing `src/routes/users.ts` syntax errors present identically on `main`.
- `npx eslint src/routes/health.ts tests/healthIdempotency.test.ts` — clean, no errors.
