### PR TITLE
[#903] Make leaderboard ordering and cursor pagination deterministic

### DIFF
--- a/drizzle/migrations/0013_address_aggregates_mv.sql
+++ b/drizzle/migrations/0013_address_aggregates_mv.sql
@@ -22,7 +22,8 @@ SELECT
         100.0 * SUM(CASE WHEN p.outcome = m.resolution_outcome THEN 1 ELSE 0 END) / COUNT(p.id)
       ELSE 0
       END DESC,
-      COUNT(p.id) DESC
+      COUNT(p.id) DESC,
+      u.id ASC
   ) AS rank
 FROM users u
 LEFT JOIN predictions p ON u.id = p.user_id

--- a/src/__tests__/services/leaderboardService.test.ts
+++ b/src/__tests__/services/leaderboardService.test.ts
@@ -438,11 +438,12 @@ describe("LeaderboardService", () => {
     });
 
     it("should use cache for first page when available", async () => {
-      (redis.get as any).mockResolvedValueOnce(JSON.stringify(page1));
+      (redis.get as any).mockResolvedValueOnce(JSON.stringify([...page1, page2[0]]));
 
       const result = await getLeaderboardPage(3, LeaderboardPeriod.ALL_TIME);
 
       expect(result.entries).toEqual(page1);
+      expect(result.nextCursor).toBeTruthy();
       expect(db.execute).not.toHaveBeenCalled();
     });
 
@@ -505,6 +506,17 @@ describe("LeaderboardService", () => {
       expect(sqlCall.toString()).not.toContain("WHERE");
     });
 
+    it("should reject a cursor with a non-numeric rank", async () => {
+      const malformed = Buffer.from("v1|3|abcuser-aaa", "utf8").toString("base64url");
+      (redis.get as any).mockResolvedValueOnce(null);
+      (db.execute as any).mockResolvedValueOnce({ rows: page1 });
+
+      await getLeaderboardPage(3, LeaderboardPeriod.ALL_TIME, malformed);
+
+      const sqlCall = (db.execute as any).mock.calls[0][0];
+      expect(sqlCall.toString()).not.toContain("WHERE");
+    });
+
     it("should handle DB errors", async () => {
       (redis.get as any).mockResolvedValueOnce(null);
       (db.execute as any).mockRejectedValueOnce(new Error("DB error"));
@@ -563,4 +575,3 @@ describe("LeaderboardService", () => {
     });
   });
 });
-

--- a/src/services/addressAggregatesService.ts
+++ b/src/services/addressAggregatesService.ts
@@ -30,7 +30,7 @@ export async function getAddressAggregates(
       SELECT user_id, stellar_address, total_predictions, correct_predictions,
              accuracy_percentage, rank
       FROM address_aggregates_mv
-      ORDER BY rank ASC
+      ORDER BY rank ASC, user_id ASC
       LIMIT ${limit}
       OFFSET ${offset}
     `

--- a/src/services/leaderboardService.ts
+++ b/src/services/leaderboardService.ts
@@ -140,7 +140,7 @@ export async function getLeaderboard(
       SELECT user_id, stellar_address, total_predictions, correct_predictions, 
              accuracy_percentage, rank
       FROM ${sql.identifier(viewName)}
-      ORDER BY rank ASC
+      ORDER BY rank ASC, user_id ASC
       LIMIT ${limit}
       OFFSET ${offset}
     `,
@@ -242,9 +242,8 @@ const RANK_PAD_WIDTH = 10;
  * Cursor-based pagination for the leaderboard.
  *
  * Uses `(rank, user_id)` as the keyset — rank is the natural sort column and
- * user_id is a unique tiebreaker.  This is stable under concurrent writes
- * because cursor pagination does not skip/duplicate rows when ranks shift
- * between page loads (unlike OFFSET).
+ * user_id is a unique tiebreaker. The materialized view assigns ranks with
+ * the same user_id tie-breaker, so equal scores have one deterministic order.
  *
  * When called **without** a cursor (first page), the result is cached under
  * `leaderboard:{period}:{limit}:0` (same key as the offset=0 page) so the
@@ -273,6 +272,10 @@ export async function getLeaderboardPage(
 
     const cursorRank = parseInt(cursorKey.sortValue, 10);
     const cursorUserId = cursorKey.id;
+    if (!Number.isSafeInteger(cursorRank) || cursorRank < 1 || !cursorUserId) {
+      logger.warn({ cursor }, "Invalid leaderboard cursor key, falling back to first page");
+      return getLeaderboardPage(limit, period, undefined);
+    }
 
     const result = await db.execute<LeaderboardEntry>(
       sql`
@@ -317,7 +320,9 @@ export async function getLeaderboardPage(
 
     if (redis && rows.length > 0) {
       try {
-        await redis.setex(cacheKey, 300, JSON.stringify(rows.slice(0, limit)));
+        // Keep the look-ahead row in the cache; without it a cached first page
+        // loses `nextCursor` and makes the rest of the leaderboard unreachable.
+        await redis.setex(cacheKey, 300, JSON.stringify(rows));
       } catch (err) {
         logger.warn({ err, cacheKey }, "Cache write failed, but query succeeded");
       }

--- a/src/validators/leaderboard.ts
+++ b/src/validators/leaderboard.ts
@@ -25,8 +25,8 @@ export enum LeaderboardPeriod {
  * 1. **Cursor-based** (preferred): pass `cursor` (opaque token from a previous
  *    response's `nextCursor`).  `offset` is ignored when `cursor` is present.
  * 2. **Offset-based** (legacy): pass `offset` for backward compatibility.
- *    Cursor-based pagination is stable under concurrent writes because it
- *    does not skip rows when the underlying data shifts between pages.
+ *    Cursor ordering is deterministic within a materialized-view snapshot;
+ *    clients should begin a new traversal after an explicit ranking refresh.
  */
 export const leaderboardQuerySchema = z
   .object({


### PR DESCRIPTION
## Summary
- use `user_id` as the final tie-breaker when assigning leaderboard ranks and when reading ranked rows
- validate decoded cursor ranks before constructing a keyset predicate
- preserve the look-ahead row in the cached first page so cache hits retain `nextCursor`
- document the materialized-view snapshot behavior for refreshes

## Acceptance criteria
- [x] Equal scores receive deterministic rank ordering
- [x] Leaderboard reads use the same deterministic `(rank, user_id)` order
- [x] Cursor inputs with invalid ranking keys fail safely
- [x] Cached first pages continue pagination instead of silently truncating the traversal
- [x] Existing offset callers remain supported

## Validation
- `git diff --check` passed
- Runtime test execution was not available in the isolated worktree because dependencies are not installed

Closes #903