### PR TITLE
fix(impersonate): apply API security headers

### DIFF
--- a/src/routes/admin/users/impersonate.ts
+++ b/src/routes/admin/users/impersonate.ts
@@ -39,6 +39,7 @@ import { signAccessToken } from "../../../services/jwtService";
 import { createAuditLog } from "../../../services/auditService";
 import { getRequestId } from "../../../lib/requestContext";
 import { logger } from "../../../config/logger";
+import { securityHeaders } from "../../../middleware/securityHeaders";
 import { db } from "../../../db/client";
 import { adminAuditLog } from "../../../db/schema";
 import {
@@ -88,6 +89,7 @@ export function createAdminImpersonateRouter(
   // merely pass through on their way to a later mount.
   router.post(
     "/:address/impersonate",
+    securityHeaders,
     impersonateRateLimit,
     requireAdmin,
     async (req, res, next) => {

--- a/tests/adminImpersonate.test.ts
+++ b/tests/adminImpersonate.test.ts
@@ -53,6 +53,16 @@ describe("POST /api/admin/users/:address/impersonate", () => {
     expect(res.body).toEqual({ error: { code: "forbidden" } });
   });
 
+  it("sets API security headers on rejected impersonation requests", async () => {
+    const res = await request(makeApp()).post(`/api/admin/users/${USER_ADDRESS}/impersonate`).send({});
+
+    expect(res.headers["content-security-policy"]).toBe(
+      "default-src 'none'; frame-ancestors 'none'; base-uri 'none'",
+    );
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+    expect(res.headers["referrer-policy"]).toBe("no-referrer");
+  });
+
   it("returns 403 with a non-admin JWT", async () => {
     const res = await request(makeApp())
       .post(`/api/admin/users/${USER_ADDRESS}/impersonate`)


### PR DESCRIPTION
Applies the existing strict API security-header middleware to the exact impersonation route, including rejected responses from the admin guard.

Focused coverage verifies CSP, X-Content-Type-Options, and Referrer-Policy headers.

Closes #860