### PR TITLE
test: cover admin access log fallback

### DIFF
--- a/tests/adminAccessLog.test.ts
+++ b/tests/adminAccessLog.test.ts
@@ -137,6 +137,18 @@ describe("Admin Access Log", () => {
     loggerInfoSpy.mockClear();
   });
 
+  it("records an anonymous actor and zero size when no identity or length exists", async () => {
+    const req = makeReq({ path: "/api/admin" });
+    const res = makeRes();
+    accessLog(req, res, jest.fn());
+    await fireFinish(res);
+
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ actor: "anonymous", size: 0, statusCode: 200 }),
+      "admin_access_log",
+    );
+  });
+
   // ── A. BASIC SUCCESSFUL REQUEST ────────────────────────────────────────
 
   it("emits an admin_access_log entry on response finish with all required fields", async () => {


### PR DESCRIPTION
Closes #822

Add regression coverage for anonymous admin access logs and zero response-size fallback metadata.

Validation: git diff --check passed.