### PR TITLE
test: cover leaderboard ETag revalidation

### DIFF
--- a/tests/leaderboard.test.ts
+++ b/tests/leaderboard.test.ts
@@ -71,6 +71,20 @@ describe("GET /api/leaderboard", () => {
     expect(mockGetAddressAggregates).toHaveBeenCalledWith(10, 20);
   });
 
+  it("returns 304 when If-None-Match matches the strong ETag", async () => {
+    mockGetAddressAggregates.mockResolvedValue([sampleEntry]);
+
+    const first = await request(app).get("/api/leaderboard");
+    const second = await request(app)
+      .get("/api/leaderboard")
+      .set("If-None-Match", first.headers.etag);
+
+    expect(first.headers.etag).toMatch(/^"[a-f0-9]{64}"$/);
+    expect(second.status).toBe(304);
+    expect(second.text).toBe("");
+    expect(second.headers.etag).toBe(first.headers.etag);
+  });
+
   it("rejects limit > 100", async () => {
     const res = await request(app)
       .get("/api/leaderboard")


### PR DESCRIPTION
Closes #820

Add an end-to-end route regression test proving the leaderboard emits a strong ETag and returns 304 for a matching If-None-Match request.

Validation: git diff --check passed.