### PR TITLE
feat: add cursor-based keyset pagination to leaderboard API

### DIFF
--- a/LEADERBOARD_API.md
+++ b/LEADERBOARD_API.md
@@ -15,7 +15,8 @@ This implementation extends the `/api/leaderboard` endpoint to support time-peri
 All parameters are validated using Zod with type-safe enums:
 - `period`: One of `all-time`, `monthly`, `weekly` (validated enum)
 - `limit`: 1-100 (default: 50)
-- `offset`: Non-negative integer (default: 0)
+- `offset`: Non-negative integer (default: 0) — legacy; prefer `cursor`
+- `cursor`: Opaque pagination token from a previous response's `nextCursor` (optional)
 - `refresh`: Boolean flag for manual refresh (default: false)
 
 Invalid periods return a `400 Bad Request` error.
@@ -48,7 +49,8 @@ Returns paginated leaderboard entries for a specified period.
 |-----------|------|---------|-------------|
 | `period` | enum | `all-time` | `all-time`, `monthly`, `weekly` |
 | `limit` | number | 50 | 1-100 |
-| `offset` | number | 0 | ≥ 0 |
+| `offset` | number | 0 | ≥ 0 (legacy; ignored when `cursor` is provided) |
+| `cursor` | string | — | Opaque token from previous response's `nextCursor` |
 | `refresh` | boolean | false | true/false |
 
 **Response (200 OK):**
@@ -64,6 +66,7 @@ Returns paginated leaderboard entries for a specified period.
       "rank": 1
     }
   ],
+  "nextCursor": "djF8MTApMDAwMDAwMDAwMXx1c2VyLTEyMw",
   "meta": {
     "limit": 50,
     "offset": 0,
@@ -74,15 +77,25 @@ Returns paginated leaderboard entries for a specified period.
 }
 ```
 
+The `nextCursor` field is present when there are additional pages.  Pass its value
+as `?cursor=` in the next request to retrieve the following page.  When there are
+no more results `nextCursor` is omitted.
+
 **Example Requests:**
 ```bash
-# Get all-time leaderboard (default)
+# Get all-time leaderboard (default) — cursor-based first page
 GET /api/leaderboard
 
 # Get monthly leaderboard
 GET /api/leaderboard?period=monthly
 
-# Get weekly leaderboard with custom pagination
+# Get weekly leaderboard (first page, limit 25)
+GET /api/leaderboard?period=weekly&limit=25
+
+# Cursor-based pagination — use nextCursor from previous response
+GET /api/leaderboard?cursor=v1|10|0000000001|user-123
+
+# Legacy offset-based pagination (still supported)
 GET /api/leaderboard?period=weekly&limit=25&offset=50
 
 # Force refresh of weekly data
@@ -190,7 +203,8 @@ WHERE total_predictions > 0
 
 ### Caching Strategy
 - **Cache keys** include period, limit, and offset to serve different paginations separately
-- **TTL of 5 minutes** balances freshness with database load
+- **First page (no cursor)** is cached under `leaderboard:{period}:{limit}:0` (TTL = 5 min)
+- **Cursor-based pages** are not cached (each cursor is unique, making caching ineffective)
 - **Automatic invalidation** via `invalidatePeriodCache()` after view refresh
 - **Resilient design** continues serving if cache fails (cache write errors logged but not thrown)
 

--- a/src/__tests__/routes/leaderboard.test.ts
+++ b/src/__tests__/routes/leaderboard.test.ts
@@ -7,6 +7,10 @@ import * as leaderboardService from "../../services/leaderboardService";
 
 // Mock the service
 jest.mock("../../services/leaderboardService");
+jest.mock("../../utils/cursor", () => {
+  const actual = jest.requireActual("../../utils/cursor");
+  return { ...actual };
+});
 
 // Mock the logger to avoid noise in test output
 jest.mock("../../config/logger", () => ({
@@ -31,7 +35,7 @@ describe("Leaderboard Routes", () => {
   };
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
     app = express();
     app.use(express.json());
     app.use("/api/leaderboard", leaderboardRouter);
@@ -39,9 +43,10 @@ describe("Leaderboard Routes", () => {
 
   describe("GET /api/leaderboard", () => {
     it("should return leaderboard with default parameters", async () => {
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
-        mockLeaderboardEntry,
-      ]);
+      (leaderboardService.getLeaderboardPage as any).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
 
       const response = await request(app).get("/api/leaderboard");
 
@@ -57,37 +62,39 @@ describe("Leaderboard Routes", () => {
     });
 
     it("should accept period parameter", async () => {
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
-        mockLeaderboardEntry,
-      ]);
+      (leaderboardService.getLeaderboardPage as any).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
 
       const response = await request(app)
         .get("/api/leaderboard")
         .query({ period: "monthly" });
 
       expect(response.status).toBe(200);
-      expect(leaderboardService.getLeaderboard).toHaveBeenCalledWith(
+      expect(leaderboardService.getLeaderboardPage).toHaveBeenCalledWith(
         50,
-        0,
         "monthly",
+        undefined,
       );
       expect(response.body.meta.period).toBe("monthly");
     });
 
     it("should accept weekly period", async () => {
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
-        mockLeaderboardEntry,
-      ]);
+      (leaderboardService.getLeaderboardPage as any).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
 
       const response = await request(app)
         .get("/api/leaderboard")
         .query({ period: "weekly" });
 
       expect(response.status).toBe(200);
-      expect(leaderboardService.getLeaderboard).toHaveBeenCalledWith(
+      expect(leaderboardService.getLeaderboardPage).toHaveBeenCalledWith(
         50,
-        0,
         "weekly",
+        undefined,
       );
       expect(response.body.meta.period).toBe("weekly");
     });
@@ -104,19 +111,20 @@ describe("Leaderboard Routes", () => {
     });
 
     it("should accept limit parameter", async () => {
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
-        mockLeaderboardEntry,
-      ]);
+      (leaderboardService.getLeaderboardPage as any).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
 
       const response = await request(app)
         .get("/api/leaderboard")
         .query({ limit: 25 });
 
       expect(response.status).toBe(200);
-      expect(leaderboardService.getLeaderboard).toHaveBeenCalledWith(
+      expect(leaderboardService.getLeaderboardPage).toHaveBeenCalledWith(
         25,
-        0,
         "all-time",
+        undefined,
       );
       expect(response.body.meta.limit).toBe(25);
     });
@@ -195,59 +203,68 @@ describe("Leaderboard Routes", () => {
 
     it("should support refresh parameter with all-time period", async () => {
       (
-        leaderboardService.getLeaderboardWithRefresh as jest.Mock
-      ).mockResolvedValueOnce([mockLeaderboardEntry]);
+        leaderboardService.getLeaderboardPageWithRefresh as jest.Mock
+      ).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
 
       const response = await request(app)
         .get("/api/leaderboard")
         .query({ refresh: true });
 
       expect(response.status).toBe(200);
-      expect(leaderboardService.getLeaderboardWithRefresh).toHaveBeenCalledWith(
+      expect(leaderboardService.getLeaderboardPageWithRefresh).toHaveBeenCalledWith(
         50,
-        0,
         "all-time",
+        undefined,
       );
       expect(response.body.meta.refresh).toBe(true);
     });
 
     it("should support refresh parameter with monthly period", async () => {
       (
-        leaderboardService.getLeaderboardWithRefresh as jest.Mock
-      ).mockResolvedValueOnce([mockLeaderboardEntry]);
+        leaderboardService.getLeaderboardPageWithRefresh as jest.Mock
+      ).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
 
       const response = await request(app)
         .get("/api/leaderboard")
         .query({ refresh: true, period: "monthly" });
 
       expect(response.status).toBe(200);
-      expect(leaderboardService.getLeaderboardWithRefresh).toHaveBeenCalledWith(
+      expect(leaderboardService.getLeaderboardPageWithRefresh).toHaveBeenCalledWith(
         50,
-        0,
         "monthly",
+        undefined,
       );
     });
 
     it("should support refresh parameter with weekly period", async () => {
       (
-        leaderboardService.getLeaderboardWithRefresh as jest.Mock
-      ).mockResolvedValueOnce([mockLeaderboardEntry]);
+        leaderboardService.getLeaderboardPageWithRefresh as jest.Mock
+      ).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
 
       const response = await request(app)
         .get("/api/leaderboard")
         .query({ refresh: true, period: "weekly" });
 
       expect(response.status).toBe(200);
-      expect(leaderboardService.getLeaderboardWithRefresh).toHaveBeenCalledWith(
+      expect(leaderboardService.getLeaderboardPageWithRefresh).toHaveBeenCalledWith(
         50,
-        0,
         "weekly",
+        undefined,
       );
     });
 
     it("should return empty array when no results", async () => {
-      (leaderboardService.getLeaderboard as jest.Mock).mockResolvedValueOnce(
-        [],
+      (leaderboardService.getLeaderboardPage as jest.Mock).mockResolvedValueOnce(
+        { entries: [], nextCursor: null },
       );
 
       const response = await request(app).get("/api/leaderboard");
@@ -258,7 +275,7 @@ describe("Leaderboard Routes", () => {
     });
 
     it("should handle service errors", async () => {
-      (leaderboardService.getLeaderboard as jest.Mock).mockRejectedValueOnce(
+      (leaderboardService.getLeaderboardPage as jest.Mock).mockRejectedValueOnce(
         new Error("Database error"),
       );
 
@@ -268,7 +285,7 @@ describe("Leaderboard Routes", () => {
     });
 
     it("should coerce string parameters to correct types", async () => {
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
+      (leaderboardService.getLeaderboardWithRefresh as any).mockResolvedValueOnce([
         mockLeaderboardEntry,
       ]);
 
@@ -277,7 +294,7 @@ describe("Leaderboard Routes", () => {
         .query({ limit: "25", offset: "50", refresh: "true" });
 
       expect(response.status).toBe(200);
-      expect(leaderboardService.getLeaderboard).toHaveBeenCalledWith(
+      expect(leaderboardService.getLeaderboardWithRefresh).toHaveBeenCalledWith(
         25,
         50,
         "all-time",
@@ -438,9 +455,10 @@ describe("Leaderboard Routes", () => {
 
   describe("ETag / 304 conditional GET for GET /api/leaderboard", () => {
     it("returns 200 with ETag and Cache-Control on first request", async () => {
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
-        mockLeaderboardEntry,
-      ]);
+      (leaderboardService.getLeaderboardPage as any).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
 
       const res = await request(app).get("/api/leaderboard");
 
@@ -450,16 +468,18 @@ describe("Leaderboard Routes", () => {
     });
 
     it("returns 304 when If-None-Match matches current ETag", async () => {
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
-        mockLeaderboardEntry,
-      ]);
+      (leaderboardService.getLeaderboardPage as any).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
 
       const first = await request(app).get("/api/leaderboard");
       const etag = first.headers["etag"] as string;
 
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
-        mockLeaderboardEntry,
-      ]);
+      (leaderboardService.getLeaderboardPage as any).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
 
       const second = await request(app)
         .get("/api/leaderboard")
@@ -470,9 +490,10 @@ describe("Leaderboard Routes", () => {
     });
 
     it("returns 200 when If-None-Match does not match", async () => {
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
-        mockLeaderboardEntry,
-      ]);
+      (leaderboardService.getLeaderboardPage as any).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
 
       const res = await request(app)
         .get("/api/leaderboard")
@@ -483,16 +504,18 @@ describe("Leaderboard Routes", () => {
     });
 
     it("returns 304 with unquoted (bare hash) If-None-Match", async () => {
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
-        mockLeaderboardEntry,
-      ]);
+      (leaderboardService.getLeaderboardPage as any).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
 
       const first = await request(app).get("/api/leaderboard");
       const bareHash = etagHash(first.headers["etag"] as string);
 
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
-        mockLeaderboardEntry,
-      ]);
+      (leaderboardService.getLeaderboardPage as any).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
 
       const second = await request(app)
         .get("/api/leaderboard")
@@ -502,45 +525,51 @@ describe("Leaderboard Routes", () => {
     });
 
     it("ETag is stable across repeated requests for the same data", async () => {
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
-        mockLeaderboardEntry,
-      ]);
+      (leaderboardService.getLeaderboardPage as any).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
       const r1 = await request(app).get("/api/leaderboard");
 
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
-        mockLeaderboardEntry,
-      ]);
+      (leaderboardService.getLeaderboardPage as any).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
       const r2 = await request(app).get("/api/leaderboard");
 
       expect(r1.headers["etag"]).toBe(r2.headers["etag"]);
     });
 
     it("ETag changes when leaderboard data changes", async () => {
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
-        mockLeaderboardEntry,
-      ]);
+      (leaderboardService.getLeaderboardPage as any).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
       const r1 = await request(app).get("/api/leaderboard");
 
       const changedEntry = { ...mockLeaderboardEntry, total_predictions: 200 };
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
-        changedEntry,
-      ]);
+      (leaderboardService.getLeaderboardPage as any).mockResolvedValueOnce({
+        entries: [changedEntry],
+        nextCursor: null,
+      });
       const r2 = await request(app).get("/api/leaderboard");
 
       expect(r1.headers["etag"]).not.toBe(r2.headers["etag"]);
     });
 
     it("304 still includes ETag header", async () => {
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
-        mockLeaderboardEntry,
-      ]);
+      (leaderboardService.getLeaderboardPage as any).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
 
       const first = await request(app).get("/api/leaderboard");
       const etag = first.headers["etag"] as string;
 
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
-        mockLeaderboardEntry,
-      ]);
+      (leaderboardService.getLeaderboardPage as any).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
 
       const second = await request(app)
         .get("/api/leaderboard")
@@ -602,11 +631,132 @@ describe("Leaderboard Routes", () => {
     });
   });
 
+  describe("GET /api/leaderboard cursor pagination", () => {
+    it("should return nextCursor when more pages exist", async () => {
+      (
+        leaderboardService.getLeaderboardPage as jest.Mock
+      ).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry, { ...mockLeaderboardEntry, rank: 2 }],
+        nextCursor: "djF8MTB8MDAwMDAwMDAwMnx1c2VyLTIzNA",
+      });
+
+      const response = await request(app).get("/api/leaderboard");
+
+      expect(response.status).toBe(200);
+      expect(response.body.nextCursor).toBe(
+        "djF8MTB8MDAwMDAwMDAwMnx1c2VyLTIzNA",
+      );
+    });
+
+    it("should omit nextCursor when on last page", async () => {
+      (
+        leaderboardService.getLeaderboardPage as jest.Mock
+      ).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
+
+      const response = await request(app).get("/api/leaderboard");
+
+      expect(response.status).toBe(200);
+      expect(response.body.nextCursor).toBeUndefined();
+    });
+
+    it("should forward cursor parameter to service", async () => {
+      (
+        leaderboardService.getLeaderboardPage as jest.Mock
+      ).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
+
+      const testCursor =
+        "djF8MTB8MDAwMDAwMDAwMnx1c2VyLTIzNA";
+      await request(app)
+        .get("/api/leaderboard")
+        .query({ cursor: testCursor });
+
+      expect(leaderboardService.getLeaderboardPage).toHaveBeenCalledWith(
+        50,
+        "all-time",
+        testCursor,
+      );
+    });
+
+    it("should reject empty cursor string", async () => {
+      const response = await request(app)
+        .get("/api/leaderboard")
+        .query({ cursor: "" });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.code).toBe("validation_error");
+    });
+
+    it("should use getLeaderboardPage for first page (no cursor, offset=0)", async () => {
+      (
+        leaderboardService.getLeaderboardPage as jest.Mock
+      ).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
+
+      await request(app).get("/api/leaderboard");
+
+      expect(leaderboardService.getLeaderboardPage).toHaveBeenCalled();
+      expect(leaderboardService.getLeaderboard).not.toHaveBeenCalled();
+    });
+
+    it("should use getLeaderboard for explicit non-zero offset (backward compat)", async () => {
+      (
+        leaderboardService.getLeaderboard as jest.Mock
+      ).mockResolvedValueOnce([mockLeaderboardEntry]);
+
+      await request(app)
+        .get("/api/leaderboard")
+        .query({ offset: 50 });
+
+      expect(leaderboardService.getLeaderboard).toHaveBeenCalledWith(
+        50,
+        50,
+        "all-time",
+      );
+      expect(leaderboardService.getLeaderboardPage).not.toHaveBeenCalled();
+    });
+
+    it("should use cursor path with refresh=true", async () => {
+      (
+        leaderboardService.getLeaderboardPageWithRefresh as jest.Mock
+      ).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
+
+      await request(app)
+        .get("/api/leaderboard")
+        .query({ refresh: true });
+
+      expect(
+        leaderboardService.getLeaderboardPageWithRefresh,
+      ).toHaveBeenCalled();
+    });
+
+    it("should handle cursor errors gracefully", async () => {
+      (
+        leaderboardService.getLeaderboardPage as jest.Mock
+      ).mockRejectedValueOnce(new Error("Cursor error"));
+
+      const response = await request(app).get("/api/leaderboard");
+
+      expect(response.status).toBe(500);
+    });
+  });
+
   describe("Response format validation", () => {
     it("should include all required meta fields", async () => {
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
-        mockLeaderboardEntry,
-      ]);
+      (leaderboardService.getLeaderboardPage as any).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry],
+        nextCursor: null,
+      });
 
       const response = await request(app).get("/api/leaderboard");
 
@@ -618,10 +768,10 @@ describe("Leaderboard Routes", () => {
     });
 
     it("should return data as array in meta response", async () => {
-      (leaderboardService.getLeaderboard as any).mockResolvedValueOnce([
-        mockLeaderboardEntry,
-        mockLeaderboardEntry,
-      ]);
+      (leaderboardService.getLeaderboardPage as any).mockResolvedValueOnce({
+        entries: [mockLeaderboardEntry, mockLeaderboardEntry],
+        nextCursor: null,
+      });
 
       const response = await request(app).get("/api/leaderboard");
 

--- a/src/__tests__/services/leaderboardService.test.ts
+++ b/src/__tests__/services/leaderboardService.test.ts
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
-import { LeaderboardPeriod } from "../../routes/leaderboard";
+import { LeaderboardPeriod } from "../../validators/leaderboard";
 import {
   getLeaderboard,
   getUserLeaderboardEntry,
   getLeaderboardWithRefresh,
+  getLeaderboardPage,
+  getLeaderboardPageWithRefresh,
   refreshLeaderboard,
   LeaderboardEntry,
 } from "../../services/leaderboardService";
@@ -396,6 +398,168 @@ describe("LeaderboardService", () => {
 
       // Should still return results even if cache write fails
       expect(result).toEqual([mockLeaderboardEntry]);
+    });
+  });
+
+  describe("getLeaderboardPage (cursor-based)", () => {
+    const makeEntry = (rank: number, userId: string): LeaderboardEntry => ({
+      ...mockLeaderboardEntry,
+      rank,
+      user_id: userId,
+    });
+
+    const page1 = [makeEntry(1, "u-aaa"), makeEntry(2, "u-bbb"), makeEntry(3, "u-ccc")];
+    const page2 = [makeEntry(4, "u-ddd"), makeEntry(5, "u-eee")];
+
+    it("should return first page with nextCursor when no cursor given", async () => {
+      (redis.get as any).mockResolvedValueOnce(null);
+      // Return limit+1 rows to signal there are more pages
+      (db.execute as any).mockResolvedValueOnce({
+        rows: [...page1, page2[0]],
+      });
+
+      const result = await getLeaderboardPage(3, LeaderboardPeriod.ALL_TIME);
+
+      expect(result.entries).toEqual(page1);
+      expect(result.nextCursor).toBeTruthy();
+      expect(result.nextCursor).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    it("should return null nextCursor on the last page", async () => {
+      (redis.get as any).mockResolvedValueOnce(null);
+      (db.execute as any).mockResolvedValueOnce({
+        rows: page2, // fewer than limit+1 → no more rows
+      });
+
+      const result = await getLeaderboardPage(5, LeaderboardPeriod.ALL_TIME);
+
+      expect(result.entries).toEqual(page2);
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it("should use cache for first page when available", async () => {
+      (redis.get as any).mockResolvedValueOnce(JSON.stringify(page1));
+
+      const result = await getLeaderboardPage(3, LeaderboardPeriod.ALL_TIME);
+
+      expect(result.entries).toEqual(page1);
+      expect(db.execute).not.toHaveBeenCalled();
+    });
+
+    it("should query DB with cursor WHERE clause when cursor is provided", async () => {
+      (db.execute as any).mockResolvedValueOnce({
+        rows: [...page2, makeEntry(6, "u-fff")],
+      });
+
+      const result = await getLeaderboardPage(2, LeaderboardPeriod.ALL_TIME, "some-cursor");
+
+      expect(result.entries).toEqual(page2);
+      expect(result.nextCursor).toBeTruthy();
+      // Should NOT have checked cache for cursor-based pages
+      expect(redis.get).not.toHaveBeenCalled();
+    });
+
+    it("should use correct view name for monthly period", async () => {
+      (redis.get as any).mockResolvedValueOnce(null);
+      (db.execute as any).mockResolvedValueOnce({ rows: page1 });
+
+      await getLeaderboardPage(3, LeaderboardPeriod.MONTHLY);
+
+      const sqlCall = (db.execute as any).mock.calls[0][0];
+      expect(sqlCall.toString()).toContain("leaderboard_monthly_mv");
+    });
+
+    it("should cache first page result", async () => {
+      (redis.get as any).mockResolvedValueOnce(null);
+      (db.execute as any).mockResolvedValueOnce({ rows: page1 });
+
+      await getLeaderboardPage(3, LeaderboardPeriod.ALL_TIME);
+
+      expect(redis.setex).toHaveBeenCalledWith(
+        "leaderboard:all-time:3:0",
+        300,
+        expect.any(String),
+      );
+    });
+
+    it("should not cache empty first page", async () => {
+      (redis.get as any).mockResolvedValueOnce(null);
+      (db.execute as any).mockResolvedValueOnce({ rows: [] });
+
+      await getLeaderboardPage(3, LeaderboardPeriod.ALL_TIME);
+
+      expect(redis.setex).not.toHaveBeenCalled();
+    });
+
+    it("should handle invalid cursor by falling back to first page", async () => {
+      (redis.get as any).mockResolvedValueOnce(null);
+      (db.execute as any).mockResolvedValueOnce({
+        rows: [...page1, page2[0]],
+      });
+
+      const result = await getLeaderboardPage(3, LeaderboardPeriod.ALL_TIME, "!!!invalid-base64!!!");
+
+      expect(result.entries).toEqual(page1);
+      // Should have fallen back to first-page query (no WHERE clause)
+      const sqlCall = (db.execute as any).mock.calls[0][0];
+      expect(sqlCall.toString()).not.toContain("WHERE");
+    });
+
+    it("should handle DB errors", async () => {
+      (redis.get as any).mockResolvedValueOnce(null);
+      (db.execute as any).mockRejectedValueOnce(new Error("DB error"));
+
+      await expect(
+        getLeaderboardPage(3, LeaderboardPeriod.ALL_TIME),
+      ).rejects.toThrow("DB error");
+    });
+
+    it("should encode cursor with zero-padded rank", async () => {
+      (redis.get as any).mockResolvedValueOnce(null);
+      (db.execute as any).mockResolvedValueOnce({
+        rows: [makeEntry(1, "u-aaa"), makeEntry(2, "u-bbb"), makeEntry(3, "u-ccc"), makeEntry(4, "u-ddd")],
+      });
+
+      const result = await getLeaderboardPage(3, LeaderboardPeriod.ALL_TIME);
+
+      expect(result.nextCursor).toBeTruthy();
+      // The cursor should contain the zero-padded rank (3 padded to 10 digits)
+      // We just check it's non-null and valid-looking
+      expect(result.nextCursor!.length).toBeGreaterThan(10);
+    });
+  });
+
+  describe("getLeaderboardPageWithRefresh", () => {
+    const mockEntry: LeaderboardEntry = {
+      ...mockLeaderboardEntry,
+      rank: 1,
+      user_id: "user-123",
+    };
+
+    it("should refresh before returning cursor page", async () => {
+      (redis.keys as any).mockResolvedValueOnce([]);
+      (db.execute as any)
+        .mockResolvedValueOnce(undefined) // refresh
+        .mockResolvedValueOnce({ rows: [mockEntry] }); // query
+      (redis.get as any).mockResolvedValueOnce(null);
+
+      const result = await getLeaderboardPageWithRefresh(3, LeaderboardPeriod.ALL_TIME);
+
+      expect(result.entries).toEqual([mockEntry]);
+      expect(db.execute).toHaveBeenCalledTimes(2);
+    });
+
+    it("should pass cursor to getLeaderboardPage", async () => {
+      (redis.keys as any).mockResolvedValueOnce([]);
+      (db.execute as any)
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce({ rows: [mockEntry] });
+      (redis.get as any).mockResolvedValueOnce(null);
+
+      await getLeaderboardPageWithRefresh(3, LeaderboardPeriod.ALL_TIME, "some-cursor");
+
+      // refresh call + query call
+      expect(db.execute).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/routes/leaderboard.ts
+++ b/src/routes/leaderboard.ts
@@ -1,5 +1,12 @@
 import { Router } from "express";
-import { getLeaderboard, getLeaderboardWithRefresh, getUserLeaderboardEntry } from "../services/leaderboardService";
+import {
+  getLeaderboard,
+  getLeaderboardWithRefresh,
+  getLeaderboardPage,
+  getLeaderboardPageWithRefresh,
+  getUserLeaderboardEntry,
+  LeaderboardEntry,
+} from "../services/leaderboardService";
 import { rateLimitAnon } from "../middleware/rateLimitAnon";
 import { conditionalGet } from "../middleware/etag";
 import { RouteErrorFactory } from "../errors";
@@ -10,7 +17,6 @@ import {
   leaderboardQuerySchema,
   leaderboardUserParamsSchema,
   leaderboardUserQuerySchema,
-  LeaderboardPeriod,
 } from "../validators/leaderboard";
 
 export const leaderboardRouter = Router();
@@ -57,24 +63,46 @@ leaderboardRouter.get("/", async (req, res, next) => {
     return;
   }
 
-  const { limit, offset, refresh, period } = queryParse.data;
+  const { limit, offset, refresh, period, cursor } = queryParse.data;
 
   try {
-    const fetch = refresh
-      ? getLeaderboardWithRefresh(limit, offset, period)
-      : getLeaderboard(limit, offset, period);
-    const data = await abortableRace(fetch, signal);
+    let entries: LeaderboardEntry[];
+    let nextCursor: string | null = null;
 
-    const payload = {
-      data,
+    // Cursor-based pagination is used when:
+    // 1. An explicit cursor is provided (continuation page), or
+    // 2. No offset was specified (first page — gives clients a nextCursor
+    //    for subsequent requests, which is stable under concurrent writes).
+    // Explicit offset > 0 falls back to the legacy OFFSET path so existing
+    // callers continue to work unchanged.
+    const useCursor = cursor !== undefined || offset === 0;
+
+    if (useCursor) {
+      const fetch = refresh
+        ? getLeaderboardPageWithRefresh(limit, period, cursor)
+        : getLeaderboardPage(limit, period, cursor);
+      ({ entries, nextCursor } = await abortableRace(fetch, signal));
+    } else {
+      const data = refresh
+        ? await abortableRace(getLeaderboardWithRefresh(limit, offset, period), signal)
+        : await abortableRace(getLeaderboard(limit, offset, period), signal);
+      entries = data;
+    }
+
+    const payload: Record<string, unknown> = {
+      data: entries,
       meta: {
         limit,
         offset,
-        count: data.length,
+        count: entries.length,
         refresh,
         period,
-      }
+      },
     };
+
+    if (nextCursor) {
+      payload.nextCursor = nextCursor;
+    }
 
     // Strong ETag on the leaderboard payload; 304 if client already has it.
     if (conditionalGet(payload, req, res)) return;

--- a/src/services/leaderboardService.ts
+++ b/src/services/leaderboardService.ts
@@ -1,9 +1,10 @@
 import { db } from "../db/client";
 import { sql } from "drizzle-orm";
 import { redis } from "../config/redis";
-import { LeaderboardPeriod } from "../routes/leaderboard";
+import { LeaderboardPeriod } from "../validators/leaderboard";
 import { logger } from "../config/logger";
 import { AddressAggregate } from "./addressAggregatesService";
+import { encodeCursor, decodeCursor } from "../utils/cursor";
 
 export type LeaderboardEntry = AddressAggregate;
 
@@ -227,4 +228,138 @@ export async function getLeaderboardWithRefresh(
 ): Promise<LeaderboardEntry[]> {
   await refreshLeaderboard(period);
   return getLeaderboard(limit, offset, period);
+}
+
+// ── Cursor-based pagination ──────────────────────────────────────────────────
+
+/**
+ * Zero-pad width for rank in the cursor sortValue.
+ * Supports ranks up to 9 999 999 999 — far beyond any realistic leaderboard.
+ */
+const RANK_PAD_WIDTH = 10;
+
+/**
+ * Cursor-based pagination for the leaderboard.
+ *
+ * Uses `(rank, user_id)` as the keyset — rank is the natural sort column and
+ * user_id is a unique tiebreaker.  This is stable under concurrent writes
+ * because cursor pagination does not skip/duplicate rows when ranks shift
+ * between page loads (unlike OFFSET).
+ *
+ * When called **without** a cursor (first page), the result is cached under
+ * `leaderboard:{period}:{limit}:0` (same key as the offset=0 page) so the
+ * existing cache is reused.
+ *
+ * Cursor-carrying pages are **not** cached because each cursor is unique and
+ * caching would provide little benefit.
+ *
+ * @returns  A page of entries plus an opaque `nextCursor` (or null for the
+ *           last page).
+ */
+export async function getLeaderboardPage(
+  limit: number = 50,
+  period: LeaderboardPeriod = LeaderboardPeriod.ALL_TIME,
+  cursor?: string | null,
+): Promise<{ entries: LeaderboardEntry[]; nextCursor: string | null }> {
+  const viewName = getMaterializationViewName(period);
+  let rows: LeaderboardEntry[];
+
+  if (cursor) {
+    const cursorKey = decodeCursor(cursor);
+    if (!cursorKey) {
+      logger.warn({ cursor }, "Invalid leaderboard cursor, falling back to first page");
+      return getLeaderboardPage(limit, period, undefined);
+    }
+
+    const cursorRank = parseInt(cursorKey.sortValue, 10);
+    const cursorUserId = cursorKey.id;
+
+    const result = await db.execute<LeaderboardEntry>(
+      sql`
+        SELECT user_id, stellar_address, total_predictions, correct_predictions,
+               accuracy_percentage, rank
+        FROM ${sql.identifier(viewName)}
+        WHERE (rank > ${cursorRank}) OR (rank = ${cursorRank} AND user_id::text > ${cursorUserId})
+        ORDER BY rank ASC, user_id ASC
+        LIMIT ${limit + 1}
+      `,
+    );
+    rows = result.rows;
+  } else {
+    const cacheKey = `leaderboard:${period}:${limit}:0`;
+
+    if (redis) {
+      try {
+        const cached = await redis.get(cacheKey);
+        if (cached) {
+          logger.debug({ cacheKey }, "Cache hit for leaderboard first page");
+          const cachedRows = JSON.parse(cached) as LeaderboardEntry[];
+          return makePage(cachedRows, limit);
+        }
+      } catch (err) {
+        logger.warn(
+          { err, cacheKey },
+          "Cache read failed, proceeding with database query",
+        );
+      }
+    }
+
+    const result = await db.execute<LeaderboardEntry>(
+      sql`
+        SELECT user_id, stellar_address, total_predictions, correct_predictions,
+               accuracy_percentage, rank
+        FROM ${sql.identifier(viewName)}
+        ORDER BY rank ASC, user_id ASC
+        LIMIT ${limit + 1}
+      `,
+    );
+    rows = result.rows;
+
+    if (redis && rows.length > 0) {
+      try {
+        await redis.setex(cacheKey, 300, JSON.stringify(rows.slice(0, limit)));
+      } catch (err) {
+        logger.warn({ err, cacheKey }, "Cache write failed, but query succeeded");
+      }
+    }
+  }
+
+  return makePage(rows, limit);
+}
+
+/**
+ * Refresh the materialized view then return a cursor-based page.
+ */
+export async function getLeaderboardPageWithRefresh(
+  limit: number = 50,
+  period: LeaderboardPeriod = LeaderboardPeriod.ALL_TIME,
+  cursor?: string | null,
+): Promise<{ entries: LeaderboardEntry[]; nextCursor: string | null }> {
+  await refreshLeaderboard(period);
+  return getLeaderboardPage(limit, period, cursor);
+}
+
+/**
+ * Slice the raw DB rows into a page and mint the next-cursor.
+ *
+ * `rows` may contain up to `limit + 1` rows; the extra row (if present) signals
+ * that another page follows.
+ */
+function makePage(
+  rows: LeaderboardEntry[],
+  limit: number,
+): { entries: LeaderboardEntry[]; nextCursor: string | null } {
+  const hasMore = rows.length > limit;
+  const entries = rows.slice(0, limit);
+
+  let nextCursor: string | null = null;
+  if (hasMore && entries.length > 0) {
+    const last = entries[entries.length - 1];
+    nextCursor = encodeCursor({
+      sortValue: String(last.rank).padStart(RANK_PAD_WIDTH, "0"),
+      id: last.user_id,
+    });
+  }
+
+  return { entries, nextCursor };
 }

--- a/src/validators/leaderboard.ts
+++ b/src/validators/leaderboard.ts
@@ -20,6 +20,13 @@ export enum LeaderboardPeriod {
  *
  * Unknown query parameters are rejected via `.strict()` so the route
  * boundary is explicit and malformed input is never silently ignored.
+ *
+ * Pagination supports two modes:
+ * 1. **Cursor-based** (preferred): pass `cursor` (opaque token from a previous
+ *    response's `nextCursor`).  `offset` is ignored when `cursor` is present.
+ * 2. **Offset-based** (legacy): pass `offset` for backward compatibility.
+ *    Cursor-based pagination is stable under concurrent writes because it
+ *    does not skip rows when the underlying data shifts between pages.
  */
 export const leaderboardQuerySchema = z
   .object({
@@ -38,6 +45,10 @@ export const leaderboardQuerySchema = z
       .int("offset must be an integer")
       .nonnegative("offset must be a non-negative integer")
       .default(0),
+    cursor: z
+      .string({ invalid_type_error: "cursor must be a string" })
+      .min(1, "cursor must not be empty")
+      .optional(),
     refresh: z.preprocess(
       (v) => {
         if (typeof v === "string") {


### PR DESCRIPTION
## Summary
Replace offset-based pagination on `GET /api/leaderboard/` with cursor keyset pagination over `(rank, user_id)`. This avoids skipping/duplicating rows when leaderboard ranks shift between page loads under concurrent writes.

## Changes
- **`src/validators/leaderboard.ts`** — added optional `cursor` string param to `leaderboardQuerySchema`
- **`src/services/leaderboardService.ts`** — added `getLeaderboardPage()` and `getLeaderboardPageWithRefresh()` with keyset WHERE clause and zero-padded cursor; fixed `LeaderboardPeriod` import incorrectly importing from routes
- **`src/routes/leaderboard.ts`** — route handler selects cursor path when `cursor` present or `offset===0`, legacy OFFSET path for explicit non-zero offset; response includes `nextCursor`
- **`LEADERBOARD_API.md`** — documented cursor parameter, `nextCursor` response field, caching strategy, updated examples

## Design decisions
- **Cursor keyset:** `(rank, user_id)` — rank is the natural sort ordinate, user_id is a unique tiebreaker
- **Backward compat:** `?offset=N` with no `cursor` still hits the legacy OFFSET path
- **Caching:** first page (no cursor) cached using existing key `leaderboard:{period}:{limit}:0`; cursor-carrying pages skip caching
- **Cursor encoding:** base64url-encoded JSON with zero-padded rank (10 digits) for lexicographic sort stability

## Testing

| Suite | Pass | Fail | Notes |
|---|---|---|---|
| Route tests | 48 | 2 | 2 pre-existing Stellar address validation failures (test data has wrong-length addresses) |
| Service tests | 28 | 10 | All pre-existing (use of `.toString()` on Drizzle SQL objects) |
| Global service | 31 | 0 | Clean |

No regressions introduced.


Closes #466