### PR TITLE
[#900] Enforce oracle freshness before settlement

### DIFF
--- a/docs/ORACLE_SETTLEMENT_GUARD.md
+++ b/docs/ORACLE_SETTLEMENT_GUARD.md
@@ -22,3 +22,6 @@ configured boundary, the same snapshot is accepted without a separate mode
 switch. Callers should persist the rejection reason in their settlement audit
 record, while returning a generic client-facing error if the reason could
 reveal provider health or configuration.
+
+Persist the accepted source set and observation time with settlement metadata.
+That evidence lets operators reconstruct exactly which quorum passed.

--- a/docs/ORACLE_SETTLEMENT_GUARD.md
+++ b/docs/ORACLE_SETTLEMENT_GUARD.md
@@ -25,3 +25,4 @@ reveal provider health or configuration.
 
 Persist the accepted source set and observation time with settlement metadata.
 That evidence lets operators reconstruct exactly which quorum passed.
+Alert when fallback mode is used repeatedly so provider degradation is visible.

--- a/docs/ORACLE_SETTLEMENT_GUARD.md
+++ b/docs/ORACLE_SETTLEMENT_GUARD.md
@@ -1,0 +1,24 @@
+# Oracle settlement guard
+
+Settlement callers should fetch a snapshot and evaluate it immediately before
+the atomic market-state mutation. `evaluateOracleSnapshot` is pure and returns
+either a deterministic median decision or an auditable rejection reason.
+
+Freshness is evaluated against the caller's trusted current time. An
+observation is fresh when `now - observedAt <= maxAgeSeconds`; observations
+ahead of the clock beyond `maxClockSkewSeconds` are rejected. Prices must be
+finite and strictly positive, and source identities are unique.
+
+The default policy requires three fresh sources and limits deviation to 100
+basis points from the median. A single fallback is never implicit: callers
+must enable it explicitly, provide a distinct named source, and still satisfy
+the same validity and freshness checks. The decision records whether fallback
+was used so operators can distinguish normal quorum settlement from degraded
+recovery.
+
+Outage behavior is fail-closed when fallback is disabled or invalid. Recovery
+is deterministic: once enough fresh sources return and agree within the
+configured boundary, the same snapshot is accepted without a separate mode
+switch. Callers should persist the rejection reason in their settlement audit
+record, while returning a generic client-facing error if the reason could
+reveal provider health or configuration.

--- a/src/services/marketResolutionService.ts
+++ b/src/services/marketResolutionService.ts
@@ -4,6 +4,11 @@ import type { Db } from "../db";
 import { markets, predictions, webhookSubscriptions } from "../db/schema";
 import { logger } from "../config/logger";
 import { emitMarketEvent, LogEvent } from "../logging/events";
+import {
+  evaluateOracleSnapshot,
+  type OracleSettlementPolicy,
+  type OracleSnapshot,
+} from "./oracleSettlementGuard";
 
 // ─── Public types ──────────────────────────────────────────────────────────
 
@@ -123,6 +128,28 @@ export async function resolveMarket(
   }
 
   return { processed: true };
+}
+
+/**
+ * Settlement entry point for callers that have fetched oracle evidence. The
+ * guard runs before any database mutation or webhook fan-out, so stale,
+ * missing, contradictory, or unsafe fallback data cannot partially settle a
+ * market. The existing event-only entry point remains available for historical
+ * indexer events that already carry an on-chain winning outcome.
+ */
+export async function resolveMarketWithOracle(
+  repo: MarketResolutionRepo,
+  event: MarketResolvedEvent,
+  oracle: OracleSnapshot,
+  policy: OracleSettlementPolicy,
+  emitWebhook: WebhookEmitter = httpWebhookEmitter,
+): Promise<{ processed: boolean; oraclePrice: number }> {
+  const decision = evaluateOracleSnapshot(oracle, event.timestamp, policy, event.marketId);
+  if (!decision.accepted) {
+    throw new Error(`oracle_settlement_rejected:${decision.reason}`);
+  }
+  const result = await resolveMarket(repo, event, emitWebhook);
+  return { ...result, oraclePrice: decision.price };
 }
 
 // ─── Drizzle repository ────────────────────────────────────────────────────

--- a/src/services/oracleSettlementGuard.matrix.test.ts
+++ b/src/services/oracleSettlementGuard.matrix.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  DEFAULT_ORACLE_SETTLEMENT_POLICY,
+  evaluateOracleSnapshot,
+  type OraclePrice,
+  type OracleSettlementPolicy,
+} from "./oracleSettlementGuard";
+
+const basePolicy: OracleSettlementPolicy = {
+  ...DEFAULT_ORACLE_SETTLEMENT_POLICY,
+  maxAgeSeconds: 60,
+  minSources: 3,
+  maxDeviationBps: 200,
+  maxClockSkewSeconds: 2,
+};
+
+const observation = (source: string, price: number, observedAt = 1_000): OraclePrice => ({ source, price, observedAt });
+const makeSnapshot = (prices: readonly OraclePrice[], fallback?: OraclePrice) => ({
+  marketId: "mkt-42",
+  prices,
+  ...(fallback === undefined ? {} : { fallback }),
+});
+
+describe("oracle guard failure matrix", () => {
+  const invalidPrices: Array<[string, number]> = [
+    ["zero", 0],
+    ["negative", -0.01],
+    ["nan", Number.NaN],
+    ["positive infinity", Number.POSITIVE_INFINITY],
+    ["negative infinity", Number.NEGATIVE_INFINITY],
+  ];
+
+  for (const [label, value] of invalidPrices) {
+    it(`rejects ${label} before quorum calculation`, () => {
+      const result = evaluateOracleSnapshot(
+        makeSnapshot([observation("source-a", value), observation("source-b", 10), observation("source-c", 10)]),
+        1_000,
+        basePolicy,
+        "mkt-42",
+      );
+      expect(result).toMatchObject({ accepted: false, reason: "invalid_price", sourceCount: 0 });
+    });
+  }
+
+  const invalidSources: Array<[string, string]> = [
+    ["blank", ""],
+    ["space", "source a"],
+    ["slash", "source/a"],
+    ["too long", "x".repeat(65)],
+  ];
+
+  for (const [label, source] of invalidSources) {
+    it(`rejects ${label} source names`, () => {
+      const result = evaluateOracleSnapshot(
+        makeSnapshot([observation(source, 10), observation("source-b", 10), observation("source-c", 10)]),
+        1_000,
+        basePolicy,
+      );
+      expect(result.reason).toBe("invalid_price");
+    });
+  }
+
+  for (const count of [0, 1, 2]) {
+    it(`rejects ${count} fresh sources when three are required`, () => {
+      const prices = Array.from({ length: count }, (_, index) => observation(`source-${index}`, 10));
+      const result = evaluateOracleSnapshot(makeSnapshot(prices), 1_000, basePolicy);
+      expect(result).toMatchObject({ accepted: false, reason: count === 0 ? "missing_prices" : "quorum_not_reached", sourceCount: count });
+    });
+  }
+
+  for (const age of [61, 100, 1_000]) {
+    it(`does not count an observation ${age} seconds old as fresh`, () => {
+      const result = evaluateOracleSnapshot(
+        makeSnapshot([observation("source-a", 10, 1_000 - age), observation("source-b", 10), observation("source-c", 10)]),
+        1_000,
+        basePolicy,
+      );
+      expect(result).toMatchObject({ accepted: false, reason: "quorum_not_reached", sourceCount: 2 });
+    });
+  }
+
+  for (const skew of [3, 10, 1_000_000]) {
+    it(`rejects an observation ${skew} seconds in the future`, () => {
+      const result = evaluateOracleSnapshot(
+        makeSnapshot([observation("source-a", 10, 1_000 + skew), observation("source-b", 10), observation("source-c", 10)]),
+        1_000,
+        basePolicy,
+      );
+      expect(result).toMatchObject({ accepted: false, reason: "future_price" });
+    });
+  }
+
+  for (const deviation of [201, 500, 2_000, 10_000]) {
+    it(`rejects a ${deviation} bps outlier`, () => {
+      const result = evaluateOracleSnapshot(
+        makeSnapshot([observation("source-a", 100), observation("source-b", 100), observation("source-c", 100 * (1 + deviation / 10_000))]),
+        1_000,
+        basePolicy,
+      );
+      expect(result).toMatchObject({ accepted: false, reason: "deviation_exceeded" });
+    });
+  }
+
+  it("does not let stale outliers affect a fresh median", () => {
+    const result = evaluateOracleSnapshot(
+      makeSnapshot([observation("source-a", 100), observation("source-b", 100), observation("source-c", 10_000, 900)]),
+      1_000,
+      basePolicy,
+    );
+    expect(result).toMatchObject({ accepted: false, reason: "quorum_not_reached", sourceCount: 2 });
+  });
+
+  it("does not let a fallback replace a valid quorum", () => {
+    const result = evaluateOracleSnapshot(
+      makeSnapshot([observation("source-a", 100), observation("source-b", 100), observation("source-c", 100)], observation("fallback", 1)),
+      1_000,
+      { ...basePolicy, allowFallback: true },
+    );
+    expect(result).toMatchObject({ accepted: true, price: 100, usedFallback: false, sourceCount: 3 });
+  });
+
+  it("rejects fallback values that exceed the clock skew", () => {
+    const result = evaluateOracleSnapshot(
+      makeSnapshot([observation("source-a", 100)], observation("fallback", 100, 1_003)),
+      1_000,
+      { ...basePolicy, allowFallback: true },
+    );
+    expect(result).toMatchObject({ accepted: false, reason: "fallback_invalid" });
+  });
+
+  it("makes identical snapshots produce identical serialized decisions", () => {
+    const input = makeSnapshot([observation("source-z", 100), observation("source-a", 100), observation("source-m", 100)]);
+    const first = evaluateOracleSnapshot(input, 1_000, basePolicy);
+    const second = evaluateOracleSnapshot(input, 1_000, basePolicy);
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+
+  it("does not mutate a caller-owned price array", () => {
+    const prices = [observation("source-z", 100), observation("source-a", 100), observation("source-m", 100)];
+    evaluateOracleSnapshot(makeSnapshot(prices), 1_000, basePolicy);
+    expect(prices.map((item) => item.source)).toEqual(["source-z", "source-a", "source-m"]);
+  });
+
+  it("keeps the oldest accepted observation timestamp for auditability", () => {
+    const result = evaluateOracleSnapshot(
+      makeSnapshot([observation("source-a", 100, 950), observation("source-b", 100, 999), observation("source-c", 100, 970)]),
+      1_000,
+      basePolicy,
+    );
+    expect(result).toMatchObject({ accepted: true, observedAt: 950 });
+  });
+});

--- a/src/services/oracleSettlementGuard.test.ts
+++ b/src/services/oracleSettlementGuard.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  DEFAULT_ORACLE_SETTLEMENT_POLICY,
+  deviationBps,
+  evaluateOracleSnapshot,
+  medianPrice,
+  normalizePolicy,
+  validatePrice,
+} from "./oracleSettlementGuard";
+
+const price = (source: string, value: number, observedAt = 900) => ({ source, price: value, observedAt });
+const snapshot = (prices: ReturnType<typeof price>[], fallback?: ReturnType<typeof price>) => ({ marketId: "market-1", prices, ...(fallback ? { fallback } : {}) });
+const policy = { ...DEFAULT_ORACLE_SETTLEMENT_POLICY, minSources: 3, maxAgeSeconds: 100 };
+
+describe("oracle settlement guard", () => {
+  it("accepts a fresh quorum and returns the deterministic median", () => {
+    const result = evaluateOracleSnapshot(snapshot([price("a", 100), price("b", 101), price("c", 99)]), 1_000, policy, "market-1");
+    expect(result).toEqual({ accepted: true, marketId: "market-1", price: 100, sourceCount: 3, sources: ["a", "b", "c"], observedAt: 900, usedFallback: false });
+  });
+
+  it("rejects missing observations and wrong markets", () => {
+    expect(evaluateOracleSnapshot(snapshot([]), 1_000, policy).reason).toBe("missing_prices");
+    expect(evaluateOracleSnapshot({ ...snapshot([price("a", 1), price("b", 1), price("c", 1)]), marketId: "other" }, 1_000, policy, "market-1")).toMatchObject({ reason: "market_mismatch" });
+  });
+
+  it("rejects stale data instead of treating it as a valid quorum", () => {
+    const result = evaluateOracleSnapshot(snapshot([price("a", 100, 899), price("b", 100, 899), price("c", 100, 899)]), 1_000, policy);
+    expect(result).toMatchObject({ accepted: false, reason: "quorum_not_reached", sourceCount: 0 });
+  });
+
+  it("accepts the exact freshness boundary and rejects one second older", () => {
+    expect(evaluateOracleSnapshot(snapshot([price("a", 100, 900), price("b", 100, 900), price("c", 100, 900)]), 1_000, policy).accepted).toBe(true);
+    expect(evaluateOracleSnapshot(snapshot([price("a", 100, 899), price("b", 100, 899), price("c", 100, 899)]), 1_000, policy).accepted).toBe(false);
+  });
+
+  it("rejects future observations beyond the allowed clock skew", () => {
+    const result = evaluateOracleSnapshot(snapshot([price("a", 100, 1_006), price("b", 100), price("c", 100)]), 1_000, policy);
+    expect(result).toMatchObject({ accepted: false, reason: "future_price", observedAt: 1_006 });
+  });
+
+  it("allows bounded clock skew", () => {
+    const result = evaluateOracleSnapshot(snapshot([price("a", 100, 1_005), price("b", 100), price("c", 100)]), 1_000, policy);
+    expect(result.accepted).toBe(true);
+  });
+
+  it("rejects zero, negative, NaN, and infinite prices", () => {
+    for (const value of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const result = evaluateOracleSnapshot(snapshot([price("a", value), price("b", 1), price("c", 1)]), 1_000, policy);
+      expect(result.reason).toBe("invalid_price");
+    }
+  });
+
+  it("rejects duplicate and malformed source identities", () => {
+    expect(evaluateOracleSnapshot(snapshot([price("a", 1), price("a", 1), price("c", 1)]), 1_000, policy).reason).toBe("duplicate_source");
+    expect(validatePrice(price("bad source", 1))).toBe("invalid_price");
+  });
+
+  it("rejects a deterministic outlier beyond the deviation boundary", () => {
+    const result = evaluateOracleSnapshot(snapshot([price("a", 100), price("b", 100), price("c", 102)]), 1_000, { ...policy, maxDeviationBps: 100 });
+    expect(result).toMatchObject({ accepted: false, reason: "deviation_exceeded", sourceCount: 3 });
+  });
+
+  it("accepts values exactly on the deviation boundary", () => {
+    const result = evaluateOracleSnapshot(snapshot([price("a", 100), price("b", 100), price("c", 101)]), 1_000, { ...policy, maxDeviationBps: 100 });
+    expect(result.accepted).toBe(true);
+  });
+
+  it("rejects below-quorum snapshots when fallback is disabled", () => {
+    const result = evaluateOracleSnapshot(snapshot([price("a", 100), price("b", 100)]), 1_000, policy);
+    expect(result).toMatchObject({ accepted: false, reason: "quorum_not_reached" });
+  });
+
+  it("uses an explicit fresh fallback only when enabled", () => {
+    const input = snapshot([price("a", 100)], price("fallback", 101));
+    expect(evaluateOracleSnapshot(input, 1_000, { ...policy, allowFallback: false }).reason).toBe("quorum_not_reached");
+    expect(evaluateOracleSnapshot(input, 1_000, { ...policy, allowFallback: true })).toMatchObject({ accepted: true, price: 101, usedFallback: true, sourceCount: 1 });
+  });
+
+  it("rejects a fallback that is stale, duplicated, or malformed", () => {
+    expect(evaluateOracleSnapshot(snapshot([price("a", 100)], price("fallback", 101, 899)), 1_000, { ...policy, allowFallback: true }).reason).toBe("fallback_invalid");
+    expect(evaluateOracleSnapshot(snapshot([price("a", 100)], price("a", 101)), 1_000, { ...policy, allowFallback: true }).reason).toBe("fallback_invalid");
+    expect(evaluateOracleSnapshot(snapshot([price("a", 100)], price("bad source", 101)), 1_000, { ...policy, allowFallback: true }).reason).toBe("fallback_invalid");
+  });
+
+  it("keeps source ordering stable for audit records", () => {
+    const result = evaluateOracleSnapshot(snapshot([price("z", 100), price("a", 100), price("m", 100)]), 1_000, policy);
+    expect(result).toMatchObject({ accepted: true, sources: ["a", "m", "z"] });
+  });
+
+  it("calculates odd and even medians without mutating inputs", () => {
+    const values = [3, 1, 2];
+    expect(medianPrice(values)).toBe(2);
+    expect(medianPrice([4, 1, 3, 2])).toBe(2.5);
+    expect(values).toEqual([3, 1, 2]);
+  });
+
+  it("calculates deviations in basis points", () => {
+    expect(deviationBps(101, 100)).toBe(100);
+    expect(deviationBps(99, 100)).toBe(100);
+    expect(deviationBps(0, 0)).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("validates policy boundaries", () => {
+    expect(normalizePolicy(policy)).toEqual(policy);
+    for (const invalid of [
+      { ...policy, maxAgeSeconds: 0 },
+      { ...policy, minSources: 0 },
+      { ...policy, maxDeviationBps: 10_001 },
+      { ...policy, maxClockSkewSeconds: -1 },
+    ]) expect(() => normalizePolicy(invalid)).toThrow();
+  });
+
+  it("rejects an invalid settlement clock", () => {
+    expect(evaluateOracleSnapshot(snapshot([price("a", 1), price("b", 1), price("c", 1)]), Number.NaN, policy).reason).toBe("future_price");
+  });
+});

--- a/src/services/oracleSettlementGuard.ts
+++ b/src/services/oracleSettlementGuard.ts
@@ -1,0 +1,178 @@
+/**
+ * Deterministic oracle admission policy for market settlement.
+ *
+ * A settlement must be based on a bounded, internally consistent snapshot.
+ * This module contains no network calls: callers fetch a snapshot from their
+ * configured providers, then pass it through this guard immediately before
+ * committing settlement state. Keeping admission pure makes clock, outage,
+ * and recovery behavior reproducible in tests and auditable in production.
+ */
+
+export type OraclePrice = {
+  source: string;
+  price: number;
+  observedAt: number;
+};
+
+export type OracleSnapshot = {
+  marketId: string;
+  prices: readonly OraclePrice[];
+  fallback?: OraclePrice;
+};
+
+export type OracleSettlementPolicy = {
+  maxAgeSeconds: number;
+  minSources: number;
+  maxDeviationBps: number;
+  maxClockSkewSeconds: number;
+  allowFallback: boolean;
+};
+
+export const DEFAULT_ORACLE_SETTLEMENT_POLICY: OracleSettlementPolicy = {
+  maxAgeSeconds: 120,
+  minSources: 3,
+  maxDeviationBps: 100,
+  maxClockSkewSeconds: 5,
+  allowFallback: false,
+};
+
+export type OracleRejectionReason =
+  | "market_mismatch"
+  | "missing_prices"
+  | "invalid_price"
+  | "duplicate_source"
+  | "stale_price"
+  | "future_price"
+  | "quorum_not_reached"
+  | "deviation_exceeded"
+  | "fallback_disabled"
+  | "fallback_invalid";
+
+export type OracleRejection = {
+  accepted: false;
+  reason: OracleRejectionReason;
+  message: string;
+  marketId: string;
+  sourceCount: number;
+  observedAt?: number;
+};
+
+export type OracleAcceptance = {
+  accepted: true;
+  marketId: string;
+  price: number;
+  sourceCount: number;
+  sources: string[];
+  observedAt: number;
+  usedFallback: boolean;
+};
+
+export type OracleDecision = OracleAcceptance | OracleRejection;
+
+export function evaluateOracleSnapshot(
+  snapshot: OracleSnapshot,
+  now: number,
+  policy: OracleSettlementPolicy = DEFAULT_ORACLE_SETTLEMENT_POLICY,
+  expectedMarketId?: string,
+): OracleDecision {
+  const normalized = normalizePolicy(policy);
+  if (expectedMarketId !== undefined && snapshot.marketId !== expectedMarketId) {
+    return reject("market_mismatch", "oracle snapshot belongs to a different market", snapshot, 0);
+  }
+  if (!Number.isSafeInteger(now) || now < 0) {
+    return reject("future_price", "settlement clock is invalid", snapshot, 0);
+  }
+  if (!Array.isArray(snapshot.prices) || snapshot.prices.length === 0) {
+    return reject("missing_prices", "no oracle prices were supplied", snapshot, 0);
+  }
+
+  const sourceNames = new Set<string>();
+  const valid: OraclePrice[] = [];
+  for (const price of snapshot.prices) {
+    const structural = validatePrice(price);
+    if (structural) return reject(structural, "oracle price failed validation", snapshot, valid.length);
+    if (sourceNames.has(price.source)) return reject("duplicate_source", "oracle sources must be unique", snapshot, valid.length);
+    sourceNames.add(price.source);
+    if (price.observedAt > now + normalized.maxClockSkewSeconds) {
+      return reject("future_price", "oracle observation is from the future", snapshot, valid.length, price.observedAt);
+    }
+    if (now - price.observedAt > normalized.maxAgeSeconds) {
+      continue;
+    }
+    valid.push({ ...price });
+  }
+
+  if (valid.length < normalized.minSources) {
+    return evaluateFallback(snapshot, now, normalized, sourceNames, valid.length);
+  }
+
+  const median = medianPrice(valid.map((item) => item.price));
+  const outlier = valid.find((item) => deviationBps(item.price, median) > normalized.maxDeviationBps);
+  if (outlier) {
+    return reject("deviation_exceeded", "oracle prices exceed the configured deviation boundary", snapshot, valid.length, outlier.observedAt);
+  }
+  return {
+    accepted: true,
+    marketId: snapshot.marketId,
+    price: median,
+    sourceCount: valid.length,
+    sources: valid.map((item) => item.source).sort(),
+    observedAt: Math.min(...valid.map((item) => item.observedAt)),
+    usedFallback: false,
+  };
+}
+
+export function medianPrice(values: readonly number[]): number {
+  if (values.length === 0) throw new Error("cannot calculate median of an empty set");
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[middle] as number : ((sorted[middle - 1] as number) + (sorted[middle] as number)) / 2;
+}
+
+export function deviationBps(value: number, reference: number): number {
+  if (reference <= 0 || !Number.isFinite(reference)) return Number.POSITIVE_INFINITY;
+  return Math.abs(value - reference) / reference * 10_000;
+}
+
+export function validatePrice(price: OraclePrice): OracleRejectionReason | undefined {
+  if (!price || typeof price.source !== "string" || !/^[A-Za-z0-9._:-]{1,64}$/.test(price.source)) return "invalid_price";
+  if (!Number.isFinite(price.price) || price.price <= 0) return "invalid_price";
+  if (!Number.isSafeInteger(price.observedAt) || price.observedAt < 0) return "invalid_price";
+  return undefined;
+}
+
+export function normalizePolicy(policy: OracleSettlementPolicy): OracleSettlementPolicy {
+  if (!Number.isSafeInteger(policy.maxAgeSeconds) || policy.maxAgeSeconds <= 0) throw new Error("maxAgeSeconds must be positive");
+  if (!Number.isSafeInteger(policy.minSources) || policy.minSources <= 0) throw new Error("minSources must be positive");
+  if (!Number.isSafeInteger(policy.maxDeviationBps) || policy.maxDeviationBps < 0 || policy.maxDeviationBps > 10_000) throw new Error("maxDeviationBps must be 0..10000");
+  if (!Number.isSafeInteger(policy.maxClockSkewSeconds) || policy.maxClockSkewSeconds < 0) throw new Error("maxClockSkewSeconds must be non-negative");
+  return { ...policy };
+}
+
+function evaluateFallback(
+  snapshot: OracleSnapshot,
+  now: number,
+  policy: OracleSettlementPolicy,
+  knownSources: Set<string>,
+  validCount: number,
+): OracleDecision {
+  if (!policy.allowFallback) return reject("quorum_not_reached", `oracle quorum requires ${policy.minSources} fresh sources`, snapshot, validCount);
+  if (!snapshot.fallback || knownSources.has(snapshot.fallback.source)) return reject("fallback_invalid", "fallback must be a distinct explicitly supplied source", snapshot, validCount);
+  const fallbackError = validatePrice(snapshot.fallback);
+  if (fallbackError || snapshot.fallback.observedAt > now + policy.maxClockSkewSeconds || now - snapshot.fallback.observedAt > policy.maxAgeSeconds) {
+    return reject("fallback_invalid", "fallback price is invalid or outside its freshness window", snapshot, validCount);
+  }
+  return {
+    accepted: true,
+    marketId: snapshot.marketId,
+    price: snapshot.fallback.price,
+    sourceCount: 1,
+    sources: [snapshot.fallback.source],
+    observedAt: snapshot.fallback.observedAt,
+    usedFallback: true,
+  };
+}
+
+function reject(reason: OracleRejectionReason, message: string, snapshot: OracleSnapshot, sourceCount: number, observedAt?: number): OracleRejection {
+  return { accepted: false, reason, message, marketId: snapshot.marketId, sourceCount, ...(observedAt === undefined ? {} : { observedAt }) };
+}


### PR DESCRIPTION
## Summary

Adds a pure oracle admission policy and `resolveMarketWithOracle` wrapper that validates evidence before any market mutation or webhook fan-out.

## Design

- Requires fresh, positive, finite prices from a unique-source quorum.
- Uses deterministic median aggregation and a configurable deviation boundary in basis points.
- Rejects stale and future observations with bounded clock-skew handling.
- Fails closed on outage/quorum loss unless an explicitly enabled, distinct, fresh fallback is supplied.
- Returns stable rejection reasons and audit-stable source ordering/observation metadata.
- Keeps the existing event-only indexer entry point for already-authoritative on-chain events; callers with oracle evidence use the guarded wrapper.

## Acceptance criteria

- [x] Stale data cannot settle through `resolveMarketWithOracle`.
- [x] Quorum and deviation boundaries are deterministic and tested at exact edges.
- [x] Fallback behavior is explicit, freshness-checked, and marked in the acceptance result.
- [x] Tests cover missing/outage data, recovery to quorum, invalid prices, duplicate sources, clock skew, outliers, fallback failures, median determinism, and policy validation.

## Verification

- `npx jest --runInBand --testMatch '**/src/services/oracleSettlementGuard*.test.ts'` — 46/46 passing
- ESLint on the changed guard and tests — passing

The repository-wide build is currently blocked by the pre-existing syntax error in `src/routes/users.ts` at line 330; no unrelated repair is included in this focused PR.

Closes #900
