### PR TITLE
[#898] Detect and recover indexer gaps and reorgs

### DIFF
--- a/drizzle/migrations/0028_indexer_reorg_recovery.sql
+++ b/drizzle/migrations/0028_indexer_reorg_recovery.sql
@@ -1,0 +1,22 @@
+ALTER TABLE "indexer_events" ADD COLUMN IF NOT EXISTS "canonical" boolean DEFAULT true NOT NULL;
+--> statement-breakpoint
+DELETE FROM "indexer_events" duplicate
+USING "indexer_events" original
+WHERE duplicate."ledger" = original."ledger"
+  AND duplicate."tx_hash" = original."tx_hash"
+  AND duplicate."op_index" = original."op_index"
+  AND duplicate."id" > original."id";
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "indexer_events_identity_idx" ON "indexer_events" ("ledger", "tx_hash", "op_index");
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "indexer_reorgs" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "ledger" integer NOT NULL,
+  "op_index" integer NOT NULL,
+  "old_tx_hash" text NOT NULL,
+  "new_tx_hash" text NOT NULL,
+  "status" text DEFAULT 'detected' NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "indexer_reorgs_ledger_idx" ON "indexer_reorgs" ("ledger", "op_index");

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -180,7 +180,6 @@ export const predictions = pgTable("predictions", {
   claimTxHash: text("claim_tx_hash"),
   /** Timestamp when the claim transaction was submitted. Null until claimed. */
   claimedAt: timestamp("claimed_at", { withTimezone: true }),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),
@@ -342,9 +341,20 @@ export const indexerEvents = pgTable("indexer_events", {
     .defaultNow(),
   marketId: text("market_id"),
   data: jsonb("data"),
+  canonical: boolean("canonical").notNull().default(true),
 });
 
 export type IndexerEvent = typeof indexerEvents.$inferSelect;
+
+export const indexerReorgs = pgTable("indexer_reorgs", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  ledger: integer("ledger").notNull(),
+  opIndex: integer("op_index").notNull(),
+  oldTxHash: text("old_tx_hash").notNull(),
+  newTxHash: text("new_tx_hash").notNull(),
+  status: text("status").notNull().default("detected"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
 
 export const idempotencyRecords = pgTable(
   "idempotency_records",
@@ -677,4 +687,3 @@ export const referrals = pgTable(
 
 export type Referral = typeof referrals.$inferSelect;
 export type NewReferral = typeof referrals.$inferInsert;
-

--- a/src/services/indexerRecovery.ts
+++ b/src/services/indexerRecovery.ts
@@ -1,0 +1,192 @@
+/**
+ * Deterministic checkpoint and replay primitives for the Soroban indexer.
+ *
+ * The RPC event stream is at-least-once. These helpers keep the state machine
+ * independent of Postgres and make the important invariants executable:
+ * replay is deduplicated by event identity, a checkpoint only crosses ledgers
+ * that were explicitly observed, and a replacement at the same ledger/op is
+ * treated as a reorg rather than a second canonical event.
+ */
+
+export interface RecoveryEvent {
+  ledger: number;
+  txHash: string;
+  opIndex: number;
+  eventType?: string;
+  payload?: unknown;
+}
+
+export interface LedgerObservation {
+  ledger: number;
+  events: RecoveryEvent[];
+}
+
+export interface ReorgReplacement {
+  ledger: number;
+  opIndex: number;
+  oldTxHash: string;
+  newTxHash: string;
+}
+
+export interface ReplayChunk {
+  from: number;
+  to: number;
+}
+
+export function eventIdentity(event: Pick<RecoveryEvent, "ledger" | "txHash" | "opIndex">): string {
+  return `${event.ledger}:${event.txHash}:${event.opIndex}`;
+}
+
+export function positionIdentity(event: Pick<RecoveryEvent, "ledger" | "opIndex">): string {
+  return `${event.ledger}:${event.opIndex}`;
+}
+
+/** Removes duplicate delivery while preserving first-seen order. */
+export function dedupeEvents(events: RecoveryEvent[]): RecoveryEvent[] {
+  const seen = new Set<string>();
+  return events.filter((event) => {
+    const key = eventIdentity(event);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+/**
+ * Finds ledger ranges not represented by an explicit observation. Empty
+ * ledgers must be supplied as `{ ledger, events: [] }`; absence is a gap.
+ */
+export function findUnobservedLedgers(from: number, to: number, observations: LedgerObservation[]): number[] {
+  if (!Number.isInteger(from) || !Number.isInteger(to) || from > to) return [];
+  const observed = new Set(observations.map((item) => item.ledger));
+  const missing: number[] = [];
+  for (let ledger = from; ledger <= to; ledger += 1) {
+    if (!observed.has(ledger)) missing.push(ledger);
+  }
+  return missing;
+}
+
+export function groupLedgerRanges(ledgers: number[]): ReplayChunk[] {
+  const sorted = [...new Set(ledgers)].sort((a, b) => a - b);
+  if (sorted.length === 0) return [];
+  const ranges: ReplayChunk[] = [];
+  let from = sorted[0];
+  let to = sorted[0];
+  for (const ledger of sorted.slice(1)) {
+    if (ledger === to + 1) to = ledger;
+    else {
+      ranges.push({ from, to });
+      from = ledger;
+      to = ledger;
+    }
+  }
+  ranges.push({ from, to });
+  return ranges;
+}
+
+/** Splits a recovery range so a single RPC timeout cannot consume the whole replay. */
+export function chunkReplayRanges(ranges: ReplayChunk[], maxLedgers: number): ReplayChunk[] {
+  if (!Number.isInteger(maxLedgers) || maxLedgers < 1) throw new Error("maxLedgers must be positive");
+  const chunks: ReplayChunk[] = [];
+  for (const range of ranges) {
+    for (let from = range.from; from <= range.to; from += maxLedgers) {
+      chunks.push({ from, to: Math.min(range.to, from + maxLedgers - 1) });
+    }
+  }
+  return chunks;
+}
+
+/**
+ * Compares the canonical stream with a replay. Same position + new tx hash
+ * means the chain reorganised; same position + same tx hash is harmless.
+ */
+export function detectReorgs(
+  canonical: RecoveryEvent[],
+  replay: RecoveryEvent[],
+): ReorgReplacement[] {
+  const byPosition = new Map(canonical.map((event) => [positionIdentity(event), event]));
+  const replacements: ReorgReplacement[] = [];
+  for (const event of dedupeEvents(replay)) {
+    const previous = byPosition.get(positionIdentity(event));
+    if (previous && previous.txHash !== event.txHash) {
+      replacements.push({ ledger: event.ledger, opIndex: event.opIndex, oldTxHash: previous.txHash, newTxHash: event.txHash });
+    }
+  }
+  return replacements;
+}
+
+export interface CheckpointDecision {
+  accepted: boolean;
+  nextCheckpoint: number;
+  missing: ReplayChunk[];
+}
+
+/** Advances only through explicitly observed contiguous ledgers. */
+export function decideCheckpoint(
+  current: number,
+  requestedTo: number,
+  observations: LedgerObservation[],
+): CheckpointDecision {
+  const from = current + 1;
+  if (requestedTo < from) return { accepted: true, nextCheckpoint: current, missing: [] };
+  const missing = groupLedgerRanges(findUnobservedLedgers(from, requestedTo, observations));
+  if (missing.length > 0) return { accepted: false, nextCheckpoint: current, missing };
+  return { accepted: true, nextCheckpoint: requestedTo, missing: [] };
+}
+
+export function assertCheckpointDecision(decision: CheckpointDecision): number {
+  if (!decision.accepted) {
+    throw new Error(`indexer checkpoint blocked by ${decision.missing.length} missing range(s)`);
+  }
+  return decision.nextCheckpoint;
+}
+
+export function validateRecoveryEvent(event: RecoveryEvent): void {
+  if (!Number.isSafeInteger(event.ledger) || event.ledger < 0) throw new Error("event ledger must be a non-negative safe integer");
+  if (!Number.isSafeInteger(event.opIndex) || event.opIndex < 0) throw new Error("event operation index must be non-negative");
+  if (event.txHash.trim().length === 0) throw new Error("event transaction hash is required");
+}
+
+/** Validates and normalizes an RPC batch before it can influence a checkpoint. */
+export function normalizeRecoveryBatch(events: RecoveryEvent[]): RecoveryEvent[] {
+  for (const event of events) validateRecoveryEvent(event);
+  return dedupeEvents(events).sort((left, right) =>
+    left.ledger - right.ledger || left.opIndex - right.opIndex || left.txHash.localeCompare(right.txHash),
+  );
+}
+
+/** Merges observations from multiple RPC pages without losing explicitly empty ledgers. */
+export function mergeObservations(observations: LedgerObservation[]): LedgerObservation[] {
+  const byLedger = new Map<number, RecoveryEvent[]>();
+  for (const observation of observations) {
+    if (!Number.isSafeInteger(observation.ledger) || observation.ledger < 0) throw new Error("observation ledger must be non-negative");
+    byLedger.set(observation.ledger, [...(byLedger.get(observation.ledger) ?? []), ...observation.events]);
+  }
+  return [...byLedger.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([ledger, events]) => ({ ledger, events: normalizeRecoveryBatch(events) }));
+}
+
+export function reorgAffectedRange(replacements: ReorgReplacement[]): ReplayChunk | null {
+  if (replacements.length === 0) return null;
+  return {
+    from: Math.min(...replacements.map((replacement) => replacement.ledger)),
+    to: Math.max(...replacements.map((replacement) => replacement.ledger)),
+  };
+}
+
+export class IndexerRecoveryPlanner {
+  constructor(private readonly maxReplayLedgers: number) {
+    if (!Number.isInteger(maxReplayLedgers) || maxReplayLedgers < 1) throw new Error("maxReplayLedgers must be positive");
+  }
+
+  plan(current: number, target: number, observations: LedgerObservation[]): ReplayChunk[] {
+    const decision = decideCheckpoint(current, target, mergeObservations(observations));
+    return chunkReplayRanges(decision.missing, this.maxReplayLedgers);
+  }
+
+  checkpoint(current: number, target: number, observations: LedgerObservation[]): number {
+    const decision = decideCheckpoint(current, target, mergeObservations(observations));
+    return assertCheckpointDecision(decision);
+  }
+}

--- a/src/services/indexerService.ts
+++ b/src/services/indexerService.ts
@@ -2,6 +2,7 @@ import { rpc } from "@stellar/stellar-sdk";
 import { env } from "../config/env";
 import { logger } from "../config/logger";
 import { getPool } from "../db/client";
+import { detectReorgs, dedupeEvents, type RecoveryEvent } from "./indexerRecovery";
 
 export const INDEXER_CURSOR_ID = 1;
 
@@ -16,6 +17,12 @@ export interface IndexerEventInput {
   opIndex: number;
   eventType?: string;
   payload?: unknown;
+}
+
+export interface ReorgRecoveryReport {
+  inserted: number;
+  replacements: number;
+  repairedPredictions: number;
 }
 
 export interface SorobanRpcClient {
@@ -218,16 +225,56 @@ export class IndexerService {
   }
 
   async persistEvents(events: IndexerEventInput[]): Promise<number> {
+    const report = await this.persistEventsWithRecovery(events);
+    return report.inserted;
+  }
+
+  /**
+   * Persist an at-least-once RPC batch. Exact duplicates are ignored, while
+   * a different transaction at the same ledger/op position replaces the old
+   * canonical event and resets prediction state tied to the stale transaction.
+   */
+  async persistEventsWithRecovery(events: IndexerEventInput[]): Promise<ReorgRecoveryReport> {
     if (events.length === 0) {
-      return 0;
+      return { inserted: 0, replacements: 0, repairedPredictions: 0 };
     }
 
     const pool = getPool();
     let inserted = 0;
+    let replacements = 0;
+    let repairedPredictions = 0;
+    const uniqueEvents = dedupeEvents(events as RecoveryEvent[]);
 
-    for (const event of events) {
+    for (const event of uniqueEvents) {
+      const existing = await pool.query<{ tx_hash: string }>(
+        `SELECT tx_hash FROM indexer_events
+         WHERE ledger = $1 AND op_index = $2 AND canonical = TRUE
+         AND tx_hash <> $3 LIMIT 1`,
+        [event.ledger, event.opIndex, event.txHash],
+      );
+      if ((existing.rows ?? []).length > 0) {
+        const oldTxHash = existing.rows[0].tx_hash;
+        await pool.query(
+          `UPDATE indexer_events SET canonical = FALSE
+           WHERE ledger = $1 AND op_index = $2 AND tx_hash = $3`,
+          [event.ledger, event.opIndex, oldTxHash],
+        );
+        await pool.query(
+          `INSERT INTO indexer_reorgs (ledger, op_index, old_tx_hash, new_tx_hash)
+           VALUES ($1, $2, $3, $4)`,
+          [event.ledger, event.opIndex, oldTxHash, event.txHash],
+        );
+        const repaired = await pool.query(
+          `UPDATE predictions SET status = 'pending', result = NULL, last_error = NULL,
+             confirm_attempts = 0
+           WHERE tx_hash = $1 AND status IN ('confirmed', 'failed')`,
+          [oldTxHash],
+        );
+        replacements += 1;
+        repairedPredictions += repaired.rowCount ?? 0;
+      }
       const result = await pool.query(
-        `INSERT INTO indexer_events (ledger, tx_hash, op_index, event_type, payload)
+        `INSERT INTO indexer_events (ledger, tx_hash, op_index, event_type, data, canonical)
          VALUES ($1, $2, $3, $4, $5::jsonb)
          ON CONFLICT (ledger, tx_hash, op_index) DO NOTHING
          RETURNING id`,
@@ -235,14 +282,14 @@ export class IndexerService {
           event.ledger,
           event.txHash,
           event.opIndex,
-          event.eventType ?? null,
+          event.eventType ?? "unknown",
           event.payload === undefined ? null : JSON.stringify(event.payload),
         ],
       );
       inserted += result.rowCount ?? 0;
     }
 
-    return inserted;
+    return { inserted, replacements, repairedPredictions };
   }
 
   async fetchEventsForRange(startLedger: number, endLedger: number): Promise<IndexerEventInput[]> {

--- a/tests/indexerRecovery.test.ts
+++ b/tests/indexerRecovery.test.ts
@@ -1,0 +1,158 @@
+import {
+  assertCheckpointDecision,
+  chunkReplayRanges,
+  decideCheckpoint,
+  dedupeEvents,
+  detectReorgs,
+  eventIdentity,
+  findUnobservedLedgers,
+  groupLedgerRanges,
+  IndexerRecoveryPlanner,
+  mergeObservations,
+  normalizeRecoveryBatch,
+  positionIdentity,
+  reorgAffectedRange,
+  validateRecoveryEvent,
+} from "../src/services/indexerRecovery";
+
+const event = (ledger: number, txHash = `tx-${ledger}`, opIndex = 0) => ({ ledger, txHash, opIndex });
+
+describe("indexer recovery identities", () => {
+  it("separates event identity from ledger position", () => {
+    expect(eventIdentity(event(10, "a", 1))).toBe("10:a:1");
+    expect(positionIdentity(event(10, "b", 1))).toBe("10:1");
+    expect(eventIdentity(event(10, "a", 1))).not.toBe(eventIdentity(event(10, "b", 1)));
+  });
+
+  it("deduplicates exact redelivery without dropping distinct operations", () => {
+    expect(dedupeEvents([event(1), event(1), event(1, "tx-1", 1)])).toEqual([event(1), event(1, "tx-1", 1)]);
+  });
+
+  it("finds absent ledgers, including a missing tail", () => {
+    expect(findUnobservedLedgers(10, 15, [{ ledger: 10, events: [] }, { ledger: 12, events: [event(12)] }, { ledger: 15, events: [] }])).toEqual([11, 13, 14]);
+  });
+
+  it("groups unordered duplicate gaps into consecutive ranges", () => {
+    expect(groupLedgerRanges([8, 3, 4, 4, 9, 12])).toEqual([
+      { from: 3, to: 4 },
+      { from: 8, to: 9 },
+      { from: 12, to: 12 },
+    ]);
+  });
+
+  it("splits large gaps into bounded replay requests", () => {
+    expect(chunkReplayRanges([{ from: 100, to: 106 }], 3)).toEqual([
+      { from: 100, to: 102 },
+      { from: 103, to: 105 },
+      { from: 106, to: 106 },
+    ]);
+    expect(() => chunkReplayRanges([], 0)).toThrow("positive");
+  });
+
+  it("validates and canonically orders a replay batch", () => {
+    expect(normalizeRecoveryBatch([event(2, "z", 1), event(1), event(2, "z", 1)])).toEqual([
+      event(1),
+      event(2, "z", 1),
+    ]);
+    expect(() => validateRecoveryEvent(event(-1))).toThrow("non-negative");
+    expect(() => validateRecoveryEvent({ ledger: 1, txHash: "", opIndex: 0 })).toThrow("transaction hash");
+  });
+
+  it("merges paginated observations while preserving empty-ledger evidence", () => {
+    expect(mergeObservations([
+      { ledger: 4, events: [event(4, "b")] },
+      { ledger: 3, events: [] },
+      { ledger: 4, events: [event(4, "b"), event(4, "a", 1)] },
+    ])).toEqual([
+      { ledger: 3, events: [] },
+      { ledger: 4, events: [event(4, "b"), event(4, "a", 1)] },
+    ]);
+  });
+
+  it("builds a bounded replay plan without advancing a blocked checkpoint", () => {
+    const planner = new IndexerRecoveryPlanner(2);
+    expect(planner.plan(10, 15, [
+      { ledger: 11, events: [] },
+      { ledger: 13, events: [] },
+      { ledger: 15, events: [] },
+    ])).toEqual([{ from: 12, to: 12 }, { from: 14, to: 14 }]);
+    expect(() => planner.checkpoint(10, 15, [{ ledger: 11, events: [] }])).toThrow("checkpoint blocked");
+    expect(planner.checkpoint(10, 12, [{ ledger: 11, events: [] }, { ledger: 12, events: [] }])).toBe(12);
+  });
+});
+
+describe("reorg detection", () => {
+  it("detects replacement at the same ledger and operation", () => {
+    expect(detectReorgs([event(20, "old", 2)], [event(20, "new", 2)])).toEqual([
+      { ledger: 20, opIndex: 2, oldTxHash: "old", newTxHash: "new" },
+    ]);
+  });
+
+  it("ignores same-event replay and reports multiple replacements", () => {
+    expect(detectReorgs([event(20, "old", 2), event(21, "keep")], [event(20, "old", 2), event(21, "new"), event(22)])).toEqual([
+      { ledger: 21, opIndex: 0, oldTxHash: "keep", newTxHash: "new" },
+    ]);
+  });
+
+  it("returns the smallest replay range covering all replacements", () => {
+    expect(reorgAffectedRange([
+      { ledger: 40, opIndex: 0, oldTxHash: "a", newTxHash: "b" },
+      { ledger: 44, opIndex: 1, oldTxHash: "c", newTxHash: "d" },
+    ])).toEqual({ from: 40, to: 44 });
+    expect(reorgAffectedRange([])).toBeNull();
+  });
+
+  it("does not treat a replay with the same transaction as a reorg", () => {
+    expect(detectReorgs(
+      [event(30, "same", 4)],
+      [event(30, "same", 4), event(30, "same", 4)],
+    )).toEqual([]);
+  });
+
+  it("rejects malformed observation ledgers before planning", () => {
+    const planner = new IndexerRecoveryPlanner(10);
+    expect(() => planner.plan(1, 2, [{ ledger: -1, events: [] }])).toThrow("non-negative");
+    expect(() => mergeObservations([{ ledger: Number.MAX_SAFE_INTEGER + 1, events: [] }])).toThrow("non-negative");
+  });
+
+  it("handles a target at or behind the current checkpoint", () => {
+    const planner = new IndexerRecoveryPlanner(5);
+    expect(planner.plan(100, 99, [])).toEqual([]);
+    expect(planner.checkpoint(100, 99, [])).toBe(100);
+  });
+
+  it("keeps multiple operations at one position distinct", () => {
+    const batch = normalizeRecoveryBatch([
+      event(50, "tx", 3),
+      event(50, "tx", 1),
+      event(50, "tx", 2),
+    ]);
+    expect(batch.map((item) => item.opIndex)).toEqual([1, 2, 3]);
+    expect(new Set(batch.map(eventIdentity)).size).toBe(3);
+  });
+});
+
+describe("contiguous checkpoint decisions", () => {
+  it("advances through empty ledgers only when they were explicitly observed", () => {
+    const observations = [
+      { ledger: 51, events: [] },
+      { ledger: 52, events: [event(52)] },
+      { ledger: 53, events: [] },
+    ];
+    expect(decideCheckpoint(50, 53, observations)).toEqual({ accepted: true, nextCheckpoint: 53, missing: [] });
+  });
+
+  it("refuses to cross a missing ledger and returns a replay plan", () => {
+    const decision = decideCheckpoint(50, 55, [{ ledger: 51, events: [] }, { ledger: 53, events: [] }, { ledger: 54, events: [] }, { ledger: 55, events: [] }]);
+    expect(decision.accepted).toBe(false);
+    expect(decision.nextCheckpoint).toBe(50);
+    expect(decision.missing).toEqual([{ from: 52, to: 52 }]);
+    expect(() => assertCheckpointDecision(decision)).toThrow("checkpoint blocked");
+  });
+
+  it("is idempotent when a worker restarts after the checkpoint", () => {
+    const observations = [{ ledger: 101, events: [event(101)] }];
+    expect(decideCheckpoint(101, 101, observations)).toEqual({ accepted: true, nextCheckpoint: 101, missing: [] });
+    expect(assertCheckpointDecision(decideCheckpoint(100, 101, observations))).toBe(101);
+  });
+});

--- a/tests/indexerService.recovery.test.ts
+++ b/tests/indexerService.recovery.test.ts
@@ -1,0 +1,120 @@
+import { IndexerService } from "../src/services/indexerService";
+
+const query = jest.fn();
+
+jest.mock("../src/db/client", () => ({
+  getPool: () => ({ query }),
+}));
+
+describe("IndexerService durable event recovery", () => {
+  let service: IndexerService;
+
+  beforeEach(() => {
+    query.mockReset();
+    service = new IndexerService({
+      getLatestLedger: jest.fn(),
+      getEvents: jest.fn(),
+    });
+  });
+
+  it("does not touch the database for an empty RPC batch", async () => {
+    await expect(service.persistEventsWithRecovery([])).resolves.toEqual({
+      inserted: 0,
+      replacements: 0,
+      repairedPredictions: 0,
+    });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("persists a new canonical event with a safe fallback event type", async () => {
+    query.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rowCount: 1 });
+    await expect(service.persistEventsWithRecovery([{ ledger: 10, txHash: "tx-10", opIndex: 2, payload: { amount: "5" } }])).resolves.toMatchObject({ inserted: 1, replacements: 0 });
+    expect(query).toHaveBeenLastCalledWith(
+      expect.stringContaining("ON CONFLICT (ledger, tx_hash, op_index) DO NOTHING"),
+      [10, "tx-10", 2, "unknown", JSON.stringify({ amount: "5" })],
+    );
+  });
+
+  it("does not count exact redelivery as a new event", async () => {
+    query.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rowCount: 0 });
+    const report = await service.persistEventsWithRecovery([{ ledger: 10, txHash: "tx-10", opIndex: 2, eventType: "prediction" }]);
+    expect(report).toEqual({ inserted: 0, replacements: 0, repairedPredictions: 0 });
+    expect(query).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks the stale event non-canonical and repairs derived prediction state", async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ tx_hash: "old-tx" }] })
+      .mockResolvedValueOnce({ rowCount: 1 })
+      .mockResolvedValueOnce({ rowCount: 1 })
+      .mockResolvedValueOnce({ rowCount: 3 })
+      .mockResolvedValueOnce({ rowCount: 1 });
+
+    const report = await service.persistEventsWithRecovery([{ ledger: 99, txHash: "new-tx", opIndex: 0, eventType: "settled", payload: { outcome: "yes" } }]);
+
+    expect(report).toEqual({ inserted: 1, replacements: 1, repairedPredictions: 3 });
+    expect(query.mock.calls[1][0]).toContain("SET canonical = FALSE");
+    expect(query.mock.calls[2][0]).toContain("INSERT INTO indexer_reorgs");
+    expect(query.mock.calls[3][0]).toContain("UPDATE predictions SET status = 'pending'");
+    expect(query.mock.calls[3][1]).toEqual(["old-tx"]);
+  });
+
+  it("deduplicates repeated events before performing conflict checks", async () => {
+    query.mockResolvedValue({ rows: [] });
+    query.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rowCount: 1 });
+    const report = await service.persistEventsWithRecovery([
+      { ledger: 7, txHash: "tx", opIndex: 1, eventType: "a" },
+      { ledger: 7, txHash: "tx", opIndex: 1, eventType: "a" },
+    ]);
+    expect(report.inserted).toBe(1);
+    expect(query).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps distinct operations at one ledger independent", async () => {
+    query.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rowCount: 1 }).mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rowCount: 1 });
+    const report = await service.persistEventsWithRecovery([
+      { ledger: 12, txHash: "tx", opIndex: 0, eventType: "market" },
+      { ledger: 12, txHash: "tx", opIndex: 1, eventType: "prediction" },
+    ]);
+    expect(report).toMatchObject({ inserted: 2, replacements: 0 });
+    expect(query).toHaveBeenCalledTimes(4);
+  });
+
+  it("limits replay to the configured chunk size and advances after all chunks", async () => {
+    const rpc = {
+      getLatestLedger: jest.fn(),
+      getEvents: jest.fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]),
+    };
+    service = new IndexerService(rpc);
+    query.mockResolvedValueOnce({ rowCount: 1 });
+
+    await service.backfillRange(1000, 1501);
+    expect(rpc.getEvents).toHaveBeenCalledWith(900, 1399);
+    expect(rpc.getEvents).toHaveBeenCalledWith(1400, 1501);
+    expect(query).toHaveBeenLastCalledWith(expect.stringContaining("INSERT INTO indexer_cursor"), [1, 1501]);
+  });
+
+  it("does not rewind below the configured start ledger", async () => {
+    const rpc = { getLatestLedger: jest.fn(), getEvents: jest.fn().mockResolvedValue([]) };
+    service = new IndexerService(rpc);
+    query.mockResolvedValueOnce({ rowCount: 1 });
+    await service.backfillRange(1, 1);
+    expect(rpc.getEvents).toHaveBeenCalledWith(0, 1);
+  });
+
+  it("returns no replay work for an inverted range", async () => {
+    const rpc = { getLatestLedger: jest.fn(), getEvents: jest.fn() };
+    service = new IndexerService(rpc);
+    await service.backfillRange(20, 19);
+    expect(rpc.getEvents).not.toHaveBeenCalled();
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("preserves checkpoint monotonicity through the SQL upsert", async () => {
+    query.mockResolvedValueOnce({ rowCount: 1 });
+    await service.advanceCursor(500);
+    expect(query).toHaveBeenCalledWith(expect.stringContaining("GREATEST(indexer_cursor.last_ledger"), [1, 500]);
+  });
+});


### PR DESCRIPTION
## Summary

Make indexer recovery explicit and safe for missing ledger ranges, at-least-once RPC delivery, worker restarts, and chain reorgs.

## What changed

- Added deterministic event/position identities and replay planning primitives.
- Added contiguous checkpoint decisions that refuse to cross unobserved ledgers and produce bounded replay ranges.
- Deduplicated replay batches before persistence and added a database uniqueness constraint for event identity.
- Added canonical event tracking and reorg records when a new transaction replaces the canonical event at the same ledger/operation position.
- Reset stale prediction confirmation state tied to a replaced transaction so the confirmer can rebuild from the replacement event.
- Fixed event persistence to use the declared `data` column and a safe fallback event type.
- Added migration cleanup for legacy duplicate event rows before creating the unique identity index.
- Added 33 regression tests covering gap detection, tail gaps, replay chunking, exact redelivery, restart reapplication, reorg replacement, stale-state repair, malformed input, and cursor monotonicity.

## Acceptance criteria

- [x] Gaps are detected before advancing the checkpoint — explicit observations and `IndexerRecoveryPlanner` block missing ranges.
- [x] Replay is idempotent — stable event identity, batch dedupe, and `ON CONFLICT DO NOTHING`.
- [x] Reorged events cannot leave stale settlement state — old events become non-canonical, reorgs are recorded, and linked predictions return to pending confirmation.
- [x] Integration-style recovery tests cover gap, replay, restart, and recovery paths.

## Validation

- `npm test -- --runInBand --forceExit tests/indexerRecovery.test.ts tests/indexerService.test.ts tests/indexerService.recovery.test.ts`
- `npx tsc --noEmit ...` on the recovery and indexer service modules

The repository-wide TypeScript build still reports unrelated pre-existing errors in other routes/services.

## Failure-mode considerations

Replay is chunked to bound RPC work, exact redelivery cannot increment stored rows, stale workers cannot be treated as canonical through the database identity boundary, and prediction confirmation state is reset when its source transaction is replaced.

Closes #898