### PR TITLE
[#906] Add transactional payout and notification outbox

### DIFF
--- a/docs/side-effect-outbox.md
+++ b/docs/side-effect-outbox.md
@@ -1,0 +1,154 @@
+# Payout and notification outbox
+
+Payouts and notifications have two different reliability boundaries: the
+database transaction that records business state and the provider call that
+delivers a side effect. The side-effect outbox joins those boundaries by
+writing an outbox row in the same logical transaction as the business record.
+The worker delivers the row later and records the result.
+
+## Transaction boundary
+
+Use `SideEffectOutbox.transaction()` for a state change that requires an
+external payout or notification:
+
+```ts
+outbox.transaction((transaction) => {
+  transaction.putSideEffect(`payout:${payoutId}`, {
+    predictionId,
+    amount,
+  });
+  transaction.enqueue(
+    `payout:${payoutId}`,
+    OUTBOX_EVENT_TYPES.PAYOUT,
+    { predictionId, amount },
+  );
+});
+```
+
+The callback stages both the business-side effect and its delivery record.
+Neither becomes visible if the callback throws. The transaction is deliberately
+small and synchronous in the in-memory implementation; a database adapter can
+put the equivalent inserts in one SQL transaction. Provider calls must never
+run inside this commit callback.
+
+This ordering addresses the crash window after commit and before delivery:
+
+1. The business state and pending outbox event commit together.
+2. The process crashes before the provider call.
+3. A later worker claims the still-pending event.
+4. The provider receives the event and the worker marks it complete.
+
+There is no silent “database committed, queue publish failed” branch. A
+duplicate idempotency key is a no-op and cannot create a second side effect.
+The first payload remains authoritative, so a caller cannot rewrite a pending
+event by repeating an enqueue with different data.
+
+## Event types and keys
+
+The current event catalog contains:
+
+| Type | Key format | Example payload |
+| ---- | ---------- | --------------- |
+| `payout` | `payout:<payout-id>` | Prediction, amount, and currency |
+| `notification` | `notification:<notification-id>` | User, title, body, and data |
+
+Use stable business IDs for keys. A retry, worker restart, HTTP retry, or
+replayed command must calculate the same key. `enqueuePayout` and
+`enqueueNotification` are small helpers that enforce the catalog prefix.
+Payloads are cloned at the transaction boundary and when returned from the
+store, preventing later caller mutation from changing an audit or delivery
+record.
+
+## Worker lifecycle
+
+The processor uses four states:
+
+- `pending`: committed and waiting for delivery or its next retry;
+- `processing`: claimed by a worker and protected by a lease;
+- `completed`: the handler acknowledged the side effect;
+- `dead_letter`: the handler failed at the maximum attempt count.
+
+`claim(limit, now, leaseMs)` orders pending rows by creation time and stable
+idempotency key,
+marks at most the bounded limit as processing, increments their attempts, and
+returns snapshots. A worker crash leaves the row processing only until the
+lease expires. A later claim reclaims it as pending. The claim operation is
+the point at which an attempt is counted, so an attempt that crashes before
+the provider call is still visible to operators.
+
+`process(handler, options, now)` claims a bounded batch and handles every
+claimed row independently. A handler exception is converted into a safe error
+string. The row returns to pending with exponential delay until its attempt
+limit is reached; after that it becomes a terminal dead letter. Processing
+continues to the next row after either outcome, so one poison notification
+cannot starve an unrelated payout.
+
+## Idempotency
+
+The outbox deduplicates enqueue operations by `idempotencyKey`. It also avoids
+calling a handler for completed rows because only pending rows can be claimed.
+The downstream payout and notification handlers must still be idempotent: a
+worker can crash after a provider accepts a request but before the completion
+update. The handler should pass the outbox event ID or business key to a
+provider that supports idempotency and should use a database uniqueness guard
+for local effects.
+
+Exactly-once execution is not promised by a networked worker. The design
+provides at-least-once delivery plus stable keys and completion state, which is
+the safe boundary for external effects.
+
+## Retry and poison handling
+
+The default maximum is five attempts. Backoff starts at 250 ms and is capped at
+60 seconds. Configuration is bounded inside the service: attempts are capped
+at 20, delays at 60 seconds, and a claim batch at 1,000 rows. Invalid negative,
+zero, fractional, or non-finite values raise `OutboxError` with the stable
+`INVALID_OPTIONS` code. The handler's internal exception text is retained only
+as the operator-facing `lastError` field; it is not thrown through the worker
+loop or returned as an HTTP response.
+
+A poison event enters `dead_letter` after its final failed attempt. It remains
+visible through `list("dead_letter")` for a separate repair or replay tool.
+The worker never deletes poison rows automatically. Operators can correct a
+bad recipient, fix a payload contract, or explicitly replay with the same
+business key after investigation.
+
+## Payout guidance
+
+Payout state should be recorded in the same transaction as a `payout` event.
+The payout handler should submit the event using a provider idempotency key,
+persist any transaction hash, and treat an already-completed payout as a
+successful no-op. It must not infer payment completion merely because an
+outbox event was claimed. Chain confirmation remains a separate concern.
+
+## Notification guidance
+
+Notification rows and their `notification` outbox event should be committed
+together when a user-visible state change requires a notification. Email,
+push, and webhook adapters should be separate handlers or downstream fanout
+steps. A malformed address or permanently rejected template should exhaust
+only that event and leave other notifications eligible for delivery.
+
+## Observability and operations
+
+Expose counts by status and event type to metrics, and alert on pending age,
+processing leases that expire repeatedly, and dead-letter growth. Include the
+outbox event ID, idempotency key, business entity ID, attempt, and correlation
+ID in structured logs. Do not include access tokens or provider credentials in
+payloads or error strings.
+
+The outbox is process-local in the development implementation. It is useful
+for deterministic tests and local behavior, but a production deployment must
+back it with durable database rows or a durable queue. The required properties
+for that adapter are the same: unique idempotency key, atomic business-plus-
+outbox commit, lease-based claiming, conditional completion, bounded retry,
+and a terminal dead-letter state.
+
+## Test matrix
+
+The regression suite covers atomic commit, rollback on callback failure,
+duplicate payout and notification requests, payload isolation, deterministic
+claiming, successful processing, crash/lease recovery, transient retry,
+terminal exhaustion, poison-message isolation, and invalid configuration.
+Together these cases protect both the database-to-outbox crash boundary and
+the outbox-to-provider delivery boundary without requiring a live provider.

--- a/src/services/sideEffectOutbox.ts
+++ b/src/services/sideEffectOutbox.ts
@@ -1,0 +1,296 @@
+import { randomUUID } from "node:crypto";
+
+export const OUTBOX_EVENT_TYPES = {
+  PAYOUT: "payout",
+  NOTIFICATION: "notification",
+} as const;
+
+export type OutboxEventType = (typeof OUTBOX_EVENT_TYPES)[keyof typeof OUTBOX_EVENT_TYPES];
+export type OutboxStatus = "pending" | "processing" | "completed" | "dead_letter";
+
+export type OutboxEvent = {
+  id: string;
+  idempotencyKey: string;
+  type: OutboxEventType;
+  payload: Record<string, unknown>;
+  status: OutboxStatus;
+  attempts: number;
+  availableAt: number;
+  leaseUntil: number | null;
+  lastError: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type OutboxProcessingOptions = {
+  maxAttempts?: number;
+  backoffBaseMs?: number;
+  backoffMaxMs?: number;
+  leaseMs?: number;
+};
+
+export type OutboxProcessingResult = {
+  claimed: number;
+  completed: number;
+  retried: number;
+  deadLettered: number;
+};
+
+export type OutboxErrorCode = "INVALID_OPTIONS" | "INVALID_EVENT";
+
+export class OutboxError extends Error {
+  readonly code: OutboxErrorCode;
+
+  constructor(code: OutboxErrorCode, message: string) {
+    super(message);
+    this.name = "OutboxError";
+    this.code = code;
+  }
+}
+
+const DEFAULT_MAX_ATTEMPTS = 5;
+const MAX_MAX_ATTEMPTS = 20;
+const DEFAULT_BACKOFF_BASE_MS = 250;
+const MAX_BACKOFF_MS = 60_000;
+const DEFAULT_LEASE_MS = 30_000;
+
+type StagedSideEffect = { key: string; value: Record<string, unknown> };
+type StagedEvent = {
+  idempotencyKey: string;
+  type: OutboxEventType;
+  payload: Record<string, unknown>;
+};
+
+function clonePayload(payload: Record<string, unknown>): Record<string, unknown> {
+  return structuredClone(payload);
+}
+
+function positiveBounded(
+  value: number | undefined,
+  fallback: number,
+  maximum: number,
+): number {
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || value < 1) {
+    throw new OutboxError("INVALID_OPTIONS", "outbox limits must be positive integers");
+  }
+  return Math.min(value, maximum);
+}
+
+function nonNegativeBounded(
+  value: number | undefined,
+  fallback: number,
+  maximum: number,
+): number {
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || value < 0) {
+    throw new OutboxError("INVALID_OPTIONS", "outbox delays must be non-negative integers");
+  }
+  return Math.min(value, maximum);
+}
+
+function snapshot(event: OutboxEvent): OutboxEvent {
+  return { ...event, payload: clonePayload(event.payload) };
+}
+
+/** Transaction context that stages business writes and their outbox records. */
+export class OutboxTransaction {
+  private readonly sideEffects: StagedSideEffect[] = [];
+  private readonly events: StagedEvent[] = [];
+
+  putSideEffect(key: string, value: Record<string, unknown>): void {
+    if (key.length === 0) {
+      throw new OutboxError("INVALID_EVENT", "side-effect key must be non-empty");
+    }
+    this.sideEffects.push({ key, value: clonePayload(value) });
+  }
+
+  enqueue(
+    idempotencyKey: string,
+    type: OutboxEventType,
+    payload: Record<string, unknown>,
+  ): void {
+    if (idempotencyKey.length === 0) {
+      throw new OutboxError("INVALID_EVENT", "outbox idempotency key must be non-empty");
+    }
+    if (!Object.values(OUTBOX_EVENT_TYPES).includes(type)) {
+      throw new OutboxError("INVALID_EVENT", "outbox event type is not recognized");
+    }
+    if (this.events.some((event) => event.idempotencyKey === idempotencyKey)) return;
+    this.events.push({ idempotencyKey, type, payload: clonePayload(payload) });
+  }
+
+  get stagedSideEffects(): readonly StagedSideEffect[] {
+    return this.sideEffects;
+  }
+
+  get stagedEvents(): readonly StagedEvent[] {
+    return this.events;
+  }
+}
+
+/**
+ * In-memory transactional outbox used by the development backend and tests.
+ * A transaction stages the business-side effect and its delivery record; both
+ * become visible at one commit boundary. Production persistence can implement
+ * the same interface with a database transaction without changing processors.
+ */
+export class SideEffectOutbox {
+  private readonly effects = new Map<string, Record<string, unknown>>();
+  private readonly events = new Map<string, OutboxEvent>();
+  private readonly eventKeys = new Map<string, string>();
+
+  transaction(work: (transaction: OutboxTransaction) => void, now = Date.now): void {
+    const transaction = new OutboxTransaction();
+    work(transaction);
+    const duplicateEffect = transaction.stagedSideEffects.find((entry) =>
+      this.effects.has(entry.key),
+    );
+    const duplicateEvent = transaction.stagedEvents.find((entry) =>
+      this.eventKeys.has(entry.idempotencyKey),
+    );
+    if (duplicateEffect || duplicateEvent) return;
+    const createdAt = now();
+    for (const effect of transaction.stagedSideEffects) {
+      this.effects.set(effect.key, clonePayload(effect.value));
+    }
+    for (const event of transaction.stagedEvents) {
+      if (this.eventKeys.has(event.idempotencyKey)) continue;
+      const id = randomUUID();
+      this.events.set(id, {
+        id,
+        idempotencyKey: event.idempotencyKey,
+        type: event.type,
+        payload: clonePayload(event.payload),
+        status: "pending",
+        attempts: 0,
+        availableAt: createdAt,
+        leaseUntil: null,
+        lastError: null,
+        createdAt,
+        updatedAt: createdAt,
+      });
+      this.eventKeys.set(event.idempotencyKey, id);
+    }
+  }
+
+  enqueue(
+    idempotencyKey: string,
+    type: OutboxEventType,
+    payload: Record<string, unknown>,
+    now = Date.now,
+  ): OutboxEvent {
+    this.transaction((transaction) => transaction.enqueue(idempotencyKey, type, payload), now);
+    const existing = this.getByKey(idempotencyKey);
+    if (!existing) {
+      throw new OutboxError("INVALID_EVENT", "outbox event was not committed");
+    }
+    return existing;
+  }
+
+  getByKey(idempotencyKey: string): OutboxEvent | undefined {
+    const id = this.eventKeys.get(idempotencyKey);
+    return id ? this.events.get(id) && snapshot(this.events.get(id) as OutboxEvent) : undefined;
+  }
+
+  get(id: string): OutboxEvent | undefined {
+    const event = this.events.get(id);
+    return event ? snapshot(event) : undefined;
+  }
+
+  getSideEffect(key: string): Record<string, unknown> | undefined {
+    const value = this.effects.get(key);
+    return value ? clonePayload(value) : undefined;
+  }
+
+  list(status?: OutboxStatus): OutboxEvent[] {
+    return [...this.events.values()]
+      .filter((event) => status === undefined || event.status === status)
+      .sort((left, right) => left.createdAt - right.createdAt || left.idempotencyKey.localeCompare(right.idempotencyKey))
+      .map(snapshot);
+  }
+
+  private reclaimExpired(now: number): void {
+    for (const event of this.events.values()) {
+      if (event.status === "processing" && event.leaseUntil !== null && event.leaseUntil <= now) {
+        event.status = "pending";
+        event.leaseUntil = null;
+        event.availableAt = now;
+        event.updatedAt = now;
+      }
+    }
+  }
+
+  claim(limit = 100, now = Date.now, leaseMs = DEFAULT_LEASE_MS): OutboxEvent[] {
+    const boundedLimit = positiveBounded(limit, 100, 1_000);
+    const boundedLease = nonNegativeBounded(leaseMs, DEFAULT_LEASE_MS, MAX_BACKOFF_MS);
+    this.reclaimExpired(now());
+    const candidates = [...this.events.values()]
+      .filter((event) => event.status === "pending" && event.availableAt <= now())
+      .sort((left, right) => left.createdAt - right.createdAt || left.idempotencyKey.localeCompare(right.idempotencyKey))
+      .slice(0, boundedLimit);
+    const claimedAt = now();
+    return candidates.map((event) => {
+      event.status = "processing";
+      event.attempts += 1;
+      event.leaseUntil = claimedAt + boundedLease;
+      event.updatedAt = claimedAt;
+      return snapshot(event);
+    });
+  }
+
+  async process(
+    handler: (event: OutboxEvent) => Promise<void>,
+    options: OutboxProcessingOptions = {},
+    now: () => number = Date.now,
+  ): Promise<OutboxProcessingResult> {
+    const maxAttempts = positiveBounded(options.maxAttempts, DEFAULT_MAX_ATTEMPTS, MAX_MAX_ATTEMPTS);
+    const base = nonNegativeBounded(options.backoffBaseMs, DEFAULT_BACKOFF_BASE_MS, MAX_BACKOFF_MS);
+    const maximum = nonNegativeBounded(options.backoffMaxMs, MAX_BACKOFF_MS, MAX_BACKOFF_MS);
+    const lease = nonNegativeBounded(options.leaseMs, DEFAULT_LEASE_MS, MAX_BACKOFF_MS);
+    const claimed = this.claim(100, now, lease);
+    const result: OutboxProcessingResult = { claimed: claimed.length, completed: 0, retried: 0, deadLettered: 0 };
+    for (const event of claimed) {
+      const current = this.events.get(event.id);
+      if (!current || current.status !== "processing") continue;
+      try {
+        await handler(snapshot(event));
+        current.status = "completed";
+        current.leaseUntil = null;
+        current.lastError = null;
+        current.updatedAt = now();
+        result.completed += 1;
+      } catch (error) {
+        current.lastError = error instanceof Error ? error.message : "outbox handler failed";
+        current.leaseUntil = null;
+        current.updatedAt = now();
+        if (current.attempts >= maxAttempts) {
+          current.status = "dead_letter";
+          result.deadLettered += 1;
+        } else {
+          current.status = "pending";
+          const delay = Math.min(maximum, base * 2 ** Math.max(0, current.attempts - 1));
+          current.availableAt = current.updatedAt + delay;
+          result.retried += 1;
+        }
+      }
+    }
+    return result;
+  }
+}
+
+export function enqueuePayout(
+  outbox: SideEffectOutbox,
+  payoutId: string,
+  payload: Record<string, unknown>,
+): OutboxEvent {
+  return outbox.enqueue(`payout:${payoutId}`, OUTBOX_EVENT_TYPES.PAYOUT, payload);
+}
+
+export function enqueueNotification(
+  outbox: SideEffectOutbox,
+  notificationId: string,
+  payload: Record<string, unknown>,
+): OutboxEvent {
+  return outbox.enqueue(`notification:${notificationId}`, OUTBOX_EVENT_TYPES.NOTIFICATION, payload);
+}

--- a/tests/sideEffectOutbox.test.ts
+++ b/tests/sideEffectOutbox.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  OUTBOX_EVENT_TYPES,
+  OutboxError,
+  SideEffectOutbox,
+  enqueueNotification,
+  enqueuePayout,
+} from "../src/services/sideEffectOutbox";
+
+const payout = { predictionId: "prediction-1", amount: 2500, currency: "XLM" };
+const notification = { userId: "user-1", title: "Payout ready", body: "Your payout is ready" };
+
+describe("transactional side-effect outbox", () => {
+  it("commits a business side effect and its outbox event together", () => {
+    const outbox = new SideEffectOutbox();
+    outbox.transaction((transaction) => {
+      transaction.putSideEffect("payout:payout-1", payout);
+      transaction.enqueue("payout:payout-1", OUTBOX_EVENT_TYPES.PAYOUT, payout);
+    }, () => 100);
+
+    const event = outbox.getByKey("payout:payout-1");
+    expect(event?.status).toBe("pending");
+    expect(event?.attempts).toBe(0);
+    expect(outbox.getSideEffect("payout:payout-1")).toEqual(payout);
+  });
+
+  it("does not leave an outbox record when the transaction callback fails", () => {
+    const outbox = new SideEffectOutbox();
+    expect(() => outbox.transaction((transaction) => {
+      transaction.putSideEffect("notification:n-1", notification);
+      transaction.enqueue("notification:n-1", OUTBOX_EVENT_TYPES.NOTIFICATION, notification);
+      throw new Error("database constraint failed");
+    })).toThrow("database constraint failed");
+    expect(outbox.list()).toEqual([]);
+    expect(outbox.getSideEffect("notification:n-1")).toBeUndefined();
+  });
+
+  it("deduplicates repeated payout and notification enqueue requests", () => {
+    const outbox = new SideEffectOutbox();
+    const firstPayout = enqueuePayout(outbox, "payout-1", payout);
+    const secondPayout = enqueuePayout(outbox, "payout-1", { ...payout, amount: 9999 });
+    const firstNotification = enqueueNotification(outbox, "notification-1", notification);
+    const secondNotification = enqueueNotification(outbox, "notification-1", { ...notification, title: "changed" });
+    expect(secondPayout).toEqual(firstPayout);
+    expect(secondNotification).toEqual(firstNotification);
+    expect(outbox.list()).toHaveLength(2);
+    expect(outbox.getByKey("payout:payout-1")?.payload).toEqual(payout);
+  });
+
+  it("keeps the payload snapshot isolated from caller mutation", () => {
+    const outbox = new SideEffectOutbox();
+    const mutable = { nested: { amount: 1 } };
+    outbox.enqueue("notification:isolated", OUTBOX_EVENT_TYPES.NOTIFICATION, mutable);
+    mutable.nested.amount = 99;
+    expect(outbox.getByKey("notification:isolated")?.payload).toEqual({ nested: { amount: 1 } });
+  });
+});
+
+describe("outbox claiming and processing", () => {
+  it("claims events in deterministic order and marks successful work complete", async () => {
+    const claimOutbox = new SideEffectOutbox();
+    claimOutbox.enqueue("notification:b", OUTBOX_EVENT_TYPES.NOTIFICATION, { id: "b" }, () => 100);
+    claimOutbox.enqueue("notification:a", OUTBOX_EVENT_TYPES.NOTIFICATION, { id: "a" }, () => 100);
+    const claimed = claimOutbox.claim(1, () => 100, 1_000);
+    expect(claimed).toHaveLength(1);
+    expect(claimed[0]?.idempotencyKey).toBe("notification:a");
+
+    const outbox = new SideEffectOutbox();
+    outbox.enqueue("notification:complete", OUTBOX_EVENT_TYPES.NOTIFICATION, notification, () => 100);
+    const result = await outbox.process(async () => undefined, { maxAttempts: 3 }, () => 100);
+    expect(result).toEqual({ claimed: 1, completed: 1, retried: 0, deadLettered: 0 });
+    expect(outbox.getByKey("notification:complete")?.status).toBe("completed");
+  });
+
+  it("recovers a claimed event after its worker crashes", async () => {
+    const outbox = new SideEffectOutbox();
+    outbox.enqueue("payout:crash", OUTBOX_EVENT_TYPES.PAYOUT, payout, () => 100);
+    outbox.claim(1, () => 100, 10);
+    expect(outbox.getByKey("payout:crash")?.status).toBe("processing");
+
+    const result = await outbox.process(async () => undefined, { maxAttempts: 2 }, () => 111);
+    expect(result.completed).toBe(1);
+    expect(outbox.getByKey("payout:crash")?.attempts).toBe(2);
+  });
+
+  it("retries a failed handler with bounded backoff", async () => {
+    const outbox = new SideEffectOutbox();
+    outbox.enqueue("notification:retry", OUTBOX_EVENT_TYPES.NOTIFICATION, notification, () => 100);
+    let calls = 0;
+    const first = await outbox.process(async () => {
+      calls += 1;
+      throw new Error("temporary provider outage");
+    }, { maxAttempts: 3, backoffBaseMs: 50, backoffMaxMs: 60 }, () => 100);
+    expect(first).toEqual({ claimed: 1, completed: 0, retried: 1, deadLettered: 0 });
+    expect(calls).toBe(1);
+    expect(outbox.getByKey("notification:retry")?.status).toBe("pending");
+    expect(outbox.getByKey("notification:retry")?.availableAt).toBe(150);
+
+    const second = await outbox.process(async () => undefined, { maxAttempts: 3 }, () => 150);
+    expect(second.completed).toBe(1);
+    expect(outbox.getByKey("notification:retry")?.lastError).toBeNull();
+  });
+
+  it("moves a poison message to the terminal state after exhaustion", async () => {
+    const outbox = new SideEffectOutbox();
+    outbox.enqueue("notification:poison", OUTBOX_EVENT_TYPES.NOTIFICATION, notification, () => 100);
+    const first = await outbox.process(async () => { throw new Error("invalid recipient"); }, {
+      maxAttempts: 2,
+      backoffBaseMs: 0,
+    }, () => 100);
+    expect(first.retried).toBe(1);
+    const second = await outbox.process(async () => { throw new Error("invalid recipient"); }, {
+      maxAttempts: 2,
+      backoffBaseMs: 0,
+    }, () => 100);
+    expect(second.deadLettered).toBe(1);
+    expect(outbox.getByKey("notification:poison")?.status).toBe("dead_letter");
+    expect(outbox.getByKey("notification:poison")?.lastError).toBe("invalid recipient");
+  });
+
+  it("does not let a poison event block a healthy event", async () => {
+    const outbox = new SideEffectOutbox();
+    outbox.enqueue("notification:poison", OUTBOX_EVENT_TYPES.NOTIFICATION, { id: "poison" }, () => 100);
+    outbox.enqueue("payout:healthy", OUTBOX_EVENT_TYPES.PAYOUT, payout, () => 100);
+    const handled: string[] = [];
+    const result = await outbox.process(async (event) => {
+      handled.push(event.idempotencyKey);
+      if (event.idempotencyKey === "notification:poison") throw new Error("poison");
+    }, { maxAttempts: 1, backoffBaseMs: 0 }, () => 100);
+    expect(result).toEqual({ claimed: 2, completed: 1, retried: 0, deadLettered: 1 });
+    expect(handled).toEqual(["notification:poison", "payout:healthy"]);
+    expect(outbox.getByKey("payout:healthy")?.status).toBe("completed");
+  });
+
+  it("rejects invalid processor settings with a stable code", async () => {
+    const outbox = new SideEffectOutbox();
+    await expect(outbox.process(async () => undefined, { maxAttempts: 0 })).rejects.toMatchObject({
+      code: "INVALID_OPTIONS",
+    } satisfies Partial<OutboxError>);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a reusable transactional outbox for payout and notification side effects so committed business state cannot lose its follow-up delivery.

## What changed

- Stages business-side effects and typed payout/notification outbox records behind one commit boundary.
- Deduplicates stable business idempotency keys and snapshots payloads against caller mutation.
- Adds bounded lease-based claiming with deterministic ordering and crash recovery.
- Processes every claimed event independently so poison messages cannot block unrelated payouts or notifications.
- Adds bounded exponential retry and terminal dead-letter handling with stable typed configuration errors.
- Provides payout and notification enqueue helpers for consistent event keys.
- Documents transactional boundaries, idempotency expectations, retry behavior, operational handling, and production persistence requirements.
- Adds regression coverage for commit/rollback, duplicate enqueue, payload isolation, crash between commit and delivery, retries, exhaustion, and poison-message isolation.

## Verification

- `npx eslint src/services/sideEffectOutbox.ts tests/sideEffectOutbox.test.ts`
- `npx jest tests/sideEffectOutbox.test.ts --runInBand --silent` (10 passing tests)

Closes #906